### PR TITLE
fix(users): give `None` back from `get_users()` when the id belongs to no user

### DIFF
--- a/pyrogram/methods/users/get_users.py
+++ b/pyrogram/methods/users/get_users.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import asyncio
-from typing import Union, List, Iterable, overload
+from typing import Optional, Union, List, Iterable, overload
 
 import pyrogram
 from pyrogram import raw
@@ -31,7 +31,7 @@ class GetUsers:
     async def get_users(  # type: ignore[overload-overlap]
         self: "pyrogram.Client",
         user_ids: Union[int, str]
-    ) -> "types.User": ...
+    ) -> Optional["types.User"]: ...
 
     @overload
     async def get_users(
@@ -42,7 +42,7 @@ class GetUsers:
     async def get_users(
         self: "pyrogram.Client",
         user_ids: Union[int, str, Iterable[Union[int, str]]]
-    ) -> Union["types.User", List["types.User"]]:
+    ) -> Optional[Union["types.User", List["types.User"]]]:
         """Get information about a user.
         You can retrieve up to 200 users at once.
 
@@ -54,8 +54,10 @@ class GetUsers:
                 For a contact that exists in your Telegram address book you can use his phone number (str).
 
         Returns:
-            :obj:`~pyrogram.types.User` | List of :obj:`~pyrogram.types.User`: In case *user_ids* was not a list,
-            a single user is returned, otherwise a list of users is returned.
+            :obj:`~pyrogram.types.User` | List of :obj:`~pyrogram.types.User` | ``None``: In case *user_ids* was not a
+            list, a single user is returned, otherwise a list of users is returned. Telegram answers with an empty
+            list for an identifier that belongs to no user — a channel, a chat, or a peer this account cannot see —
+            in which case None is returned for a single identifier and the missing users are absent from the list.
 
         Example:
             .. code-block:: python
@@ -82,4 +84,4 @@ class GetUsers:
         for i in r:
             users.append(await types.User._parse(self, i))
 
-        return users if is_iterable else users[0]
+        return users if is_iterable else users[0] if users else None

--- a/tests/unit/methods/test_get_users.py
+++ b/tests/unit/methods/test_get_users.py
@@ -1,0 +1,85 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from typing import List, Union
+
+import pytest
+
+from pyrogram import raw
+from pyrogram.methods.users.get_users import GetUsers
+
+
+class Answerer(GetUsers):
+    """A client that answers `users.GetUsers` with a fixed vector and resolves any peer."""
+
+    def __init__(self, answer: List["raw.base.User"]) -> None:
+        self.answer = answer
+
+    async def resolve_peer(self, peer_id: Union[int, str]) -> "raw.types.InputUser":
+        return raw.types.InputUser(user_id=1, access_hash=0)
+
+    async def invoke(self, query: "raw.core.TLObject") -> List["raw.base.User"]:
+        return self.answer
+
+
+def a_user(user_id: int) -> "raw.types.User":
+    # `usernames` and `restriction_reason` are `flags.N?Vector<...>`, and the generated `read()`
+    #  gives an absent vector back as `[]`. `User._parse()` iterates both without guarding, so a
+    #  hand-built `raw.types.User` has to spell out what the wire implies.
+    return raw.types.User(
+        id=user_id,
+        first_name=f"User {user_id}",
+        usernames=[],
+        restriction_reason=[]
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_single_identifier_that_is_no_user_gives_nothing_back() -> None:
+    # Telegram answers with an empty vector for an id that belongs to a channel, a chat or a
+    #  peer this account cannot see. Indexing into it raised `IndexError` out of the method body.
+    assert await Answerer([]).get_users("a_channel_username") is None
+
+
+@pytest.mark.asyncio
+async def test_a_single_identifier_still_gives_its_user_back() -> None:
+    user = await Answerer([a_user(42)]).get_users(42)
+
+    assert user.id == 42
+
+
+@pytest.mark.asyncio
+async def test_a_list_of_identifiers_that_are_no_users_gives_an_empty_list() -> None:
+    users = await Answerer([]).get_users(["a_channel_username"])
+
+    assert users == []
+
+
+@pytest.mark.asyncio
+async def test_a_list_keeps_only_the_users_telegram_answered_with() -> None:
+    users = await Answerer([a_user(1), a_user(2)]).get_users([1, 2, 3])
+
+    assert [user.id for user in users] == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_a_deleted_account_arrives_as_nothing() -> None:
+    # `userEmpty` is what the server sends for an account that no longer exists; `User._parse()`
+    #  turns it into `None`, and that is what the single-identifier path has always returned.
+    assert await Answerer([raw.types.UserEmpty(id=42)]).get_users(42) is None


### PR DESCRIPTION
## What

`users.GetUsers` answers with an empty vector for an identifier that belongs to no user — a
channel username, an account that was deleted, a peer this account cannot see. `get_users()`
indexed into that answer without looking:

```python
await app.get_users("telegram")
# IndexError: list index out of range
```

The single-identifier path now gives `None` back instead, which is what the rest of the library
already does — `get_messages()`, `forward_messages()`, `get_stories()` and
`get_direct_messages_topics_by_id()` all end in `x[0] if x else None`. The overloads and the
`Returns:` block say so.

```python
-return users if is_iterable else users[0]
+return users if is_iterable else users[0] if users else None
```

The iterable path is unchanged: it still gives back a list, with the missing users simply absent.

## Why

`IndexError` out of the method body is the one outcome neither the docstring nor the
`-> types.User` annotation admits, and it carries nothing a caller can act on — no id, no
mention of which of the two hundred identifiers was the problem. A caller that wants to know
whether a username belongs to a user has to wrap the call in `try`/`except IndexError` and hope
no genuine indexing bug is hiding underneath.

This is a behaviour change: code that catches `IndexError` today gets `None` after this. Nothing
in the library relies on the old behaviour.

## How to test

`make test-unit` — `426 passed, 7 deselected`. The five new ones are
`tests/unit/methods/test_get_users.py`, driving the method with a client that answers with a
fixed vector: an empty answer to a single identifier, a normal answer, an empty answer to a
list, a list that comes back shorter than it went out, and `userEmpty` for a deleted account.

To see them bite, put the old line back:

```
E       IndexError: list index out of range
pyrogram/methods/users/get_users.py:87: IndexError
FAILED tests/unit/methods/test_get_users.py::test_a_single_identifier_that_is_no_user_gives_nothing_back
1 failed, 4 passed
```

`make lint` — `All checks passed!`.
