### PR TITLE
fix(upload): raise the failure that `save_file()` used to log and hide

### DIFF
--- a/pyrogram/methods/advanced/save_file.py
+++ b/pyrogram/methods/advanced/save_file.py
@@ -25,7 +25,7 @@ import math
 import os
 from hashlib import md5
 from pathlib import PurePath
-from typing import Union, BinaryIO, Callable, Optional
+from typing import List, Union, BinaryIO, Callable, Optional
 
 import pyrogram
 from pyrogram import StopTransmission
@@ -90,15 +90,17 @@ class SaveFile:
 
         Returns:
             ``InputFile`` | ``None``: On success, the uploaded file is returned in form of an InputFile object. In case
-            *path* is None, in case *file_id* is given so that a single missing part is uploaded instead of the whole
-            file, and in case the upload fails, None is returned.
+            *path* is None, and in case *file_id* is given so that a single missing part is uploaded instead of the
+            whole file, None is returned. A failed upload raises.
 
         Raises:
-            RPCError: In case of a Telegram RPC error.
+            RPCError: In case of a Telegram RPC error, including one that happened while a part was being sent.
         """
         async with self.save_file_semaphore:
             if path is None:
                 return None
+
+            failures: List[Exception] = []
 
             async def worker(session):
                 while True:
@@ -110,7 +112,11 @@ class SaveFile:
                     try:
                         await session.invoke(data)
                     except Exception as e:
+                        # The failure is remembered rather than raised, because a worker that stops
+                        #  consuming leaves the producer below blocked forever on `queue.put()` — the
+                        #  queue holds one item. It is raised at the end, once every worker has drained.
                         log.exception(e)
+                        failures.append(e)
 
             part_size = 512 * 1024
 
@@ -179,7 +185,7 @@ class SaveFile:
                     await queue.put(rpc)
 
                     if is_missing_part:
-                        return None
+                        break
 
                     if not is_big and not is_missing_part:
                         md5_sum.update(chunk)
@@ -202,21 +208,7 @@ class SaveFile:
                 raise
             except Exception as e:
                 log.exception(e)
-            else:
-                if is_big:
-                    return raw.types.InputFileBig(
-                        id=file_id,
-                        parts=file_total_parts,
-                        name=file_name,
-
-                    )
-                else:
-                    return raw.types.InputFile(
-                        id=file_id,
-                        parts=file_total_parts,
-                        name=file_name,
-                        md5_checksum=md5_sum
-                    )
+                raise
             finally:
                 for _ in workers:
                     await queue.put(None)
@@ -226,6 +218,24 @@ class SaveFile:
                 if isinstance(path, (str, PurePath)):
                     fp.close()
 
-            # NOTE: The `except Exception` branch above swallows the failure, so the upload can end
-            #       without a file.
-            return None
+            # Outside the `finally` on purpose: a worker only reports a failed part once it has been
+            #  woken up and drained above, so a check any earlier can miss it.
+            if failures:
+                raise failures[0]
+
+            if is_missing_part:
+                return None
+
+            if is_big:
+                return raw.types.InputFileBig(
+                    id=file_id,
+                    parts=file_total_parts,
+                    name=file_name
+                )
+
+            return raw.types.InputFile(
+                id=file_id,
+                parts=file_total_parts,
+                name=file_name,
+                md5_checksum=md5_sum
+            )

--- a/tests/unit/methods/__init__.py
+++ b/tests/unit/methods/__init__.py
@@ -1,0 +1,17 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.

--- a/tests/unit/methods/test_save_file.py
+++ b/tests/unit/methods/test_save_file.py
@@ -1,0 +1,139 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+import asyncio
+from concurrent.futures import Executor
+from pathlib import Path
+from typing import Final, List, Optional, Union
+
+import pytest
+
+from pyrogram import raw, types
+from pyrogram.methods.advanced.save_file import SaveFile
+
+_PART_SIZE: Final[int] = 512 * 1024
+
+# `rnd_id()` below answers with this too, so a re-upload addresses the same file as the
+#  upload that produced it.
+_FILE_ID: Final[int] = 1234567890
+
+
+class Storage:
+    async def dc_id(self) -> int:
+        return 2
+
+
+class Media:
+    """A media session that records the parts it was asked to save."""
+
+    def __init__(self, rejects_part: Optional[int] = None) -> None:
+        self.rejects_part = rejects_part
+        self.saved_parts: List[int] = []
+
+    async def invoke(
+        self,
+        query: Union[raw.functions.upload.SaveFilePart, raw.functions.upload.SaveBigFilePart],
+    ) -> None:
+        if query.file_part == self.rejects_part:
+            raise ConnectionError("the server closed the connection")
+
+        self.saved_parts.append(query.file_part)
+
+
+class Uploader(SaveFile):
+    def __init__(self, media: Media) -> None:
+        self.media = media
+        self.me: Optional[types.User] = None
+        self.storage = Storage()
+        self.executor: Optional[Executor] = None
+        self.save_file_semaphore = asyncio.Semaphore(1)
+
+    @property
+    def loop(self) -> asyncio.AbstractEventLoop:
+        return asyncio.get_event_loop()
+
+    def rnd_id(self) -> int:
+        return _FILE_ID
+
+    async def get_session(self, dc_id: int, *, is_media: bool = False) -> Media:
+        return self.media
+
+
+@pytest.fixture
+def three_parts(tmp_path: Path) -> str:
+    path = tmp_path / "upload.bin"
+    path.write_bytes(b"x" * (2 * _PART_SIZE + 1))
+
+    return str(path)
+
+
+@pytest.mark.asyncio
+async def test_a_finished_upload_describes_every_part(three_parts: str) -> None:
+    media = Media()
+
+    file = await Uploader(media).save_file(three_parts)
+
+    assert isinstance(file, raw.types.InputFile)
+    assert file.parts == 3
+    assert media.saved_parts == [0, 1, 2]
+
+
+@pytest.mark.asyncio
+async def test_a_part_the_server_refused_reaches_the_caller(three_parts: str) -> None:
+    # The failure used to be logged inside the worker and nowhere else: `save_file()` handed back
+    #  an `InputFile` for a file the server never received in full, and the send that followed
+    #  failed with an unrelated error — or, for a caller that stored the id, much later.
+    media = Media(rejects_part=1)
+
+    with pytest.raises(ConnectionError):
+        await Uploader(media).save_file(three_parts)
+
+
+@pytest.mark.asyncio
+async def test_the_parts_around_the_refused_one_are_still_sent(three_parts: str) -> None:
+    media = Media(rejects_part=1)
+
+    with pytest.raises(ConnectionError):
+        await Uploader(media).save_file(three_parts)
+
+    # The upload is not aborted mid-way — a worker that stops consuming leaves the producer
+    #  blocked on a queue of size one, so every part is offered and only the answer is remembered.
+    assert media.saved_parts == [0, 2]
+
+
+@pytest.mark.asyncio
+async def test_re_uploading_one_missing_part_answers_with_nothing(three_parts: str) -> None:
+    media = Media()
+
+    file = await Uploader(media).save_file(three_parts, file_id=_FILE_ID, file_part=1)
+
+    assert file is None
+    assert media.saved_parts == [1]
+
+
+@pytest.mark.asyncio
+async def test_a_missing_part_the_server_refused_reaches_the_caller_too(three_parts: str) -> None:
+    media = Media(rejects_part=1)
+
+    with pytest.raises(ConnectionError):
+        await Uploader(media).save_file(three_parts, file_id=_FILE_ID, file_part=1)
+
+
+@pytest.mark.asyncio
+async def test_no_path_is_not_an_upload_at_all() -> None:
+    assert await Uploader(Media()).save_file(None) is None


### PR DESCRIPTION
## What

`save_file()` can report success for a file the server never received in full, and can report
nothing at all. Two handlers swallow:

```python
# the per-part worker, save_file.py:105
try:
    await session.invoke(data)
except Exception as e:
    log.exception(e)          # keeps consuming; the part is simply lost

# the outer handler, save_file.py:201
except Exception as e:
    log.exception(e)          # falls out of the function -> `return None`
```

The second one is the visible half: `None` reaches serialisation and dies four frames deep,
naming neither the upload nor the file.

```python
class BrokenUpload(io.RawIOBase):
    name = "broken.jpg"
    ...
    def read(self, size=-1):
        raise OSError("the source went away mid-upload")

await client.send_photo("me", BrokenUpload(64 * 1024))
```

```
File "pyrogram/raw/types/input_media_uploaded_photo.py", line 106, in write
    b.write(self.file.write())
AttributeError: 'NoneType' object has no attribute 'write'
```

The real cause — `OSError` — only ever appears in the log, at whatever level the application
configured. `except OSError` around `send_photo()` does not catch it.

The first one is worse, because nothing fails at all: one part is dropped, every other part goes
up, and `save_file()` hands back a normal `InputFile` describing a file that is incomplete on the
server. The send that follows fails with an unrelated error — or, for a caller that stored the
id, much later.

## The change

- The worker remembers the exception instead of dropping it. Once every worker has drained, the
  first failure is raised.
- The outer handler re-raises after logging.
- The success return moves out of `else:` to below the `try`, because the failure check has to run
  *after* `finally` has drained the workers. The missing-part path `break`s out of the producer
  loop instead of returning from inside it.
- The docstring said a failed upload returns `None`; it now says it raises.

`None` keeps the two meanings it was meant to have: *path* was `None`, or this was a deliberate
single missing-part upload.

## Why the worker does not raise directly

The queue holds one item, so a worker that stops consuming leaves the producer blocked forever on
`queue.put()` — a raise there trades a wrong result for a hang. Every worker therefore drains to
the end and the failure is raised afterwards. For the same reason the check sits outside `finally`
rather than inside it: a worker only reports a failed part once it has been woken up and drained.

## Behaviour change

A failed upload used to raise `AttributeError` out of serialisation, or nothing at all when a
single part failed. It now raises what actually went wrong — `OSError`, `ConnectionError`,
`RPCError`. Callers that today catch `AttributeError`, or that check the result for `None` to
detect a failure, need to catch the real exception instead.

## Tests

`tests/unit/methods/test_save_file.py`, six cases: a finished upload describes every part; a part
the server refused reaches the caller; the parts around the refused one are still sent; a
re-uploaded missing part answers with `None`; a refused missing part reaches the caller too; no
path is not an upload at all.

`make test-unit` — 360 passed.
