### PR TITLE
fix(typing): drop `Optional` from two `_parse()` helpers that always return an object

### DIFF
--- a/pyrogram/types/bots_and_keyboards/users_shared.py
+++ b/pyrogram/types/bots_and_keyboards/users_shared.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Union
 
 import pyrogram
 from pyrogram import raw, types, utils
@@ -52,7 +52,7 @@ class UsersShared(Object):
             "raw.types.MessageActionRequestedPeerSentMe"
         ],
         users: Dict[int, "raw.base.User"] = {}
-    ) -> Optional["UsersShared"]:
+    ) -> "UsersShared":
         requested_users = types.List()
 
         for peer in action.peers:

--- a/pyrogram/types/messages_and_media/message_entity.py
+++ b/pyrogram/types/messages_and_media/message_entity.py
@@ -92,7 +92,7 @@ class MessageEntity(Object):
         self.date_time_format = date_time_format
 
     @staticmethod
-    async def _parse(client, entity: "raw.base.MessageEntity", users: dict) -> Optional["MessageEntity"]:
+    async def _parse(client, entity: "raw.base.MessageEntity", users: dict) -> "MessageEntity":
         user_id = None
         unix_time = None
         date_time_format = None


### PR DESCRIPTION
## What

Two `_parse()` helpers declare `Optional[...]` and cannot return `None`. Each has exactly one
`return`, and it is a constructor call:

| helper | its only `return` |
| --- | --- |
| `UsersShared._parse`, `users_shared.py:48` | `return UsersShared(...)` at `:80` |
| `MessageEntity._parse`, `message_entity.py:95` | `return MessageEntity(...)` at `:132` |

The cost is at the call sites: every caller either writes a `None` check that can never fire,
or does not and is flagged for it.

## The change

The two return annotations, and the now-unused `Optional` import in `users_shared.py`:

```python
-    ) -> Optional["UsersShared"]:
+    ) -> "UsersShared":

-    async def _parse(client, entity: "raw.base.MessageEntity", users: dict) -> Optional["MessageEntity"]:
+    async def _parse(client, entity: "raw.base.MessageEntity", users: dict) -> "MessageEntity":
```

Nothing else moves. If either helper is meant to grow a `None` path later, this is the commit
to revert.
