### PR TITLE
fix(invite_links): stop `get_chat_admins_with_invite_links()` handing `types.List` an async generator

### DIFF
--- a/pyrogram/methods/invite_links/get_chat_admins_with_invite_links.py
+++ b/pyrogram/methods/invite_links/get_chat_admins_with_invite_links.py
@@ -51,6 +51,8 @@ class GetChatAdminsWithInviteLinks:
         users = {i.id: i for i in r.users}
 
         return types.List(
-            await types.ChatAdminWithInviteLinks._parse(self, admin, users)
-            for admin in r.admins
+            [
+                await types.ChatAdminWithInviteLinks._parse(self, admin, users)
+                for admin in r.admins
+            ]
         )

--- a/tests/unit/methods/invite_links/__init__.py
+++ b/tests/unit/methods/invite_links/__init__.py
@@ -1,0 +1,18 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+

--- a/tests/unit/methods/invite_links/test_get_chat_admins_with_invite_links.py
+++ b/tests/unit/methods/invite_links/test_get_chat_admins_with_invite_links.py
@@ -1,0 +1,84 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Final, List
+
+import pytest
+
+from pyrogram import raw, types
+from pyrogram.methods.invite_links.get_chat_admins_with_invite_links import (
+    GetChatAdminsWithInviteLinks,
+)
+
+_CHAT_ID: Final[int] = -1001234567890
+
+
+class Client(GetChatAdminsWithInviteLinks):
+    """A client that answers `messages.GetAdminsWithInvites` with the admins it was given."""
+
+    def __init__(self, admins: List[raw.types.ChatAdminWithInvites]) -> None:
+        self.admins = admins
+
+    async def resolve_peer(self, peer_id: int) -> raw.types.InputPeerChannel:
+        return raw.types.InputPeerChannel(channel_id=abs(peer_id), access_hash=0)
+
+    async def invoke(
+        self, query: raw.functions.messages.GetAdminsWithInvites
+    ) -> raw.types.messages.ChatAdminsWithInvites:
+        return raw.types.messages.ChatAdminsWithInvites(
+            admins=self.admins,
+            users=[
+                raw.types.User(
+                    id=admin.admin_id,
+                    first_name=f"Admin {admin.admin_id}",
+                    usernames=[],
+                    restriction_reason=[],
+                )
+                for admin in self.admins
+            ],
+        )
+
+
+@pytest.mark.asyncio
+async def test_every_admin_is_parsed() -> None:
+    # The call used to hand `types.List` a generator expression, and PEP 530 makes one
+    #  holding an `await` an async generator: `list()` refused it with
+    #  `TypeError: 'async_generator' object is not iterable`, so the method never returned.
+    client = Client(
+        [
+            raw.types.ChatAdminWithInvites(
+                admin_id=7, invites_count=3, revoked_invites_count=1
+            ),
+            raw.types.ChatAdminWithInvites(
+                admin_id=8, invites_count=0, revoked_invites_count=0
+            ),
+        ]
+    )
+
+    admins = await client.get_chat_admins_with_invite_links(_CHAT_ID)
+
+    assert isinstance(admins, types.List)
+    assert [admin.admin.id for admin in admins] == [7, 8]
+    assert [admin.chat_invite_links_count for admin in admins] == [3, 0]
+
+
+@pytest.mark.asyncio
+async def test_a_chat_with_no_such_admin_answers_with_an_empty_list() -> None:
+    admins = await Client([]).get_chat_admins_with_invite_links(_CHAT_ID)
+
+    assert admins == []


### PR DESCRIPTION
## What

`get_chat_admins_with_invite_links()` raises on every call:

```
TypeError: 'async_generator' object is not iterable
```

It builds its result as `types.List(<generator expression>)`, and that expression holds an
`await`. PEP 530 makes any comprehension or generator expression containing an `await` an
asynchronous one, so what reaches the constructor is an `async_generator` — and `types.List`
subclasses `list`, whose constructor takes a synchronous iterable. The call therefore fails
before it can return anything: there is no input for which the method succeeds.

https://peps.python.org/pep-0530/

The fix is the brackets. A list comprehension is allowed to contain `await` inside an
`async def` and awaits each element as it builds, which is what every sibling that parses a
vector this way already does — `get_privacy()` and `set_privacy()` are the nearest two.

## Why

Checked against a supergroup where the account is the owner, before and after, same session:

```
before:  raw call OK: 3 admin(s), 3 user(s)
         wrapper raised: TypeError: 'async_generator' object is not iterable

after:   raw call OK: 3 admin(s), 3 user(s)
         wrapper returned: List with 3 item(s)
```

The raw `messages.GetAdminsWithInvites` underneath succeeds either way, so this is not a
permissions or a peer-resolution problem — the wrapper is the whole of it.

Walking the hand-written tree for generator expressions containing an `await` finds this one
site and nothing else, so no other method needs the same change.

## How to test

`tests/unit/methods/invite_links/test_get_chat_admins_with_invite_links.py` covers the parse
path with a client that answers `messages.GetAdminsWithInvites` from a fixed list: one case
with two admins, one with a chat that has none. Both fail against the previous body.

`make test-unit` — `423 passed, 7 deselected`.
`make lint` — `All checks passed!`.
