### PR TITLE
ci(build): run the unit suite in CI and fix its failures below 3.12

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -21,17 +21,17 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install tox
+          make venv-dev
 
       - name: Generate API
         run: |
-          make venv
           make api
 
+      # The integration tests need live api credentials, which a fork's runner has
+      #  no way to hold, so they stay deselected and skip on their own besides.
       - name: Run tests
         run: |
-          tox
+          make test-unit
 
   lint:
 

--- a/tests/unit/connection/transport/tcp/test_tcp.py
+++ b/tests/unit/connection/transport/tcp/test_tcp.py
@@ -75,6 +75,13 @@ def _web_proxy(secret_hex: str = PLAIN_SECRET_HEX) -> WebProxy:
 # Every `serve` below is an `asyncio.start_server` handler, which the stdlib calls
 #  with two positional arguments - so those signatures are its shape, not ours.
 
+# Each one closes its writer on the way out. On 3.12 `Server` counts live connections
+#  by hand and `wait_closed()` never returns while one is still attached, so a handler
+#  that just returned hung eight tests here until the run's own timeout. 3.13 replaced
+#  that counter with a `WeakSet`, which the garbage collector empties on its own, and
+#  3.11 returned from `wait_closed()` without waiting at all.
+#  https://github.com/python/cpython/blob/3bb231a6a5dc02b95658877318bf61501a7209e9/Lib/asyncio/base_events.py#L298-L302
+
 
 class _ProxyStub(NamedTuple):
     server: asyncio.AbstractServer
@@ -86,8 +93,12 @@ async def _start_proxy_stub(*, read_bytes: int) -> _ProxyStub:
     """A local server standing in for an MTProxy: reads `read_bytes` and stops."""
     received: "asyncio.Future[bytes]" = asyncio.get_running_loop().create_future()
 
-    async def serve(reader: asyncio.StreamReader, _writer: asyncio.StreamWriter) -> None:
-        received.set_result(await reader.readexactly(read_bytes))
+    async def serve(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        try:
+            received.set_result(await reader.readexactly(read_bytes))
+
+        finally:
+            writer.close()
 
     server = await asyncio.start_server(serve, host="127.0.0.1", port=0)
 
@@ -255,35 +266,39 @@ async def _start_fake_tls_stub(
     received: "asyncio.Future[bytes]" = loop.create_future()
 
     async def serve(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
-        head = await reader.readexactly(RECORD_HEADER_SIZE)
-        greeting = head + await reader.readexactly(int.from_bytes(head[3:5], "big"))
-        hello.set_result(greeting)
+        try:
+            head = await reader.readexactly(RECORD_HEADER_SIZE)
+            greeting = head + await reader.readexactly(int.from_bytes(head[3:5], "big"))
+            hello.set_result(greeting)
 
-        writer.write(_server_hello(greeting[_RANDOM_OFFSET : _RANDOM_OFFSET + _RANDOM_SIZE], secret=secret))
-        await writer.drain()
+            writer.write(_server_hello(greeting[_RANDOM_OFFSET : _RANDOM_OFFSET + _RANDOM_SIZE], secret=secret))
+            await writer.drain()
 
-        if not expects_packet:
-            return
+            if not expects_packet:
+                return
 
-        # Read what a real proxy reads - the change-cipher-spec and then one whole
-        #  application record - rather than a byte count the random padding decides.
-        #  Reading exactly what the length field declares is also what checks it:
-        #  a record that under-declares leaves the stub waiting until the test's
-        #  own timeout.
-        prologue = await reader.readexactly(len(CHANGE_CIPHER_SPEC) + RECORD_HEADER_SIZE)
-        body = await reader.readexactly(int.from_bytes(prologue[-RECORD_LENGTH_SIZE:], "big"))
-        received.set_result(prologue + body)
+            # Read what a real proxy reads - the change-cipher-spec and then one whole
+            #  application record - rather than a byte count the random padding decides.
+            #  Reading exactly what the length field declares is also what checks it:
+            #  a record that under-declares leaves the stub waiting until the test's
+            #  own timeout.
+            prologue = await reader.readexactly(len(CHANGE_CIPHER_SPEC) + RECORD_HEADER_SIZE)
+            body = await reader.readexactly(int.from_bytes(prologue[-RECORD_LENGTH_SIZE:], "big"))
+            received.set_result(prologue + body)
 
-        if not reply:
-            return
+            if not reply:
+                return
 
-        encrypted = aes.ctr256_encrypt(
-            reply,
-            *_client_decrypt_args(body[:_OBFUSCATED2_HEADER_SIZE], secret=secret),
-        )
+            encrypted = aes.ctr256_encrypt(
+                reply,
+                *_client_decrypt_args(body[:_OBFUSCATED2_HEADER_SIZE], secret=secret),
+            )
 
-        writer.write(_as_records(encrypted, record_size=reply_record_size))
-        await writer.drain()
+            writer.write(_as_records(encrypted, record_size=reply_record_size))
+            await writer.drain()
+
+        finally:
+            writer.close()
 
     server = await asyncio.start_server(serve, host="127.0.0.1", port=0)
 
@@ -423,8 +438,12 @@ async def test_connect_via_mtproxy_rejects_a_fake_tls_reply_signed_with_another_
 async def test_connect_via_mtproxy_rejects_a_fake_tls_reply_that_is_not_a_server_hello() -> None:
     # What a plain web server on the configured port answers with.
     async def serve(_reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
-        writer.write(b"HTTP/1.1 400 Bad Request\r\n\r\n")
-        await writer.drain()
+        try:
+            writer.write(b"HTTP/1.1 400 Bad Request\r\n\r\n")
+            await writer.drain()
+
+        finally:
+            writer.close()
 
     server = await asyncio.start_server(serve, host="127.0.0.1", port=0)
     transport = TCPIntermediatePadded(

--- a/tests/unit/connection/transport/tcp/test_web_proxy_carrier.py
+++ b/tests/unit/connection/transport/tcp/test_web_proxy_carrier.py
@@ -438,6 +438,14 @@ async def _run_failing_tracked_task(carrier: WebProxyCarrier) -> None:
     assert carrier._background_tasks == set(), "a finished task must not stay in the tracking set"
 
 
+def _carrier_records(caplog: pytest.LogCaptureFixture) -> List[logging.LogRecord]:
+    # `caplog` collects at the root, so a report from another logger lands in it too.
+    #  On 3.8 the garbage collector reaches a task an earlier test left pending mid-run
+    #  and `asyncio` logs "Task was destroyed but it is pending!" at ERROR, which the
+    #  comparisons below then read as a line this module emitted.
+    return [record for record in caplog.records if record.name == web_proxy_carrier.log.name]
+
+
 async def test_a_failed_background_task_the_carrier_recorded_is_reported_at_debug(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -449,7 +457,7 @@ async def test_a_failed_background_task_the_carrier_recorded_is_reported_at_debu
 
     # The next `send()` raises `_fail_exc` at the caller, so this is the second
     #  report of an error that already has an owner.
-    assert [(record.levelno, record.getMessage()) for record in caplog.records] == [
+    assert [(record.levelno, record.getMessage()) for record in _carrier_records(caplog)] == [
         (logging.DEBUG, "WEB proxy: background task failed: uplink rejected: HTTP 409"),
     ]
 
@@ -464,7 +472,7 @@ async def test_a_failed_background_task_nothing_recorded_is_reported_at_error(
 
     # `_fail_exc` is unset, so no caller will ever be handed this failure and
     #  swallowing it at debug would lose it outright.
-    assert [(record.levelno, record.getMessage()) for record in caplog.records] == [
+    assert [(record.levelno, record.getMessage()) for record in _carrier_records(caplog)] == [
         (
             logging.ERROR,
             "WEB proxy: background task failed with nothing to report it: uplink rejected: HTTP 409",
@@ -484,7 +492,7 @@ async def test_a_cancelled_background_task_is_not_reported(caplog: pytest.LogCap
 
         await carrier._cancel_tracked(task)
 
-    assert caplog.records == []
+    assert _carrier_records(caplog) == []
 
 
 async def test_recv_after_close_does_not_start_a_grant_task() -> None:

--- a/tests/unit/connection/transport/tcp/test_web_proxy_carrier.py
+++ b/tests/unit/connection/transport/tcp/test_web_proxy_carrier.py
@@ -285,9 +285,15 @@ def _window_grant(amount: int) -> Frame:
 
 
 async def _run_until_blocked(sending: "asyncio.Task[None]") -> None:
-    # `send()` only suspends once it runs out of credit, so a single loop
-    #  iteration is enough to drive it up to that point.
-    await asyncio.sleep(0)
+    # `send()` suspends once it runs out of credit, and waking it after a WINDOW
+    #  grant costs three loop iterations below 3.12, where `asyncio.wait_for` ran the
+    #  wait in a task of its own, against one on 3.12+, which awaits the coroutine
+    #  directly. A single yield left the grant unspent and failed
+    #  `test_send_never_puts_more_on_the_wire_than_the_credit_granted` on 3.9-3.11.
+    #  Ten is that measured three with room to spare.
+    #  https://github.com/python/cpython/blob/0fb18b02c8ad56299d6a2910be0bab8ad601ef24/Lib/asyncio/tasks.py#L509
+    for _ in range(10):
+        await asyncio.sleep(0)
 
     assert not sending.done()
 


### PR DESCRIPTION
## What

The `build` job has never run a test. It installs `tox` and calls it, and there is no `tox`
configuration anywhere in the repository, so `tox` builds an sdist, installs it, and exits 0:

```
py: install_package> pip install --force-reinstall --no-deps .../kurigram-2.2.25.tar.gz
  py: OK (9.53 seconds)
  congratulations :) (9.56 seconds)
```

No `commands`, so nothing is executed. That is 14 jobs across the matrix spending ten seconds
each to report success on a suite they never touched.

Switching the job on turns the matrix red, which is the second half of this change: the suite
has three failures, all in test code and none in the library. Nothing had ever run it on
anything but the newest Python, so they went unnoticed.

## The change

The job now mirrors the `lint` job — one `make` recipe per step, so the workflow does not
spell the check out a second time:

```yaml
      - name: Install dependencies
        run: |
          make venv-dev

      - name: Generate API
        run: |
          make api

      - name: Run tests
        run: |
          make test-unit
```

`make test-unit` is `pytest -m 'not integration'`. The integration tests take live api
credentials from the environment and skip by name when they are absent, so they are
deselected here rather than relied on to skip.

### 1. A test helper assumed one event loop iteration — 3.8 to 3.11

`_run_until_blocked` drove `WebProxyCarrier.send()` with a single `await asyncio.sleep(0)`.
That is enough on 3.12+, where `asyncio.wait_for` awaits its coroutine directly:

```python
    async with timeouts.timeout(timeout):
        return await fut
```

Before 3.12 it wrapped the wait in a task of its own, so waking after a WINDOW grant costs
three iterations, not one:

```python
    waiter = loop.create_future()
    timeout_handle = loop.call_later(timeout, _release_waiter, waiter)
    ...
    fut = ensure_future(fut, loop=loop)
```

Measured on this suite: 3 iterations on 3.9 and 3.11, 1 on 3.12 and 3.14. With one yield the
granted credit went unspent, and
`test_send_never_puts_more_on_the_wire_than_the_credit_granted` sat out the full 30s credit
timeout before failing:

```
assert recorder.bytes_sent == _INITIAL_STREAM_WINDOW + _UPLINK_FRAME_MAX
E   assert 4194304 == (4194304 + 65536)
WebCarrierError('timed out waiting for uplink WINDOW credit')
```

The helper now yields ten times.

### 2. The stub servers never closed their connections — 3.12

Eight tests in `test_tcp.py` hang forever on 3.12. Reproduced on a clean checkout of `dev`, so
this one is already in the tree. The event loop sits in `select(-1)` with no timer scheduled,
and the test's own `asyncio.wait_for` never fires because the hang is after the assertions, in
`await server.wait_closed()`.

`asyncio.Server` tracks live connections differently on either side of 3.13:

```python
# 3.12
self._active_count = 0        # decremented only from the transport's connection_lost

# 3.13
self._clients = weakref.WeakSet()
```

Our `asyncio.start_server` handlers returned without closing their writer. On 3.13+ the
garbage collector drops the transport out of the `WeakSet`; on 3.11 and below `wait_closed()`
returned without waiting at all — its own 3.12 docstring calls that "broken". On 3.12 the
counter stays at 1 and `wait_closed()` never returns.

Each handler now closes its writer in a `finally`.

### 3. Three tests compared the whole root log capture — 3.8

`caplog` collects at the root, and the assertions compared every record in it. On 3.8 the
garbage collector reaches a background task an earlier test left pending, `asyncio` logs
`Task was destroyed but it is pending!` at ERROR, and it lands in the comparison:

```
E  At index 0 diff: (40, "Task was destroyed but it is pending!...") != (10, 'WEB proxy: background task failed: ...')
```

The three assertions now filter to this module's own logger.

## Result

Full unit suite, per interpreter, before and after:

| | before | after |
|---|---|---|
| 3.8 | 1 failed, 353 passed in 3.1s | 354 passed in 3.6s |
| 3.9 | 1 failed, 353 passed in 33.3s | 354 passed in 3.6s |
| 3.10 | 1 failed, 353 passed in 33.3s | 354 passed in 3.6s |
| 3.11 | 1 failed, 353 passed in 32.3s | 354 passed in 3.4s |
| 3.12 | 8 failed, 346 passed | 354 passed in 3.3s |
| 3.13 | 354 passed | 354 passed in 3.9s |
| 3.14 | 354 passed | 354 passed in 3.9s |

The eight on 3.12 each hang until the run's own timeout cuts them, so the real cost there is
the timeout multiplied by eight rather than any of the figures above.

The three new steps were also run end to end from a fresh clone with no generated packages, on
3.8 and on 3.14: `make venv-dev`, `make api`, `make test-unit`, all exit 0.
