### PR TITLE
fix(typing): reword the comment `mypy` reads as a `# type:` comment

### DIFF
--- a/pyrogram/connection/transport/tcp/web_proxy_carrier.py
+++ b/pyrogram/connection/transport/tcp/web_proxy_carrier.py
@@ -37,8 +37,9 @@ log = logging.getLogger(__name__)
 #  which the hosted relay and this carrier both implement.
 #  https://github.com/telegramdesktop/tdesktop/blob/23dff657fc857c3223fa20472aa8614b9ab2c7eb/docs/web-proxy-plan.md
 
-# type:u8 | stream_id:u24 (big-endian) | length:u32 (big-endian) | payload, laid
-#  out by tdesktop's `SerializeFrame`.
+# A frame header is `type:u8 | stream_id:u24 (big-endian) | length:u32 (big-endian) |
+#  payload`, laid out by tdesktop's `SerializeFrame`. It cannot start at `type:`, which
+#  `mypy` reads as a `# type:` comment and refuses to parse.
 #  https://github.com/telegramdesktop/tdesktop/blob/23dff657fc857c3223fa20472aa8614b9ab2c7eb/Telegram/SourceFiles/mtproto/web_proxy/web_proxy_frame.cpp#L33-L55
 FRAME_HEADER_SIZE: Final[int] = 8
 


### PR DESCRIPTION
## What

`mypy` cannot check this project at all. One run, on a clean tree:

```
pyrogram/connection/transport/tcp/web_proxy_carrier.py:40: error: Invalid syntax  [syntax]
Found 1 error in 1 file (errors prevented further checking)
```

The file parses fine and every other tool reads it. What `mypy` chokes on is a comment:

```python
# type:u8 | stream_id:u24 (big-endian) | length:u32 (big-endian) | payload, laid
#  out by tdesktop's `SerializeFrame`.
```

A comment that begins `# type:` is a PEP 484 type comment, so `mypy` parses the rest of the
line as a type expression, fails, and stops. It reports the one syntax error and checks
nothing else in the tree.

## The change

The comment says the same thing, starting from a word instead of from `type:`:

```python
# A frame header is `type:u8 | stream_id:u24 (big-endian) | length:u32 (big-endian) |
#  payload`, laid out by tdesktop's `SerializeFrame`. It cannot start at `type:`, which
#  `mypy` reads as a `# type:` comment and refuses to parse.
```

No code changes. Afterwards:

```
Found 7492 errors in 1110 files (checked 4119 source files)
```

That number is what the annotations actually look like today, and it is a separate matter —
this only makes it visible.
