### PR TITLE
fix(typing): annotate the return of the 45 public methods that document one

### DIFF
--- a/pyrogram/methods/account/get_account_ttl.py
+++ b/pyrogram/methods/account/get_account_ttl.py
@@ -23,7 +23,7 @@ from pyrogram import raw
 class GetAccountTTL:
     async def get_account_ttl(
         self: "pyrogram.Client",
-    ):
+    ) -> int:
         """Get days to live of account.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/account/get_privacy.py
+++ b/pyrogram/methods/account/get_privacy.py
@@ -16,6 +16,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import List
+
 import pyrogram
 from pyrogram import raw, types, enums
 
@@ -24,7 +26,7 @@ class GetPrivacy:
     async def get_privacy(
         self: "pyrogram.Client",
         key: "enums.PrivacyKey"
-    ):
+    ) -> List["types.PrivacyRule"]:
         """Get account privacy rules.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/account/remove_profile_audio.py
+++ b/pyrogram/methods/account/remove_profile_audio.py
@@ -22,7 +22,7 @@ from pyrogram.file_id import FileType
 
 
 class RemoveProfileAudio:
-    async def remove_profile_audio(self: "pyrogram.Client", file_id: str):
+    async def remove_profile_audio(self: "pyrogram.Client", file_id: str) -> bool:
         """Removes an audio file from the profile audio files of the current user.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/account/set_account_ttl.py
+++ b/pyrogram/methods/account/set_account_ttl.py
@@ -24,7 +24,7 @@ class SetAccountTTL:
     async def set_account_ttl(
         self: "pyrogram.Client",
         days: int
-    ):
+    ) -> bool:
         """Set days to live of account.
 
         .. note::

--- a/pyrogram/methods/account/set_inactive_session_ttl.py
+++ b/pyrogram/methods/account/set_inactive_session_ttl.py
@@ -24,7 +24,7 @@ class SetInactiveSessionTTL:
     async def set_inactive_session_ttl(
         self: "pyrogram.Client",
         inactive_session_ttl_days: int
-    ):
+    ) -> bool:
         """Changes the period of inactivity after which sessions will automatically be terminated.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/account/set_privacy.py
+++ b/pyrogram/methods/account/set_privacy.py
@@ -40,7 +40,7 @@ class SetPrivacy:
             "types.InputPrivacyRuleDisallowContacts",
             "types.InputPrivacyRuleDisallowUsers"
         ]],
-    ):
+    ) -> List["types.PrivacyRule"]:
         """Set account privacy rules.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/account/set_profile_audio_position.py
+++ b/pyrogram/methods/account/set_profile_audio_position.py
@@ -26,7 +26,7 @@ from pyrogram.file_id import FileType
 class SetProfileAudioPosition:
     async def set_profile_audio_position(
         self: "pyrogram.Client", file_id: str, after_file_id: Optional[str] = None
-    ):
+    ) -> bool:
         """Changes position of an audio file in the profile audio files of the current user.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/auth/log_out.py
+++ b/pyrogram/methods/auth/log_out.py
@@ -27,7 +27,7 @@ log = logging.getLogger(__name__)
 class LogOut:
     async def log_out(
         self: "pyrogram.Client",
-    ):
+    ) -> bool:
         """Log out from Telegram and delete the *\\*.session* file.
 
         When you log out, the current client is stopped and the storage session deleted.

--- a/pyrogram/methods/bots/answer_callback_query.py
+++ b/pyrogram/methods/bots/answer_callback_query.py
@@ -30,7 +30,7 @@ class AnswerCallbackQuery:
         show_alert: Optional[bool] = None,
         url: Optional[str] = None,
         cache_time: int = 0
-    ):
+    ) -> bool:
         """Send answers to callback queries sent from inline keyboards.
         The answer will be displayed to the user as a notification at the top of the chat screen or as an alert.
 

--- a/pyrogram/methods/bots/answer_guest_query.py
+++ b/pyrogram/methods/bots/answer_guest_query.py
@@ -23,7 +23,7 @@ from pyrogram import raw, types
 class AnswerGuestQuery:
     async def answer_guest_query(
         self: "pyrogram.Client", guest_query_id: str, result: "types.InlineQueryResult"
-    ):
+    ) -> "types.SentGuestMessage":
         """Use this method to reply to a received guest message.
 
         .. include:: /_includes/usable-by/bots.rst

--- a/pyrogram/methods/bots/answer_inline_query.py
+++ b/pyrogram/methods/bots/answer_inline_query.py
@@ -34,7 +34,7 @@ class AnswerInlineQuery:
         next_offset: str = "",
         switch_pm_text: str = "",
         switch_pm_parameter: str = ""
-    ):
+    ) -> bool:
         """Send answers to an inline query.
 
         A maximum of 50 results per query is allowed.

--- a/pyrogram/methods/bots/answer_pre_checkout_query.py
+++ b/pyrogram/methods/bots/answer_pre_checkout_query.py
@@ -28,7 +28,7 @@ class AnswerPreCheckoutQuery:
         pre_checkout_query_id: str,
         ok: Optional[bool] = None,
         error_message: Optional[str] = None
-    ):
+    ) -> bool:
         """Send answers to pre-checkout queries.
 
         .. include:: /_includes/usable-by/bots.rst

--- a/pyrogram/methods/bots/answer_shipping_query.py
+++ b/pyrogram/methods/bots/answer_shipping_query.py
@@ -30,7 +30,7 @@ class AnswerShippingQuery:
         ok: bool,
         shipping_options: Optional[List["types.ShippingOption"]] = None,
         error_message: Optional[str] = None
-    ):
+    ) -> bool:
         """If you sent an invoice requesting a shipping address and the parameter ``is_flexible`` was specified, the API sends the confirmation in the form of an :obj:`~pyrogram.handlers.ShippingQueryHandler`.
 
         Use this method to reply to shipping queries.

--- a/pyrogram/methods/bots/get_inline_bot_results.py
+++ b/pyrogram/methods/bots/get_inline_bot_results.py
@@ -31,7 +31,7 @@ class GetInlineBotResults:
         offset: str = "",
         latitude: Optional[float] = None,
         longitude: Optional[float] = None
-    ):
+    ) -> "raw.base.messages.BotResults":
         """Get bot results via inline queries.
         You can then send a result using :meth:`~pyrogram.Client.send_inline_bot_result`
 
@@ -58,7 +58,7 @@ class GetInlineBotResults:
                 Useful for location-based results only.
 
         Returns:
-            :obj:`BotResults <pyrogram.api.types.messages.BotResults>`: On Success.
+            :obj:`BotResults <pyrogram.raw.base.messages.BotResults>`: On Success.
 
         Raises:
             TimeoutError: In case the bot fails to answer within 10 seconds.

--- a/pyrogram/methods/bots/get_inline_bot_results.py
+++ b/pyrogram/methods/bots/get_inline_bot_results.py
@@ -58,7 +58,7 @@ class GetInlineBotResults:
                 Useful for location-based results only.
 
         Returns:
-            :obj:`BotResults <pyrogram.raw.base.messages.BotResults>`: On Success.
+            :obj:`~pyrogram.raw.base.messages.BotResults`: On Success.
 
         Raises:
             TimeoutError: In case the bot fails to answer within 10 seconds.

--- a/pyrogram/methods/bots/request_callback_answer.py
+++ b/pyrogram/methods/bots/request_callback_answer.py
@@ -30,7 +30,7 @@ class RequestCallbackAnswer:
         callback_data: Union[str, bytes],
         password: Optional[str] = None,
         timeout: int = 10
-    ):
+    ) -> "raw.base.messages.BotCallbackAnswer":
         """Request a callback answer from bots.
         This is the equivalent of clicking an inline button containing callback data.
 
@@ -56,8 +56,8 @@ class RequestCallbackAnswer:
                 Timeout in seconds.
 
         Returns:
-            The answer containing info useful for clients to display a notification at the top of the chat screen
-            or as an alert.
+            :obj:`BotCallbackAnswer <pyrogram.raw.base.messages.BotCallbackAnswer>`: The answer containing info
+            useful for clients to display a notification at the top of the chat screen or as an alert.
 
         Raises:
             TimeoutError: In case the bot fails to answer within 10 seconds.

--- a/pyrogram/methods/bots/request_callback_answer.py
+++ b/pyrogram/methods/bots/request_callback_answer.py
@@ -56,7 +56,7 @@ class RequestCallbackAnswer:
                 Timeout in seconds.
 
         Returns:
-            :obj:`BotCallbackAnswer <pyrogram.raw.base.messages.BotCallbackAnswer>`: The answer containing info
+            :obj:`~pyrogram.raw.base.messages.BotCallbackAnswer`: The answer containing info
             useful for clients to display a notification at the top of the chat screen or as an alert.
 
         Raises:

--- a/pyrogram/methods/business/get_business_account_gifts.py
+++ b/pyrogram/methods/business/get_business_account_gifts.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from typing import AsyncGenerator, Optional
 
 import pyrogram
 from pyrogram import raw, types
@@ -39,7 +39,7 @@ class GetBusinessAccountGifts:
         sort_by_price: Optional[bool] = None,
         limit: int = 0,
         offset: str = "",
-    ):
+    ) -> AsyncGenerator["types.Gift", None]:
         """Return the gifts received and owned by a managed business account.
 
         .. note::

--- a/pyrogram/methods/business/get_business_account_gifts.py
+++ b/pyrogram/methods/business/get_business_account_gifts.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import AsyncGenerator, Optional
+from typing import AsyncIterator, Optional
 
 import pyrogram
 from pyrogram import raw, types
@@ -39,7 +39,7 @@ class GetBusinessAccountGifts:
         sort_by_price: Optional[bool] = None,
         limit: int = 0,
         offset: str = "",
-    ) -> AsyncGenerator["types.Gift", None]:
+    ) -> AsyncIterator["types.Gift"]:
         """Return the gifts received and owned by a managed business account.
 
         .. note::

--- a/pyrogram/methods/business/get_business_connection.py
+++ b/pyrogram/methods/business/get_business_connection.py
@@ -24,7 +24,7 @@ class GetBusinessConnection:
     async def get_business_connection(
         self: "pyrogram.Client",
         business_connection_id: str
-    ):
+    ) -> "types.BusinessConnection":
         """Use this method to get information about the connection of the bot with a business account.
 
         .. include:: /_includes/usable-by/bots.rst

--- a/pyrogram/methods/contacts/add_contact.py
+++ b/pyrogram/methods/contacts/add_contact.py
@@ -31,7 +31,7 @@ class AddContact:
         phone_number: str = "",
         share_phone_number: bool = False,
         note: Optional[Union[str, "types.FormattedText"]] = None
-    ):
+    ) -> "types.User":
         """Add an existing Telegram user as contact, even without a phone number.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/contacts/import_contacts.py
+++ b/pyrogram/methods/contacts/import_contacts.py
@@ -37,7 +37,7 @@ class ImportContacts:
                 The contact list to be added
 
         Returns:
-            :obj:`ImportedContacts <pyrogram.raw.base.contacts.ImportedContacts>`: On success.
+            :obj:`~pyrogram.raw.base.contacts.ImportedContacts`: On success.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/contacts/import_contacts.py
+++ b/pyrogram/methods/contacts/import_contacts.py
@@ -27,7 +27,7 @@ class ImportContacts:
     async def import_contacts(
         self: "pyrogram.Client",
         contacts: List["types.InputPhoneContact"]
-    ):
+    ) -> "raw.base.contacts.ImportedContacts":
         """Import contacts to your Telegram address book.
 
         .. include:: /_includes/usable-by/users.rst
@@ -37,7 +37,7 @@ class ImportContacts:
                 The contact list to be added
 
         Returns:
-            :obj:`types.contacts.ImportedContacts`
+            :obj:`ImportedContacts <pyrogram.raw.base.contacts.ImportedContacts>`: On success.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/contacts/search_contacts.py
+++ b/pyrogram/methods/contacts/search_contacts.py
@@ -26,7 +26,7 @@ class SearchContacts:
         self: "pyrogram.Client",
         query: str,
         limit: int = 0
-    ):
+    ) -> "types.FoundContacts":
         """Returns users or channels found by name substring and auxiliary data.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/contacts/set_contact_note.py
+++ b/pyrogram/methods/contacts/set_contact_note.py
@@ -27,7 +27,7 @@ class SetContactNote:
         self: "pyrogram.Client",
         user_id: Union[int, str],
         note: Optional[Union[str, "types.FormattedText"]] = None,
-    ):
+    ) -> bool:
         """Changes a note of a contact user.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/invite_links/get_chat_admins_with_invite_links.py
+++ b/pyrogram/methods/invite_links/get_chat_admins_with_invite_links.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union
+from typing import List, Union
 
 import pyrogram
 from pyrogram import raw, types
@@ -26,7 +26,7 @@ class GetChatAdminsWithInviteLinks:
     async def get_chat_admins_with_invite_links(
         self: "pyrogram.Client",
         chat_id: Union[int, str],
-    ):
+    ) -> List["types.ChatAdminWithInviteLinks"]:
         """Get the list of the administrators that have exported invite links in a chat.
 
         You must be the owner of a chat for this to work.

--- a/pyrogram/methods/utilities/add_handler.py
+++ b/pyrogram/methods/utilities/add_handler.py
@@ -16,6 +16,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from typing import Tuple
+
 import pyrogram
 from pyrogram.handlers import StartHandler, StopHandler, ConnectHandler, DisconnectHandler
 from pyrogram.handlers.handler import Handler
@@ -26,7 +28,7 @@ class AddHandler:
         self: "pyrogram.Client",
         handler: "Handler",
         group: int = 0
-    ):
+    ) -> Tuple["Handler", int]:
         """Register an update handler.
 
         You can register multiple handlers, but at most one handler within a group will be used for a single update.

--- a/pyrogram/methods/utilities/export_session_string.py
+++ b/pyrogram/methods/utilities/export_session_string.py
@@ -22,7 +22,7 @@ import pyrogram
 class ExportSessionString:
     async def export_session_string(
         self: "pyrogram.Client"
-    ):
+    ) -> str:
         """Export the current authorized session as a serialized string.
 
         Session strings are useful for storing in-memory authorized sessions in a portable, serialized string.

--- a/pyrogram/methods/utilities/restart.py
+++ b/pyrogram/methods/utilities/restart.py
@@ -24,7 +24,7 @@ class Restart:
         self: "pyrogram.Client",
         block: bool = True,
         clear_handlers: bool = False
-    ):
+    ) -> "pyrogram.Client":
         """Restart the Client.
 
         This method will first call :meth:`~pyrogram.Client.stop` and then :meth:`~pyrogram.Client.start` in a row in

--- a/pyrogram/methods/utilities/start.py
+++ b/pyrogram/methods/utilities/start.py
@@ -31,7 +31,7 @@ class Start:
         self: "pyrogram.Client", *,
         use_qr: bool = False,
         except_ids: List[int] = [],
-    ):
+    ) -> "pyrogram.Client":
         """Start the client.
 
         This method connects the client to Telegram and, in case of new sessions, automatically manages the

--- a/pyrogram/methods/utilities/stop.py
+++ b/pyrogram/methods/utilities/stop.py
@@ -24,7 +24,7 @@ class Stop:
         self: "pyrogram.Client",
         block: bool = True,
         clear_handlers: bool = True
-    ):
+    ) -> "pyrogram.Client":
         """Stop the Client.
 
         This method disconnects the client from Telegram and stops the underlying tasks.

--- a/pyrogram/types/authorization/active_session.py
+++ b/pyrogram/types/authorization/active_session.py
@@ -156,7 +156,7 @@ class ActiveSession(Object):
             is_official_application=getattr(session, "official_app", None)
         )
 
-    async def reset(self):
+    async def reset(self) -> bool:
         """Bound method *reset* of :obj:`~pyrogram.types.ActiveSession`.
 
         Use as a shortcut for:

--- a/pyrogram/types/bots_and_keyboards/pre_checkout_query.py
+++ b/pyrogram/types/bots_and_keyboards/pre_checkout_query.py
@@ -103,7 +103,7 @@ class PreCheckoutQuery(Object, Update):
             client=client
         )
 
-    async def answer(self, ok: Optional[bool] = None, error_message: Optional[str] = None):
+    async def answer(self, ok: Optional[bool] = None, error_message: Optional[str] = None) -> bool:
         """Bound method *answer* of :obj:`~pyrogram.types.PreCheckoutQuery`.
 
         Use this method as a shortcut for:

--- a/pyrogram/types/bots_and_keyboards/shipping_query.py
+++ b/pyrogram/types/bots_and_keyboards/shipping_query.py
@@ -83,7 +83,7 @@ class ShippingQuery(Object, Update):
         ok: bool,
         shipping_options: Optional["types.ShippingOptions"] = None,
         error_message: Optional[str] = None
-    ):
+    ) -> bool:
         """Bound method *answer* of :obj:`~pyrogram.types.ShippingQuery`.
 
         Use this method as a shortcut for:

--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -8651,7 +8651,7 @@ class Message(Object, Update):
             paid_message_star_count=paid_message_star_count,
         )
 
-    async def delete(self, revoke: bool = True):
+    async def delete(self, revoke: bool = True) -> bool:
         """Shortcut for method :obj:`~pyrogram.Client.delete_messages` and :obj:`~pyrogram.Client.delete_ephemeral_message` will automatically fill method attributes:
 
         * chat_id
@@ -8694,7 +8694,7 @@ class Message(Object, Update):
         quote: Optional[bool] = None,
         timeout: int = 10,
         password: Optional[str] = None
-    ):
+    ) -> Optional[Union[str, "types.Chat", "raw.base.messages.BotCallbackAnswer"]]:
         """Bound method *click* of :obj:`~pyrogram.types.Message`.
 
         Use as a shortcut for clicking a button attached to the message instead of:
@@ -8756,7 +8756,8 @@ class Message(Object, Update):
 
         Returns:
             -   The result of :meth:`~pyrogram.Client.request_callback_answer` in case of inline callback button clicks.
-            -   The result of :meth:`~Message.reply()` or :meth:`~Message.answer()` in case of normal button clicks.
+            -   ``None`` in case of normal button clicks: the label is sent with :meth:`~Message.reply()` or
+                :meth:`~Message.answer()`, whose result is not passed on.
             -   A string in case the inline button is a URL, a *switch_inline_query*,
                 *switch_inline_query_current_chat* or a *copy_text* button.
             -   A string URL with the user details, in case of a WebApp button.

--- a/pyrogram/types/messages_and_media/story.py
+++ b/pyrogram/types/messages_and_media/story.py
@@ -1789,7 +1789,7 @@ class Story(Object, Update):
             disallowed_users=disallowed_users
         )
 
-    async def delete(self):
+    async def delete(self) -> List[int]:
         """Bound method *delete* of :obj:`~pyrogram.types.Story`.
 
         Use as a shortcut for:
@@ -1806,7 +1806,7 @@ class Story(Object, Update):
                 await story.delete()
 
         Returns:
-            True on success, False otherwise.
+            List of ``int``: On success, the list of deleted story identifiers is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.

--- a/pyrogram/types/user_and_chats/chat.py
+++ b/pyrogram/types/user_and_chats/chat.py
@@ -1481,7 +1481,7 @@ class Chat(Object):
     def full_name(self) -> Optional[str]:
         return " ".join(filter(None, [self.first_name, self.last_name])) or self.title or None
 
-    async def archive(self):
+    async def archive(self) -> bool:
         """Bound method *archive* of :obj:`~pyrogram.types.Chat`.
 
         Use as a shortcut for:
@@ -1503,7 +1503,7 @@ class Chat(Object):
         """
         return await self._client.archive_chats(self.id)
 
-    async def unarchive(self):
+    async def unarchive(self) -> bool:
         """Bound method *unarchive* of :obj:`~pyrogram.types.Chat`.
 
         Use as a shortcut for:
@@ -1840,7 +1840,7 @@ class Chat(Object):
             chat_id=self.id, user_id=user_id, privileges=privileges
         )
 
-    async def join(self):
+    async def join(self) -> "types.ChatJoinResult":
         """Bound method *join* of :obj:`~pyrogram.types.Chat`.
 
         Use as a shortcut for:
@@ -1859,7 +1859,7 @@ class Chat(Object):
             This only works for public groups, channels that have set a username or linked chats.
 
         Returns:
-            :obj:`~pyrogram.types.Chat`: On success, a chat object is returned.
+            :obj:`~pyrogram.types.ChatJoinResult`: On success, the outcome of the join is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -1885,7 +1885,7 @@ class Chat(Object):
         """
         return await self._client.leave_chat(self.id)
 
-    async def export_invite_link(self):
+    async def export_invite_link(self) -> "types.ChatInviteLink":
         """Bound method *export_invite_link* of :obj:`~pyrogram.types.Chat`.
 
         Use as a shortcut for:
@@ -1900,7 +1900,7 @@ class Chat(Object):
                 chat.export_invite_link()
 
         Returns:
-            ``str``: On success, the exported invite link is returned.
+            :obj:`~pyrogram.types.ChatInviteLink`: On success, the exported invite link is returned.
 
         Raises:
             ValueError: In case the chat_id belongs to a user.

--- a/pyrogram/types/user_and_chats/folder.py
+++ b/pyrogram/types/user_and_chats/folder.py
@@ -390,7 +390,7 @@ class Folder(Object):
             excluded_chats=[i.id for i in self.excluded_chats or []] + [chat_id],
         )
 
-    async def pin_chat(self, chat_id: Union[int, str]):
+    async def pin_chat(self, chat_id: Union[int, str]) -> bool:
         """Bound method *pin_chat* of :obj:`~pyrogram.types.Folder`.
 
         Use as a shortcut for:
@@ -422,7 +422,7 @@ class Folder(Object):
             pinned_chats=[i.id for i in self.pinned_chats or []] + [chat_id]
         )
 
-    async def remove_chat(self, chat_id: Union[int, str]):
+    async def remove_chat(self, chat_id: Union[int, str]) -> bool:
         """Bound method *remove_chat* of :obj:`~pyrogram.types.Folder`.
 
         Remove chat in folder from included/excluded/pinned chats.
@@ -451,7 +451,7 @@ class Folder(Object):
         )
 
 
-    async def update_color(self, color: "enums.FolderColor"):
+    async def update_color(self, color: "enums.FolderColor") -> bool:
         """Bound method *update_color* of :obj:`~pyrogram.types.Folder`.
 
         Use as a shortcut for:

--- a/pyrogram/types/user_and_chats/user.py
+++ b/pyrogram/types/user_and_chats/user.py
@@ -922,7 +922,7 @@ class User(Object, Update):
             client=client,
         )
 
-    async def archive(self):
+    async def archive(self) -> bool:
         """Bound method *archive* of :obj:`~pyrogram.types.User`.
 
         Use as a shortcut for:
@@ -945,7 +945,7 @@ class User(Object, Update):
 
         return await self._client.archive_chats(self.id)
 
-    async def unarchive(self):
+    async def unarchive(self) -> bool:
         """Bound method *unarchive* of :obj:`~pyrogram.types.User`.
 
         Use as a shortcut for:
@@ -968,7 +968,7 @@ class User(Object, Update):
 
         return await self._client.unarchive_chats(self.id)
 
-    async def block(self):
+    async def block(self) -> bool:
         """Bound method *block* of :obj:`~pyrogram.types.User`.
 
         Use as a shortcut for:
@@ -991,7 +991,7 @@ class User(Object, Update):
 
         return await self._client.block_user(self.id)
 
-    async def unblock(self):
+    async def unblock(self) -> bool:
         """Bound method *unblock* of :obj:`~pyrogram.types.User`.
 
         Use as a shortcut for:
@@ -1014,7 +1014,7 @@ class User(Object, Update):
 
         return await self._client.unblock_user(self.id)
 
-    async def get_common_chats(self):
+    async def get_common_chats(self) -> List["types.Chat"]:
         """Bound method *get_common_chats* of :obj:`~pyrogram.types.User`.
 
         Use as a shortcut for:


### PR DESCRIPTION
## What

45 public methods describe what they give back in a `Returns:` block and carry no return
annotation. This annotates them, so the docstring and the signature say the same thing.

Five of those docstrings turned out to describe something the body does not return. The
annotation follows the code and the docstring is corrected, not the other way round:

| method | `Returns:` said | body gives |
| --- | --- | --- |
| `Chat.join()` | `Chat` | `ChatJoinResult` |
| `Chat.export_invite_link()` | `str` | `ChatInviteLink` |
| `Story.delete()` | `True` on success | `List[int]`, the deleted ids |
| `import_contacts()` | `types.contacts.ImportedContacts` | `raw.base.contacts.ImportedContacts` — the `types.` path does not exist |
| `get_inline_bot_results()` | `pyrogram.api.types.messages.BotResults` | same type, but the `pyrogram.api` path has not existed since Pyrogram 1.0 |

`Message.click()` is the one with a real union: `str` for a URL, switch-query or copy-text
button, `Chat` for a user-profile button, `raw.base.messages.BotCallbackAnswer` for a callback
button, and `None` for every non-inline button, where the label is sent with `reply()` and the
sent message is dropped. Its `Returns:` block claimed that last one comes back.

## Why

The package ships `py.typed`, so an unannotated method is `Any` at every call site under a type
checker, and the information needed to fill it in is already sitting in the docstring right
below the signature. Where the two had drifted, the docstring is what a reader trusts and it was
wrong in five places.

No behaviour changes: this is annotations and five documentation lines.

## How to test

`make test-unit` — `360 passed, 7 deselected`, unchanged, since nothing runs differently.
`make lint` — `All checks passed!`.

The count is checkable: walking `pyrogram/` outside `raw/` and `errors/` for public methods whose
docstring has a `Returns:` block and whose signature has no return annotation gives 45 before and
none after.
