### PR TITLE
fix(typing): keep the callback signature that the handler decorators erased

### DIFF
--- a/pyrogram/methods/decorators/handler_type.py
+++ b/pyrogram/methods/decorators/handler_type.py
@@ -1,0 +1,26 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Callable, TypeVar
+
+# Every handler decorator returns the function it was handed, unchanged. Binding the
+#  parameter and the return to one type variable is what carries the callback's own
+#  signature through: `def decorator(func: Callable) -> Callable` erased it, so a
+#  decorated handler was `Any` to a type checker and `handler(1, 2, 3, 4)` passed.
+#  A `TypeVar` rather than the 3.12 syntax because `requires-python` is `>=3.8`.
+HandlerType = TypeVar("HandlerType", bound=Callable)

--- a/pyrogram/methods/decorators/on_business_connection.py
+++ b/pyrogram/methods/decorators/on_business_connection.py
@@ -20,6 +20,7 @@ from typing import Callable, Optional, Union
 
 import pyrogram
 from pyrogram.filters import Filter
+from .handler_type import HandlerType
 
 
 class OnBusinessConnection:
@@ -27,7 +28,7 @@ class OnBusinessConnection:
         self: Union["OnBusinessConnection", Filter, None] = None,
         filters: Optional[Filter] = None,
         group: int = 0,
-    ) -> Callable:
+    ) -> Callable[[HandlerType], HandlerType]:
         """Decorator for handling changes in business connection.
 
         This does the same thing as :meth:`~pyrogram.Client.add_handler` using the
@@ -44,7 +45,7 @@ class OnBusinessConnection:
                 The group identifier, defaults to 0.
         """
 
-        def decorator(func: Callable) -> Callable:
+        def decorator(func: HandlerType) -> HandlerType:
             if isinstance(self, pyrogram.Client):
                 self.add_handler(pyrogram.handlers.BusinessConnectionHandler(func, filters), group)
             elif isinstance(self, Filter) or self is None:

--- a/pyrogram/methods/decorators/on_business_message.py
+++ b/pyrogram/methods/decorators/on_business_message.py
@@ -20,6 +20,7 @@ from typing import Callable, Optional, Union
 
 import pyrogram
 from pyrogram.filters import Filter
+from .handler_type import HandlerType
 
 
 class OnBusinessMessage:
@@ -27,7 +28,7 @@ class OnBusinessMessage:
         self: Union["OnBusinessMessage", Filter, None] = None,
         filters: Optional[Filter] = None,
         group: int = 0,
-    ) -> Callable:
+    ) -> Callable[[HandlerType], HandlerType]:
         """Decorator for handling new messages from business connection.
 
         This does the same thing as :meth:`~pyrogram.Client.add_handler` using the
@@ -44,7 +45,7 @@ class OnBusinessMessage:
                 The group identifier, defaults to 0.
         """
 
-        def decorator(func: Callable) -> Callable:
+        def decorator(func: HandlerType) -> HandlerType:
             if isinstance(self, pyrogram.Client):
                 self.add_handler(pyrogram.handlers.BusinessMessageHandler(func, filters), group)
             elif isinstance(self, Filter) or self is None:

--- a/pyrogram/methods/decorators/on_callback_query.py
+++ b/pyrogram/methods/decorators/on_callback_query.py
@@ -20,6 +20,7 @@ from typing import Callable, Optional, Union
 
 import pyrogram
 from pyrogram.filters import Filter
+from .handler_type import HandlerType
 
 
 class OnCallbackQuery:
@@ -27,7 +28,7 @@ class OnCallbackQuery:
         self: Union["OnCallbackQuery", Filter, None] = None,
         filters: Optional[Filter] = None,
         group: int = 0,
-    ) -> Callable:
+    ) -> Callable[[HandlerType], HandlerType]:
         """Decorator for handling callback queries.
 
         This does the same thing as :meth:`~pyrogram.Client.add_handler` using the
@@ -44,7 +45,7 @@ class OnCallbackQuery:
                 The group identifier, defaults to 0.
         """
 
-        def decorator(func: Callable) -> Callable:
+        def decorator(func: HandlerType) -> HandlerType:
             if isinstance(self, pyrogram.Client):
                 self.add_handler(pyrogram.handlers.CallbackQueryHandler(func, filters), group)
             elif isinstance(self, Filter) or self is None:

--- a/pyrogram/methods/decorators/on_chat_boost.py
+++ b/pyrogram/methods/decorators/on_chat_boost.py
@@ -20,6 +20,7 @@ from typing import Callable, Optional, Union
 
 import pyrogram
 from pyrogram.filters import Filter
+from .handler_type import HandlerType
 
 
 class OnChatBoost:
@@ -27,7 +28,7 @@ class OnChatBoost:
         self: Union["OnChatBoost", Filter, None] = None,
         filters: Optional[Filter] = None,
         group: int = 0,
-    ) -> Callable:
+    ) -> Callable[[HandlerType], HandlerType]:
         """Decorator for handling applied chat boosts.
 
         This does the same thing as :meth:`~pyrogram.Client.add_handler` using the
@@ -45,7 +46,7 @@ class OnChatBoost:
 
         """
 
-        def decorator(func: Callable) -> Callable:
+        def decorator(func: HandlerType) -> HandlerType:
             if isinstance(self, pyrogram.Client):
                 self.add_handler(pyrogram.handlers.ShippingQueryHandler(func, filters), group)
             elif isinstance(self, Filter) or self is None:

--- a/pyrogram/methods/decorators/on_chat_join_request.py
+++ b/pyrogram/methods/decorators/on_chat_join_request.py
@@ -20,6 +20,7 @@ from typing import Callable, Optional, Union
 
 import pyrogram
 from pyrogram.filters import Filter
+from .handler_type import HandlerType
 
 
 class OnChatJoinRequest:
@@ -27,7 +28,7 @@ class OnChatJoinRequest:
         self: Union["OnChatJoinRequest", Filter, None] = None,
         filters: Optional[Filter] = None,
         group: int = 0,
-    ) -> Callable:
+    ) -> Callable[[HandlerType], HandlerType]:
         """Decorator for handling chat join requests.
 
         This does the same thing as :meth:`~pyrogram.Client.add_handler` using the
@@ -43,7 +44,7 @@ class OnChatJoinRequest:
                 The group identifier, defaults to 0.
         """
 
-        def decorator(func: Callable) -> Callable:
+        def decorator(func: HandlerType) -> HandlerType:
             if isinstance(self, pyrogram.Client):
                 self.add_handler(pyrogram.handlers.ChatJoinRequestHandler(func, filters), group)
             elif isinstance(self, Filter) or self is None:

--- a/pyrogram/methods/decorators/on_chat_member_updated.py
+++ b/pyrogram/methods/decorators/on_chat_member_updated.py
@@ -20,6 +20,7 @@ from typing import Callable, Optional, Union
 
 import pyrogram
 from pyrogram.filters import Filter
+from .handler_type import HandlerType
 
 
 class OnChatMemberUpdated:
@@ -27,7 +28,7 @@ class OnChatMemberUpdated:
         self: Union["OnChatMemberUpdated", Filter, None] = None,
         filters: Optional[Filter] = None,
         group: int = 0,
-    ) -> Callable:
+    ) -> Callable[[HandlerType], HandlerType]:
         """Decorator for handling event changes on chat members.
 
         This does the same thing as :meth:`~pyrogram.Client.add_handler` using the
@@ -43,7 +44,7 @@ class OnChatMemberUpdated:
                 The group identifier, defaults to 0.
         """
 
-        def decorator(func: Callable) -> Callable:
+        def decorator(func: HandlerType) -> HandlerType:
             if isinstance(self, pyrogram.Client):
                 self.add_handler(pyrogram.handlers.ChatMemberUpdatedHandler(func, filters), group)
             elif isinstance(self, Filter) or self is None:

--- a/pyrogram/methods/decorators/on_chosen_inline_result.py
+++ b/pyrogram/methods/decorators/on_chosen_inline_result.py
@@ -20,6 +20,7 @@ from typing import Callable, Optional, Union
 
 import pyrogram
 from pyrogram.filters import Filter
+from .handler_type import HandlerType
 
 
 class OnChosenInlineResult:
@@ -27,7 +28,7 @@ class OnChosenInlineResult:
         self: Union["OnChosenInlineResult", Filter, None] = None,
         filters: Optional[Filter] = None,
         group: int = 0,
-    ) -> Callable:
+    ) -> Callable[[HandlerType], HandlerType]:
         """Decorator for handling chosen inline results.
 
         This does the same thing as :meth:`~pyrogram.Client.add_handler` using the
@@ -44,7 +45,7 @@ class OnChosenInlineResult:
                 The group identifier, defaults to 0.
         """
 
-        def decorator(func: Callable) -> Callable:
+        def decorator(func: HandlerType) -> HandlerType:
             if isinstance(self, pyrogram.Client):
                 self.add_handler(pyrogram.handlers.ChosenInlineResultHandler(func, filters), group)
             elif isinstance(self, Filter) or self is None:

--- a/pyrogram/methods/decorators/on_connect.py
+++ b/pyrogram/methods/decorators/on_connect.py
@@ -19,10 +19,11 @@
 from typing import Callable, Optional
 
 import pyrogram
+from .handler_type import HandlerType
 
 
 class OnConnect:
-    def on_connect(self: Optional["OnConnect"] = None) -> Callable:
+    def on_connect(self: Optional["OnConnect"] = None) -> Callable[[HandlerType], HandlerType]:
         """Decorator for handling connections.
 
         This does the same thing as :meth:`~pyrogram.Client.add_handler` using the
@@ -31,7 +32,7 @@ class OnConnect:
         .. include:: /_includes/usable-by/users-bots.rst
         """
 
-        def decorator(func: Callable) -> Callable:
+        def decorator(func: HandlerType) -> HandlerType:
             if isinstance(self, pyrogram.Client):
                 self.add_handler(pyrogram.handlers.ConnectHandler(func))
             else:

--- a/pyrogram/methods/decorators/on_deleted_business_messages.py
+++ b/pyrogram/methods/decorators/on_deleted_business_messages.py
@@ -20,6 +20,7 @@ from typing import Callable, Optional, Union
 
 import pyrogram
 from pyrogram.filters import Filter
+from .handler_type import HandlerType
 
 
 class OnDeletedBusinessMessages:
@@ -27,7 +28,7 @@ class OnDeletedBusinessMessages:
         self: Union["OnDeletedBusinessMessages", Filter, None] = None,
         filters: Optional[Filter] = None,
         group: int = 0,
-    ) -> Callable:
+    ) -> Callable[[HandlerType], HandlerType]:
         """Decorator for handling deleted messages from business connection.
 
         This does the same thing as :meth:`~pyrogram.Client.add_handler` using the
@@ -44,7 +45,7 @@ class OnDeletedBusinessMessages:
                 The group identifier, defaults to 0.
         """
 
-        def decorator(func: Callable) -> Callable:
+        def decorator(func: HandlerType) -> HandlerType:
             if isinstance(self, pyrogram.Client):
                 self.add_handler(pyrogram.handlers.DeletedBusinessMessagesHandler(func, filters), group)
             elif isinstance(self, Filter) or self is None:

--- a/pyrogram/methods/decorators/on_deleted_messages.py
+++ b/pyrogram/methods/decorators/on_deleted_messages.py
@@ -20,6 +20,7 @@ from typing import Callable, Optional, Union
 
 import pyrogram
 from pyrogram.filters import Filter
+from .handler_type import HandlerType
 
 
 class OnDeletedMessages:
@@ -27,7 +28,7 @@ class OnDeletedMessages:
         self: Union["OnDeletedMessages", Filter, None] = None,
         filters: Optional[Filter] = None,
         group: int = 0,
-    ) -> Callable:
+    ) -> Callable[[HandlerType], HandlerType]:
         """Decorator for handling deleted messages.
 
         This does the same thing as :meth:`~pyrogram.Client.add_handler` using the
@@ -44,7 +45,7 @@ class OnDeletedMessages:
                 The group identifier, defaults to 0.
         """
 
-        def decorator(func: Callable) -> Callable:
+        def decorator(func: HandlerType) -> HandlerType:
             if isinstance(self, pyrogram.Client):
                 self.add_handler(pyrogram.handlers.DeletedMessagesHandler(func, filters), group)
             elif isinstance(self, Filter) or self is None:

--- a/pyrogram/methods/decorators/on_disconnect.py
+++ b/pyrogram/methods/decorators/on_disconnect.py
@@ -19,10 +19,11 @@
 from typing import Callable, Optional
 
 import pyrogram
+from .handler_type import HandlerType
 
 
 class OnDisconnect:
-    def on_disconnect(self: Optional["OnDisconnect"] = None) -> Callable:
+    def on_disconnect(self: Optional["OnDisconnect"] = None) -> Callable[[HandlerType], HandlerType]:
         """Decorator for handling disconnections.
 
         This does the same thing as :meth:`~pyrogram.Client.add_handler` using the
@@ -31,7 +32,7 @@ class OnDisconnect:
         .. include:: /_includes/usable-by/users-bots.rst
         """
 
-        def decorator(func: Callable) -> Callable:
+        def decorator(func: HandlerType) -> HandlerType:
             if isinstance(self, pyrogram.Client):
                 self.add_handler(pyrogram.handlers.DisconnectHandler(func))
             else:

--- a/pyrogram/methods/decorators/on_edited_business_message.py
+++ b/pyrogram/methods/decorators/on_edited_business_message.py
@@ -20,6 +20,7 @@ from typing import Callable, Optional, Union
 
 import pyrogram
 from pyrogram.filters import Filter
+from .handler_type import HandlerType
 
 
 class OnEditedBusinessMessage:
@@ -27,7 +28,7 @@ class OnEditedBusinessMessage:
         self: Union["OnEditedBusinessMessage", Filter, None] = None,
         filters: Optional[Filter] = None,
         group: int = 0,
-    ) -> Callable:
+    ) -> Callable[[HandlerType], HandlerType]:
         """Decorator for handling edited messages from business connection.
 
         This does the same thing as :meth:`~pyrogram.Client.add_handler` using the
@@ -44,7 +45,7 @@ class OnEditedBusinessMessage:
                 The group identifier, defaults to 0.
         """
 
-        def decorator(func: Callable) -> Callable:
+        def decorator(func: HandlerType) -> HandlerType:
             if isinstance(self, pyrogram.Client):
                 self.add_handler(pyrogram.handlers.EditedBusinessMessageHandler(func, filters), group)
             elif isinstance(self, Filter) or self is None:

--- a/pyrogram/methods/decorators/on_edited_message.py
+++ b/pyrogram/methods/decorators/on_edited_message.py
@@ -20,6 +20,7 @@ from typing import Callable, Optional, Union
 
 import pyrogram
 from pyrogram.filters import Filter
+from .handler_type import HandlerType
 
 
 class OnEditedMessage:
@@ -27,7 +28,7 @@ class OnEditedMessage:
         self: Union["OnEditedMessage", Filter, None] = None,
         filters: Optional[Filter] = None,
         group: int = 0,
-    ) -> Callable:
+    ) -> Callable[[HandlerType], HandlerType]:
         """Decorator for handling edited messages.
 
         This does the same thing as :meth:`~pyrogram.Client.add_handler` using the
@@ -44,7 +45,7 @@ class OnEditedMessage:
                 The group identifier, defaults to 0.
         """
 
-        def decorator(func: Callable) -> Callable:
+        def decorator(func: HandlerType) -> HandlerType:
             if isinstance(self, pyrogram.Client):
                 self.add_handler(pyrogram.handlers.EditedMessageHandler(func, filters), group)
             elif isinstance(self, Filter) or self is None:

--- a/pyrogram/methods/decorators/on_error.py
+++ b/pyrogram/methods/decorators/on_error.py
@@ -20,6 +20,7 @@ from typing import Callable, Optional, Sequence, Union
 
 import pyrogram
 from pyrogram.filters import Filter
+from .handler_type import HandlerType
 
 
 class OnError:
@@ -28,7 +29,7 @@ class OnError:
         exceptions: Optional[Union[Exception, Sequence[Exception]]] = None,
         filters: Optional[Filter] = None,
         group: int = 0,
-    ) -> Callable:
+    ) -> Callable[[HandlerType], HandlerType]:
         """Decorator for handling unexpected errors.
 
         This does the same thing as :meth:`~pyrogram.Client.add_handler` using the
@@ -49,7 +50,7 @@ class OnError:
                 The group identifier, defaults to 0.
         """
 
-        def decorator(func: Callable) -> Callable:
+        def decorator(func: HandlerType) -> HandlerType:
             if isinstance(self, pyrogram.Client):
                 self.add_handler(pyrogram.handlers.ErrorHandler(func, exceptions, filters), group)
             else:

--- a/pyrogram/methods/decorators/on_guest_message.py
+++ b/pyrogram/methods/decorators/on_guest_message.py
@@ -20,6 +20,7 @@ from typing import Callable, Optional, Union
 
 import pyrogram
 from pyrogram.filters import Filter
+from .handler_type import HandlerType
 
 
 class OnGuestMessage:
@@ -27,7 +28,7 @@ class OnGuestMessage:
         self: Union["OnGuestMessage", Filter, None] = None,
         filters: Optional[Filter] = None,
         group: int = 0,
-    ) -> Callable:
+    ) -> Callable[[HandlerType], HandlerType]:
         """Decorator for handling new guest messages.
 
         This does the same thing as :meth:`~pyrogram.Client.add_handler` using the
@@ -44,7 +45,7 @@ class OnGuestMessage:
                 The group identifier, defaults to 0.
         """
 
-        def decorator(func: Callable) -> Callable:
+        def decorator(func: HandlerType) -> HandlerType:
             if isinstance(self, pyrogram.Client):
                 self.add_handler(pyrogram.handlers.GuestMessageHandler(func, filters), group)
             elif isinstance(self, Filter) or self is None:

--- a/pyrogram/methods/decorators/on_inline_query.py
+++ b/pyrogram/methods/decorators/on_inline_query.py
@@ -20,6 +20,7 @@ from typing import Callable, Optional, Union
 
 import pyrogram
 from pyrogram.filters import Filter
+from .handler_type import HandlerType
 
 
 class OnInlineQuery:
@@ -27,7 +28,7 @@ class OnInlineQuery:
         self: Union["OnInlineQuery", Filter, None] = None,
         filters: Optional[Filter] = None,
         group: int = 0,
-    ) -> Callable:
+    ) -> Callable[[HandlerType], HandlerType]:
         """Decorator for handling inline queries.
 
         This does the same thing as :meth:`~pyrogram.Client.add_handler` using the
@@ -44,7 +45,7 @@ class OnInlineQuery:
                 The group identifier, defaults to 0.
         """
 
-        def decorator(func: Callable) -> Callable:
+        def decorator(func: HandlerType) -> HandlerType:
             if isinstance(self, pyrogram.Client):
                 self.add_handler(pyrogram.handlers.InlineQueryHandler(func, filters), group)
             elif isinstance(self, Filter) or self is None:

--- a/pyrogram/methods/decorators/on_managed_bot.py
+++ b/pyrogram/methods/decorators/on_managed_bot.py
@@ -20,6 +20,7 @@ from typing import Callable, Optional, Union
 
 import pyrogram
 from pyrogram.filters import Filter
+from .handler_type import HandlerType
 
 
 class OnManagedBot:
@@ -27,7 +28,7 @@ class OnManagedBot:
         self: Union["OnManagedBot", Filter, None] = None,
         filters: Optional[Filter] = None,
         group: int = 0,
-    ) -> Callable:
+    ) -> Callable[[HandlerType], HandlerType]:
         """Decorator for handling new managed bot creation updates.
 
         This does the same thing as :meth:`~pyrogram.Client.add_handler` using the
@@ -44,7 +45,7 @@ class OnManagedBot:
                 The group identifier, defaults to 0.
         """
 
-        def decorator(func: Callable) -> Callable:
+        def decorator(func: HandlerType) -> HandlerType:
             if isinstance(self, pyrogram.Client):
                 self.add_handler(pyrogram.handlers.ManagedBotUpdatedHandler(func, filters), group)
             elif isinstance(self, Filter) or self is None:

--- a/pyrogram/methods/decorators/on_message.py
+++ b/pyrogram/methods/decorators/on_message.py
@@ -20,6 +20,7 @@ from typing import Callable, Optional, Union
 
 import pyrogram
 from pyrogram.filters import Filter
+from .handler_type import HandlerType
 
 
 class OnMessage:
@@ -27,7 +28,7 @@ class OnMessage:
         self: Union["OnMessage", Filter, None] = None,
         filters: Optional[Filter] = None,
         group: int = 0,
-    ) -> Callable:
+    ) -> Callable[[HandlerType], HandlerType]:
         """Decorator for handling new messages.
 
         This does the same thing as :meth:`~pyrogram.Client.add_handler` using the
@@ -44,7 +45,7 @@ class OnMessage:
                 The group identifier, defaults to 0.
         """
 
-        def decorator(func: Callable) -> Callable:
+        def decorator(func: HandlerType) -> HandlerType:
             if isinstance(self, pyrogram.Client):
                 self.add_handler(pyrogram.handlers.MessageHandler(func, filters), group)
             elif isinstance(self, Filter) or self is None:

--- a/pyrogram/methods/decorators/on_message_reaction.py
+++ b/pyrogram/methods/decorators/on_message_reaction.py
@@ -20,6 +20,7 @@ from typing import Callable, Optional, Union
 
 import pyrogram
 from pyrogram.filters import Filter
+from .handler_type import HandlerType
 
 
 class OnMessageReaction:
@@ -27,7 +28,7 @@ class OnMessageReaction:
         self: Union["OnMessageReaction", Filter, None] = None,
         filters: Optional[Filter] = None,
         group: int = 0
-    ) -> Callable:
+    ) -> Callable[[HandlerType], HandlerType]:
         """Decorator for handling reaction changes on messages.
 
         This does the same thing as :meth:`~pyrogram.Client.add_handler` using the
@@ -43,7 +44,7 @@ class OnMessageReaction:
                 The group identifier, defaults to 0.
         """
 
-        def decorator(func: Callable) -> Callable:
+        def decorator(func: HandlerType) -> HandlerType:
             if isinstance(self, pyrogram.Client):
                 self.add_handler(pyrogram.handlers.MessageReactionHandler(func, filters), group)
             elif isinstance(self, Filter) or self is None:

--- a/pyrogram/methods/decorators/on_message_reaction_count.py
+++ b/pyrogram/methods/decorators/on_message_reaction_count.py
@@ -20,6 +20,7 @@ from typing import Callable, Optional, Union
 
 import pyrogram
 from pyrogram.filters import Filter
+from .handler_type import HandlerType
 
 
 class OnMessageReactionCount:
@@ -27,7 +28,7 @@ class OnMessageReactionCount:
         self: Union["OnMessageReactionCount", Filter, None] = None,
         filters: Optional[Filter] = None,
         group: int = 0
-    ) -> Callable:
+    ) -> Callable[[HandlerType], HandlerType]:
         """Decorator for handling anonymous reaction changes on messages.
 
         This does the same thing as :meth:`~pyrogram.Client.add_handler` using the
@@ -43,7 +44,7 @@ class OnMessageReactionCount:
                 The group identifier, defaults to 0.
         """
 
-        def decorator(func: Callable) -> Callable:
+        def decorator(func: HandlerType) -> HandlerType:
             if isinstance(self, pyrogram.Client):
                 self.add_handler(pyrogram.handlers.MessageReactionCountHandler(func, filters), group)
             elif isinstance(self, Filter) or self is None:

--- a/pyrogram/methods/decorators/on_poll.py
+++ b/pyrogram/methods/decorators/on_poll.py
@@ -20,6 +20,7 @@ from typing import Callable, Optional, Union
 
 import pyrogram
 from pyrogram.filters import Filter
+from .handler_type import HandlerType
 
 
 class OnPoll:
@@ -27,7 +28,7 @@ class OnPoll:
         self: Union["OnPoll", Filter, None] = None,
         filters: Optional[Filter] = None,
         group: int = 0,
-    ) -> Callable:
+    ) -> Callable[[HandlerType], HandlerType]:
         """Decorator for handling poll updates.
 
         This does the same thing as :meth:`~pyrogram.Client.add_handler` using the
@@ -44,7 +45,7 @@ class OnPoll:
                 The group identifier, defaults to 0.
         """
 
-        def decorator(func: Callable) -> Callable:
+        def decorator(func: HandlerType) -> HandlerType:
             if isinstance(self, pyrogram.Client):
                 self.add_handler(pyrogram.handlers.PollHandler(func, filters), group)
             elif isinstance(self, Filter) or self is None:

--- a/pyrogram/methods/decorators/on_pre_checkout_query.py
+++ b/pyrogram/methods/decorators/on_pre_checkout_query.py
@@ -20,6 +20,7 @@ from typing import Callable, Optional, Union
 
 import pyrogram
 from pyrogram.filters import Filter
+from .handler_type import HandlerType
 
 
 class OnPreCheckoutQuery:
@@ -27,7 +28,7 @@ class OnPreCheckoutQuery:
         self: Union["OnPreCheckoutQuery", Filter, None] = None,
         filters: Optional[Filter] = None,
         group: int = 0,
-    ) -> Callable:
+    ) -> Callable[[HandlerType], HandlerType]:
         """Decorator for handling pre-checkout queries.
 
         This does the same thing as :meth:`~pyrogram.Client.add_handler` using the
@@ -44,7 +45,7 @@ class OnPreCheckoutQuery:
                 The group identifier, defaults to 0.
         """
 
-        def decorator(func: Callable) -> Callable:
+        def decorator(func: HandlerType) -> HandlerType:
             if isinstance(self, pyrogram.Client):
                 self.add_handler(pyrogram.handlers.PreCheckoutQueryHandler(func, filters), group)
             elif isinstance(self, Filter) or self is None:

--- a/pyrogram/methods/decorators/on_purchased_paid_media.py
+++ b/pyrogram/methods/decorators/on_purchased_paid_media.py
@@ -20,6 +20,7 @@ from typing import Callable, Optional, Union
 
 import pyrogram
 from pyrogram.filters import Filter
+from .handler_type import HandlerType
 
 
 class OnPurchasedPaidMedia:
@@ -27,7 +28,7 @@ class OnPurchasedPaidMedia:
         self: Union["OnPurchasedPaidMedia", Filter, None] = None,
         filters: Optional[Filter] = None,
         group: int = 0
-    ) -> Callable:
+    ) -> Callable[[HandlerType], HandlerType]:
         """Decorator for handling purchased paid media.
 
         This does the same thing as :meth:`~pyrogram.Client.add_handler` using the
@@ -43,7 +44,7 @@ class OnPurchasedPaidMedia:
                 The group identifier, defaults to 0.
         """
 
-        def decorator(func: Callable) -> Callable:
+        def decorator(func: HandlerType) -> HandlerType:
             if isinstance(self, pyrogram.Client):
                 self.add_handler(pyrogram.handlers.PurchasedPaidMediaHandler(func, filters), group)
             elif isinstance(self, Filter) or self is None:

--- a/pyrogram/methods/decorators/on_raw_update.py
+++ b/pyrogram/methods/decorators/on_raw_update.py
@@ -20,6 +20,7 @@ from typing import Callable, Optional
 
 import pyrogram
 from pyrogram.filters import Filter
+from .handler_type import HandlerType
 
 
 class OnRawUpdate:
@@ -27,7 +28,7 @@ class OnRawUpdate:
         self: Optional["OnRawUpdate"] = None,
         filters=None,
         group: int = 0,
-    ) -> Callable:
+    ) -> Callable[[HandlerType], HandlerType]:
         """Decorator for handling raw updates.
 
         This does the same thing as :meth:`~pyrogram.Client.add_handler` using the
@@ -44,7 +45,7 @@ class OnRawUpdate:
                 The group identifier, defaults to 0.
         """
 
-        def decorator(func: Callable) -> Callable:
+        def decorator(func: HandlerType) -> HandlerType:
             if isinstance(self, pyrogram.Client):
                 self.add_handler(pyrogram.handlers.RawUpdateHandler(func, filters), group)
             elif isinstance(self, Filter) or self is None:

--- a/pyrogram/methods/decorators/on_shipping_query.py
+++ b/pyrogram/methods/decorators/on_shipping_query.py
@@ -20,6 +20,7 @@ from typing import Callable, Optional, Union
 
 import pyrogram
 from pyrogram.filters import Filter
+from .handler_type import HandlerType
 
 
 class OnShippingQuery:
@@ -27,7 +28,7 @@ class OnShippingQuery:
         self: Union["OnShippingQuery", Filter, None] = None,
         filters: Optional[Filter] = None,
         group: int = 0,
-    ) -> Callable:
+    ) -> Callable[[HandlerType], HandlerType]:
         """Decorator for handling shipping queries.
 
         This does the same thing as :meth:`~pyrogram.Client.add_handler` using the
@@ -45,7 +46,7 @@ class OnShippingQuery:
 
         """
 
-        def decorator(func: Callable) -> Callable:
+        def decorator(func: HandlerType) -> HandlerType:
             if isinstance(self, pyrogram.Client):
                 self.add_handler(pyrogram.handlers.ShippingQueryHandler(func, filters), group)
             elif isinstance(self, Filter) or self is None:

--- a/pyrogram/methods/decorators/on_start.py
+++ b/pyrogram/methods/decorators/on_start.py
@@ -19,10 +19,11 @@
 from typing import Callable, Optional
 
 import pyrogram
+from .handler_type import HandlerType
 
 
 class OnStart:
-    def on_start(self: Optional["OnStart"] = None) -> Callable:
+    def on_start(self: Optional["OnStart"] = None) -> Callable[[HandlerType], HandlerType]:
         """Decorator for handling client start.
 
         This does the same thing as :meth:`~pyrogram.Client.add_handler` using the
@@ -31,7 +32,7 @@ class OnStart:
         .. include:: /_includes/usable-by/users-bots.rst
         """
 
-        def decorator(func: Callable) -> Callable:
+        def decorator(func: HandlerType) -> HandlerType:
             if isinstance(self, pyrogram.Client):
                 self.add_handler(pyrogram.handlers.StartHandler(func))
             else:

--- a/pyrogram/methods/decorators/on_stop.py
+++ b/pyrogram/methods/decorators/on_stop.py
@@ -19,10 +19,11 @@
 from typing import Callable, Optional
 
 import pyrogram
+from .handler_type import HandlerType
 
 
 class OnStop:
-    def on_stop(self: Optional["OnStop"] = None) -> Callable:
+    def on_stop(self: Optional["OnStop"] = None) -> Callable[[HandlerType], HandlerType]:
         """Decorator for handling client stop.
 
         This does the same thing as :meth:`~pyrogram.Client.add_handler` using the
@@ -31,7 +32,7 @@ class OnStop:
         .. include:: /_includes/usable-by/users-bots.rst
         """
 
-        def decorator(func: Callable) -> Callable:
+        def decorator(func: HandlerType) -> HandlerType:
             if isinstance(self, pyrogram.Client):
                 self.add_handler(pyrogram.handlers.StopHandler(func))
             else:

--- a/pyrogram/methods/decorators/on_stopped_message_generation.py
+++ b/pyrogram/methods/decorators/on_stopped_message_generation.py
@@ -20,6 +20,7 @@ from typing import Callable, Optional, Union
 
 import pyrogram
 from pyrogram.filters import Filter
+from .handler_type import HandlerType
 
 
 class OnStoppedMessageGeneration:
@@ -27,7 +28,7 @@ class OnStoppedMessageGeneration:
         self: Union["OnStoppedMessageGeneration", Filter, None] = None,
         filters: Optional[Filter] = None,
         group: int = 0,
-    ) -> Callable:
+    ) -> Callable[[HandlerType], HandlerType]:
         """Decorator for handling stopped message generation.
 
         This does the same thing as :meth:`~pyrogram.Client.add_handler` using the
@@ -44,7 +45,7 @@ class OnStoppedMessageGeneration:
                 The group identifier, defaults to 0.
         """
 
-        def decorator(func: Callable) -> Callable:
+        def decorator(func: HandlerType) -> HandlerType:
             if isinstance(self, pyrogram.Client):
                 self.add_handler(pyrogram.handlers.StoppedMessageGenerationHandler(func, filters), group)
             elif isinstance(self, Filter) or self is None:

--- a/pyrogram/methods/decorators/on_story.py
+++ b/pyrogram/methods/decorators/on_story.py
@@ -20,6 +20,7 @@ from typing import Callable, Optional, Union
 
 import pyrogram
 from pyrogram.filters import Filter
+from .handler_type import HandlerType
 
 
 class OnStory:
@@ -27,7 +28,7 @@ class OnStory:
         self: Union["OnStory", Filter, None] = None,
         filters: Optional[Filter] = None,
         group: int = 0,
-    ) -> Callable:
+    ) -> Callable[[HandlerType], HandlerType]:
         """Decorator for handling new stories.
 
         This does the same thing as :meth:`~pyrogram.Client.add_handler` using the
@@ -44,7 +45,7 @@ class OnStory:
                 The group identifier, defaults to 0.
         """
 
-        def decorator(func: Callable) -> Callable:
+        def decorator(func: HandlerType) -> HandlerType:
             if isinstance(self, pyrogram.Client):
                 self.add_handler(pyrogram.handlers.StoryHandler(func, filters), group)
             elif isinstance(self, Filter) or self is None:

--- a/pyrogram/methods/decorators/on_user_status.py
+++ b/pyrogram/methods/decorators/on_user_status.py
@@ -20,6 +20,7 @@ from typing import Callable, Optional, Union
 
 import pyrogram
 from pyrogram.filters import Filter
+from .handler_type import HandlerType
 
 
 class OnUserStatus:
@@ -27,7 +28,7 @@ class OnUserStatus:
         self: Union["OnUserStatus", Filter, None] = None,
         filters: Optional[Filter] = None,
         group: int = 0,
-    ) -> Callable:
+    ) -> Callable[[HandlerType], HandlerType]:
         """Decorator for handling user status updates.
         This does the same thing as :meth:`~pyrogram.Client.add_handler` using the
         :obj:`~pyrogram.handlers.UserStatusHandler`.
@@ -42,7 +43,7 @@ class OnUserStatus:
                 The group identifier, defaults to 0.
         """
 
-        def decorator(func: Callable) -> Callable:
+        def decorator(func: HandlerType) -> HandlerType:
             if isinstance(self, pyrogram.Client):
                 self.add_handler(pyrogram.handlers.UserStatusHandler(func, filters), group)
             elif isinstance(self, Filter) or self is None:

--- a/tests/unit/methods/decorators/__init__.py
+++ b/tests/unit/methods/decorators/__init__.py
@@ -1,0 +1,17 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.

--- a/tests/unit/methods/decorators/test_decorators.py
+++ b/tests/unit/methods/decorators/test_decorators.py
@@ -1,0 +1,67 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+import inspect
+from pathlib import Path
+from typing import Callable, List, Set
+
+import pytest
+
+import pyrogram
+from pyrogram.methods import decorators
+from pyrogram.methods.decorators.handler_type import HandlerType
+
+
+def _decorator_names() -> List[str]:
+    names: Set[str] = set()
+
+    for _, decorator_class in inspect.getmembers(decorators, inspect.isclass):
+        for method_name, _ in inspect.getmembers(decorator_class, inspect.isfunction):
+            if method_name.startswith("on_"):
+                names.add(method_name)
+
+    return sorted(names)
+
+
+def _module_names() -> List[str]:
+    package_directory = Path(decorators.__file__).parent
+
+    return sorted(path.stem for path in package_directory.glob("on_*.py"))
+
+
+def test_every_module_contributes_the_decorator_named_after_it() -> None:
+    assert _decorator_names() == _module_names()
+
+
+@pytest.mark.parametrize("decorator_name", _decorator_names())
+def test_decorator_gives_back_the_function_it_was_handed(decorator_name: str) -> None:
+    async def handler(client: pyrogram.Client, update: pyrogram.types.Update) -> None: ...
+
+    decorated = getattr(pyrogram.Client, decorator_name)()(handler)
+
+    assert decorated is handler
+    assert len(handler.handlers) == 1
+
+
+@pytest.mark.parametrize("decorator_name", _decorator_names())
+def test_decorator_binds_the_callback_signature_to_one_type_variable(decorator_name: str) -> None:
+    # A module added later starts from a sibling that still reads `-> Callable`, and the two
+    #  tests above pass either way: they check what the decorator returns, not what it promises.
+    decorator = getattr(pyrogram.Client, decorator_name)
+
+    assert inspect.signature(decorator).return_annotation == Callable[[HandlerType], HandlerType]


### PR DESCRIPTION
## What

Every handler decorator declared `def decorator(func: Callable) -> Callable`. A bare
`Callable` takes no parameters, so it erases the signature it was handed and the decorated
function comes back as `Any`.

The 30 modules under `pyrogram/methods/decorators/` now bind the parameter and the return
to one type variable, so the callback keeps its own signature:

```python
def on_message(...) -> Callable[[HandlerType], HandlerType]:
    def decorator(func: HandlerType) -> HandlerType:
        ...
        return func
```

`HandlerType = TypeVar("HandlerType", bound=Callable)` lives in one new module,
`pyrogram/methods/decorators/handler_type.py`. A `TypeVar` rather than the 3.12 `[T: Callable]`
syntax because `requires-python` is `>=3.8`, and a module of its own rather than 30 copies of
the same declaration.

Nothing else changed: every decorator still returns the function unchanged and registers the
same handler in the same group.

## Why

The package ships `py.typed`, so this reaches every user running a type checker. Before, with
`mypy --ignore-missing-imports`:

```python
app = Client("probe")

@app.on_message()
async def handler(client: Client, message: Message) -> None: ...

reveal_type(handler)      # Revealed type is "Any"
handler(1, 2, 3, 4)       # no error
```

After:

```
note: Revealed type is "def (client: pyrogram.client.Client,
       message: pyrogram.types.messages_and_media.message.Message) -> Coroutine[Any, Any, None]"
error: Too many arguments for "handler"  [call-arg]
error: Argument 1 to "handler" has incompatible type "int"; expected "Client"  [arg-type]
error: Argument 2 to "handler" has incompatible type "int"; expected "Message"  [arg-type]
```

This is the one place in the library where an annotation actively destroys information rather
than merely failing to add it.

## How to test

`make test-unit` — `421 passed, 7 deselected`. The 61 new ones are
`tests/unit/methods/decorators/test_decorators.py`: one asserting that every `on_*.py` module
contributes the decorator named after it, so a module cannot be skipped silently, and two
parameterised over all 30 — one asserting the decorator gives back the same function object and
registers exactly one handler, one asserting its return annotation is
`Callable[[HandlerType], HandlerType]`.

That last one is why it is 30 and not 29. A module added later starts from a sibling that still
reads `-> Callable`, and the first two tests pass either way, because they check what the
decorator returns rather than what it promises.

To see it bite, make any decorator `return None` instead of `return func`:

```
FAILED tests/unit/methods/decorators/test_decorators.py::test_decorator_gives_back_the_function_it_was_handed[on_poll]
1 failed, 60 passed
```

`make lint` — `All checks passed!`.
