### PR TITLE
fix(typing): `Message.topic` also holds a `DirectMessagesTopic`

### DIFF
--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -119,8 +119,10 @@ class Message(Object, Update):
         from_offline (``bool``, *optional*):
             True, if the message was sent by an implicit action, for example, as an away or a greeting business message, or as a scheduled message.
 
-        topic (:obj:`~pyrogram.types.ForumTopic`, *optional*):
+        topic (:obj:`~pyrogram.types.ForumTopic` | :obj:`~pyrogram.types.DirectMessagesTopic`, *optional*):
             Topic the message belongs to.
+            A :obj:`~pyrogram.types.ForumTopic` in a forum, a :obj:`~pyrogram.types.DirectMessagesTopic` in a channel
+            direct messages chat.
 
         forward_origin (:obj:`~pyrogram.types.MessageOrigin`, *optional*):
             Information about the original message for forwarded messages.
@@ -652,7 +654,7 @@ class Message(Object, Update):
         show_caption_above_media: Optional[bool] = None,
         external_reply: Optional["types.ExternalReplyInfo"] = None,
         quote: Optional["types.TextQuote"] = None,
-        topic: Optional["types.ForumTopic"] = None,
+        topic: Optional[Union["types.ForumTopic", "types.DirectMessagesTopic"]] = None,
         forward_origin: Optional["types.MessageOrigin"] = None,
         message_thread_id: Optional[int] = None,
         direct_messages_topic_id: Optional[int] = None,


### PR DESCRIPTION
## What

`Message.topic` is annotated `Optional["types.ForumTopic"]` at `message.py:655`, and in a
channel direct-messages chat it holds a `DirectMessagesTopic`. `message.py:1870`, in the
branch guarded by `chat.type == enums.ChatType.DIRECT`:

```python
parsed_message.topic = await client.get_direct_messages_topics_by_id(
    chat_id=parsed_message.chat.id,
    topic_ids=parsed_message.direct_messages_topic_id
)
```

The cache branch a few lines above it does the same. So reading `message.topic.icon_color`
after a `ForumTopic`-shaped check passes the type checker and raises at runtime in a direct
chat, and the honest code — checking which of the two it is — is reported as unreachable.

## The change

The annotation, and the docstring entry that describes it:

```python
topic: Optional[Union["types.ForumTopic", "types.DirectMessagesTopic"]] = None,
```

I took the assignment as correct and the annotation as the thing that was behind — the
direct-messages topic is a real, separate type with its own fetch method, so narrowing the
other way would mean deciding that `message.py:1870` is the bug. If you would rather it went
that way, say so and I will redo it.
