### PR TITLE
chore(lint): add a `ruff` check, run from `make lint` in CI and `pre-commit`

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -32,3 +32,24 @@ jobs:
       - name: Run tests
         run: |
           tox
+
+  lint:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      # The generated packages are excluded from the check, so this job needs no `make api`.
+      - name: Install dependencies
+        run: |
+          make venv-dev
+
+      - name: Run ruff
+        run: |
+          make lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+# The rule set and the excludes live in `pyproject.toml`, and this hook runs `make lint` —
+#  the same recipe the `lint` job runs — so the two cannot drift apart.
+repos:
+  - repo: local
+    hooks:
+      - id: lint
+        name: ruff
+        # The recipe uses the project venv, so `make venv-dev` has to have been run once.
+        entry: make lint
+        language: system
+        # `ruff` reads its own file list from the config, and the whole tree takes 0.03s,
+        #  so the hook checks everything rather than only what is staged.
+        pass_filenames: false
+        always_run: true

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ BLUE   := \033[0;34m
 BOLD   := \033[1m
 RESET  := \033[0m
 
-.PHONY: venv venv-dev venv-docs clean-venv clean-build clean-api clean-docs clean api docs docs-archive build tag dtag test test-unit test-integration
+.PHONY: venv venv-dev venv-docs clean-venv clean-build clean-api clean-docs clean api docs docs-archive build tag dtag lint test test-unit test-integration
 
 venv:
 	@if [ ! -d "$(VENV)" ]; then \
@@ -76,6 +76,11 @@ docs:
 
 docs-archive:
 	cd docs/build/html && zip -r ../docs.zip ./
+
+# `ruff` takes its rule set and its excludes from `pyproject.toml`, so the `lint` job and
+#  the `pre-commit` hook both run this recipe instead of spelling the check out again.
+lint:
+	$(PYTHON) -m ruff check
 
 # `make venv` installs the package alone, so the runner needs `make venv-dev` first.
 test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,10 +60,12 @@ Community = "https://t.me/kurigram_chat"
 dev = [
     "keyring<=25.7.0",
     "hatch<=1.17.0",
+    "pre-commit<=4.6.2",
     "pytest<=9.1.1",
     "pytest-asyncio<=1.4.0",
     "pytest-cov<=7.1.0",
     "pytest-timeout<=2.4.0",
+    "ruff<=0.16.3",
     "twine<=6.2.0",
 ]
 
@@ -115,3 +117,23 @@ exclude = [
 [tool.hatch.build.targets.wheel]
 ignore-vcs = true
 packages = ["pyrogram"]
+
+[tool.ruff]
+# `pyrogram/raw` and `pyrogram/errors/exceptions` are written by `make api`, so they are
+# excluded here as well as in `.gitignore`: a checkout that has already been built must
+# lint the same as a fresh one.
+extend-exclude = ["pyrogram/raw", "pyrogram/errors/exceptions"]
+
+[tool.ruff.lint]
+# This selection is a floor, not a style guide. It is the set of rules the tree already
+#  passes, so the check can only ever fail on something newly written, and it is meant to
+#  grow one rule at a time. Anything wider is unusable for now: `ruff check --select ALL
+#  --statistics` reports over 26000 findings, the bulk of them line length, missing
+#  trailing commas and docstring section formatting.
+select = [
+    "E9",     # Syntax errors and files that cannot be read.
+    "F632",   # `is` used against a literal.
+    "F821",   # Undefined name.
+    "F822",   # Undefined name in `__all__`.
+    "RUF013", # Implicit `Optional`, e.g. `def method(chat_id: int = None)`.
+]

--- a/tests/filters/__init__.py
+++ b/tests/filters/__init__.py
@@ -16,6 +16,9 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Optional
+
+
 class Client:
     def __init__(self):
         self.me = User("username")
@@ -25,12 +28,12 @@ class Client:
 
 
 class User:
-    def __init__(self, username: str = None):
+    def __init__(self, username: Optional[str] = None):
         self.username = username
 
 
 class Message:
-    def __init__(self, text: str = None, caption: str = None):
+    def __init__(self, text: Optional[str] = None, caption: Optional[str] = None):
         self.text = text
         self.caption = caption
         self.command = None


### PR DESCRIPTION
## What

Nothing in CI reads the source. The workflow's only job builds the package across the
matrix and runs `tox`; there is no `tox.ini`, no `[tool.tox]` and no `tox.toml` anywhere
in the tree, so that step reports success without collecting a single test:

```
ROOT: No tox.ini or setup.cfg or pyproject.toml or tox.toml found, assuming empty tox.ini
```

That is a separate problem and this PR does not touch it. What this PR adds is the other
half: a check that reads the code, so a typo in a name or the shape #343 fixed cannot land
unnoticed.

## The change

`ruff`, wired so there is one place that says what is checked and one command that runs it.

**The rule set**, in `pyproject.toml`:

```toml
[tool.ruff.lint]
select = [
    "E9",     # Syntax errors and files that cannot be read.
    "F632",   # `is` used against a literal.
    "F821",   # Undefined name.
    "F822",   # Undefined name in `__all__`.
    "RUF013", # Implicit `Optional`, e.g. `def method(chat_id: int = None)`.
]
```

This is a floor, not a style guide: it is the set of rules the tree already passes, so the
check can only ever fail on something newly written. Anything wider is unusable right now —
`ruff check --select ALL --statistics` reports 26437 findings, the bulk of them line length,
missing trailing commas and docstring section formatting. The intent is to grow it one rule
at a time, when someone wants to.

`RUF013` is the one carrying weight today. It is exactly what #343 fixed, so that fix can no
longer regress.

**The excludes**, same file:

```toml
[tool.ruff]
extend-exclude = ["pyrogram/raw", "pyrogram/errors/exceptions"]
```

Those are written by `make api`. Excluding them here as well as in `.gitignore` buys two
things: a checkout that has already been built lints identically to a fresh one, and the CI
job needs no `make api` at all.

**One recipe**, in the `Makefile`:

```make
lint:
	$(PYTHON) -m ruff check
```

**Two callers**, both running that recipe rather than spelling the check out again — the
workflow job, and a `pre-commit` hook:

```yaml
repos:
  - repo: local
    hooks:
      - id: lint
        name: ruff
        entry: make lint
        language: system
        pass_filenames: false
        always_run: true
```

`pass_filenames: false` because `ruff` takes its own file list from the config, and
`always_run` because the whole tree costs 30ms — cheap enough that a change to the config
itself cannot slip past either.

`ruff` and `pre-commit` are pinned in the `dev` extra, so the version lives in one place and
the workflow does not repeat it.

## The one code change

Three parameters in `tests/filters/__init__.py`, which is the only thing in the tree that
`RUF013` still flags:

```
tests/filters/__init__.py:28:34   def __init__(self, username: str = None)
tests/filters/__init__.py:33:30   def __init__(self, text: str = None, ...)
tests/filters/__init__.py:33:51   ...caption: str = None)
```

They are in the separate commit ahead of the wiring, so the check is green from the moment
it is introduced.

## What I checked

On a clean clone with nothing generated — no `pyrogram/raw`, no `pyrogram/errors/exceptions`:

- `make venv-dev` installs on 3.14 in ~9s and brings `ruff`; `make lint` then exits 0.
- A bare `ruff check` looks at 906 files, none of them under the excluded paths. On a built
  checkout with 3258 generated `.py` on disk it is the same 906 files and the same verdict.
- The gate goes red where it should. Appending `def _probe(chat_id: int = None)` to
  `pyrogram/client.py` and committing gives:

  ```
  ruff.....................................................................Failed
  - hook id: lint
  - exit code: 2
  RUF013 PEP 484 prohibits implicit `Optional`
      --> pyrogram/client.py:1604:21
  make: *** [Makefile:83: lint] Error 1
  ```

  and the commit does not land.

`pytest -m 'not integration'` is unchanged at 354 passed.
