### PR TITLE
fix(typing): accept a built `JsonValue` in `init_connection_params`

### DIFF
--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -253,9 +253,10 @@ class Client(Methods):
         loop (:py:class:`asyncio.AbstractEventLoop`, *optional*):
             Event loop.
 
-        init_connection_params (``dict``, *optional*):
+        init_connection_params (``dict`` | :obj:`~pyrogram.raw.base.JsonValue`, *optional*):
             Additional initConnection parameters.
             For now, only the tz_offset field is supported, for specifying timezone offset in seconds.
+            A dict is converted on connect; an already built JsonValue is sent as it is.
     """
 
     APP_VERSION = f"Pyrogram {__version__}"
@@ -326,7 +327,7 @@ class Client(Methods):
         fetch_topics: Optional[bool] = True,
         fetch_stories: Optional[bool] = True,
         fetch_stickers: Optional[bool] = True,
-        init_connection_params: Optional[dict] = None,
+        init_connection_params: Optional[Union[dict, "raw.base.JsonValue"]] = None,
         connection_factory: Type[Connection] = Connection,
         protocol_factory: Type[TCP] = TCPAbridged,
         loop: Optional[asyncio.AbstractEventLoop] = None


### PR DESCRIPTION
## What

`Client(init_connection_params=...)` is annotated `Optional[dict]`, but a built `JsonValue`
works and is arguably the more direct thing to pass. `session.py:195` converts only when the
value is a `dict`:

```python
if isinstance(init_connection_params, dict):
    init_connection_params = utils.obj_to_jsonvalue(init_connection_params)
```

Anything else goes straight into `InvokeWithLayer(..., params=init_connection_params)`. So a
caller who has already built a `raw.types.JsonObject` — because they wanted control over the
value types, or because they are forwarding one they received — passes it, it works, and
every type checker and IDE marks the call as wrong.

## The change

The annotation, and the docstring line above it:

```python
init_connection_params: Optional[Union[dict, "raw.base.JsonValue"]] = None,
```

No behaviour moves: the `isinstance` branch already draws exactly this distinction, and this
only writes down the half of it that was missing.
