### PR TITLE
chore(comments): drop the `NOTE:` prefix and the dashes standing in for punctuation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
-# The rule set and the excludes live in `pyproject.toml`, and this hook runs `make lint` —
-#  the same recipe the `lint` job runs — so the two cannot drift apart.
+# The rule set and the excludes live in `pyproject.toml`, and this hook runs `make lint`,
+#  the same recipe the `lint` job runs, so the two cannot drift apart.
 repos:
   - repo: local
     hooks:

--- a/pyrogram/errors/rpc_error.py
+++ b/pyrogram/errors/rpc_error.py
@@ -34,7 +34,7 @@ STRING_PARAMETER_PREFIXES: Final[Tuple[str, ...]] = (
 PARAMETER: Final[Pattern[str]] = re.compile(r"_(\d+)")
 
 # Canonical: `compiler/errors/compiler.py`, which writes one row per code keyed `"_"`, holding the
-# name of the category class that code's errors subclass — `BadRequest` for 400, `Forbidden` for
+# name of the category class that code's errors subclass: `BadRequest` for 400, `Forbidden` for
 # 403. It is what an error whose message is not in the table falls back to.
 CATEGORY: Final[str] = "_"
 

--- a/pyrogram/file_id.py
+++ b/pyrogram/file_id.py
@@ -151,16 +151,16 @@ class ThumbnailSource(IntEnum):
     STICKER_SET_THUMBNAIL_VERSION = 9
 
 
-# NOTE: TDLib's `Version::RemovePhotoVolumeAndLocalId` — the minor version from which photo file ids
-#       carry neither `volume_id` nor `local_id`, the sources that still need them having become
-#       values 5 to 9 above. Reading a current file id against the older layout takes the source tag
-#       for `volume_id` and part of the tail for the source:
+# TDLib's `Version::RemovePhotoVolumeAndLocalId`, the minor version from which photo file ids
+#  carry neither `volume_id` nor `local_id`, the sources that still need them having become
+#  values 5 to 9 above. Reading a current file id against the older layout takes the source tag
+#  for `volume_id` and part of the tail for the source:
 #
-#         FileId.decode("AgACAgIAAxkBAAIENGfeY4AfRquwTL2LpDrzqvFMVNt_AAIG9DEbXX3wSq3o"
-#                       "I7t_PqQGAQADAgADbQADNgQ")
-#         # -> ValueError: Unknown thumbnail_source 109 of file_id AgACAgI...
+#    FileId.decode("AgACAgIAAxkBAAIENGfeY4AfRquwTL2LpDrzqvFMVNt_AAIG9DEbXX3wSq3o"
+#                  "I7t_PqQGAQADAgADbQADNgQ")
+#    # -> ValueError: Unknown thumbnail_source 109 of file_id AgACAgI...
 #
-#       https://github.com/tdlib/td/blob/master/td/telegram/files/FileLocation.hpp
+#  https://github.com/tdlib/td/blob/master/td/telegram/files/FileLocation.hpp
 NO_VOLUME_AND_LOCAL_ID_MINOR: Final[int] = 32
 
 
@@ -203,14 +203,14 @@ def read_photo_tail(buffer: BytesIO, *, thumbnail_source: ThumbnailSource) -> Ph
 
         return PhotoTail(secret=secret)
 
-    # NOTE: `thumbnail_size` is the `type` of the `PhotoSize` the file id points at — one letter,
-    #       whose character code the file id stores as an int32 while
-    #       `inputPhotoFileLocation.thumb_size` takes a `string`. It is a `str` from here on:
-    #       `chr()` in, `ord()` back out in `write_photo_tail()`, `get_file()` passes it through.
+    # `thumbnail_size` is the `type` of the `PhotoSize` the file id points at: one letter,
+    #  whose character code the file id stores as an int32 while
+    #  `inputPhotoFileLocation.thumb_size` takes a `string`. It is a `str` from here on:
+    #  `chr()` in, `ord()` back out in `write_photo_tail()`, `get_file()` passes it through.
     #
-    #       What the letters mean: https://core.telegram.org/api/files#image-thumbnail-types, and
-    #       the same table with the order Telegram Desktop picks them in:
-    #       https://github.com/telegramdesktop/tdesktop/blob/8e18cb71103d83d7d98994ff27f0a2bca55c489c/Telegram/SourceFiles/data/data_session.cpp#L102-L114
+    #  What the letters mean: https://core.telegram.org/api/files#image-thumbnail-types, and
+    #  the same table with the order Telegram Desktop picks them in:
+    #  https://github.com/telegramdesktop/tdesktop/blob/8e18cb71103d83d7d98994ff27f0a2bca55c489c/Telegram/SourceFiles/data/data_session.cpp#L102-L114
     if thumbnail_source == ThumbnailSource.THUMBNAIL:
         thumbnail_file_type, thumbnail_size = struct.unpack("<ii", buffer.read(8))
 
@@ -226,8 +226,8 @@ def read_photo_tail(buffer: BytesIO, *, thumbnail_source: ThumbnailSource) -> Ph
 
         return PhotoTail(sticker_set_id=sticker_set_id, sticker_set_access_hash=sticker_set_access_hash)
 
-    # NOTE: `secret` sits between the other two, where `inputPhotoLegacyFileLocation` lists them as
-    #       `volume_id local_id secret`. The file id follows `FullLegacy::store`, not the schema.
+    # `secret` sits between the other two, where `inputPhotoLegacyFileLocation` lists them as
+    #  `volume_id local_id secret`. The file id follows `FullLegacy::store`, not the schema.
     if thumbnail_source == ThumbnailSource.FULL_LEGACY:
         volume_id, secret, local_id = struct.unpack("<qqi", buffer.read(20))
 
@@ -267,7 +267,7 @@ def read_photo_tail(buffer: BytesIO, *, thumbnail_source: ThumbnailSource) -> Ph
 
 
 def write_photo_tail(file_id: "FileId") -> bytes:
-    """The counterpart of `read_photo_tail()` — same layout per source, same order."""
+    """The counterpart of `read_photo_tail()`: same layout per source, same order."""
     if file_id.thumbnail_source == ThumbnailSource.LEGACY:
         return struct.pack("<q", file_id.secret)
 

--- a/pyrogram/filters.py
+++ b/pyrogram/filters.py
@@ -147,9 +147,9 @@ _SELF = "self"
 _ME_ALIASES = frozenset({_ME, _SELF})
 
 
-# NOTE: `Update` declares none of these -- an inline query happens in no chat, a poll update
-#       has no sender -- so each field names the types that carry it. Kept in sync by
-#       `test_the_filters_name_every_update_type_that_carries_the_field`.
+# `Update` declares none of these (an inline query happens in no chat, a poll update
+#  has no sender), so each field names the types that carry it. Kept in sync by
+#  `test_the_filters_name_every_update_type_that_carries_the_field`.
 _WITH_A_SENDER = (
     CallbackQuery,
     ChatJoinRequest,
@@ -195,10 +195,10 @@ def _is_outgoing(update: Update) -> bool:
     return bool(update.outgoing) if isinstance(update, _CAN_BE_OUTGOING) else False
 
 
-# NOTE: `business_connection_id`, `forward_origin` and `topic` live on `Message` alone, so the
-#       filters that read them cannot take the field off the update the way the ones above do.
-#       They go through the message the update is about instead, which is the same message the
-#       user is looking at when a button under it is pressed.
+# `business_connection_id`, `forward_origin` and `topic` live on `Message` alone, so the
+#  filters that read them cannot take the field off the update the way the ones above do.
+#  They go through the message the update is about instead, which is the same message the
+#  user is looking at when a button under it is pressed.
 _WITH_A_MESSAGE = (CallbackQuery,)
 
 
@@ -1269,8 +1269,8 @@ class chat(Filter, set):
             return True
         sender = _sender_of(update)
 
-        # NOTE: Saved Messages is the chat whose id is your own user id.
-        #       `is_self` on its own is true of anything you caused, in any chat.
+        # Saved Messages is the chat whose id is your own user id.
+        #  `is_self` on its own is true of anything you caused, in any chat.
         return bool(
             not self.isdisjoint(_ME_ALIASES)
             and sender

--- a/pyrogram/methods/advanced/save_file.py
+++ b/pyrogram/methods/advanced/save_file.py
@@ -113,8 +113,8 @@ class SaveFile:
                         await session.invoke(data)
                     except Exception as e:
                         # The failure is remembered rather than raised, because a worker that stops
-                        #  consuming leaves the producer below blocked forever on `queue.put()` — the
-                        #  queue holds one item. It is raised at the end, once every worker has drained.
+                        #  consuming leaves the producer below blocked forever on `queue.put()`, since
+                        #  the queue holds one item. It is raised at the end, once every worker has drained.
                         log.exception(e)
                         failures.append(e)
 

--- a/pyrogram/methods/chats/get_direct_messages_topics_by_id.py
+++ b/pyrogram/methods/chats/get_direct_messages_topics_by_id.py
@@ -89,8 +89,8 @@ class GetDirectMessagesTopicsByID:
         for i in r.dialogs:
             topics.append(await types.DirectMessagesTopic._parse(client=self, topic=i, users=users, chats=chats))
 
-        # NOTE: A topic exists only once its peer has written to the chat, and asking for a peer
-        #       without one answers with an empty `dialogs` vector rather than an error:
+        # A topic exists only once its peer has written to the chat, and asking for a peer
+        #  without one answers with an empty `dialogs` vector rather than an error:
         #
-        #       await app.get_direct_messages_topics_by_id(chat_id, user_id)  # -> None
+        #  await app.get_direct_messages_topics_by_id(chat_id, user_id)  # -> None
         return topics if is_iterable else topics[0] if topics else None

--- a/pyrogram/methods/users/get_users.py
+++ b/pyrogram/methods/users/get_users.py
@@ -25,8 +25,8 @@ from pyrogram import types
 
 
 class GetUsers:
-    # NOTE: `str` is itself an iterable of `str`, so a username matches both overloads.
-    #       The single-user one comes first, resolving it the way the body does.
+    # `str` is itself an iterable of `str`, so a username matches both overloads.
+    #  The single-user one comes first, resolving it the way the body does.
     @overload
     async def get_users(  # type: ignore[overload-overlap]
         self: "pyrogram.Client",
@@ -56,7 +56,7 @@ class GetUsers:
         Returns:
             :obj:`~pyrogram.types.User` | List of :obj:`~pyrogram.types.User` | ``None``: In case *user_ids* was not a
             list, a single user is returned, otherwise a list of users is returned. Telegram answers with an empty
-            list for an identifier that belongs to no user — a channel, a chat, or a peer this account cannot see —
+            list for an identifier that belongs to no user (a channel, a chat, or a peer this account cannot see),
             in which case None is returned for a single identifier and the missing users are absent from the list.
 
         Example:

--- a/tests/unit/errors/test_rpc_error.py
+++ b/tests/unit/errors/test_rpc_error.py
@@ -217,7 +217,7 @@ def test_the_base_class_renders_the_value_on_its_own() -> None:
         # https://github.com/tdlib/td/blob/022d60202e446ad1287b9fb68e687c8a0760788b/td/telegram/net/NetQueryDispatcher.cpp#L73-L82
         #
         # The reCAPTCHA one carries an action with an underscore of its own, and TDLib splits it
-        # off at the *last* `__` — its loop keeps overwriting rather than breaking, so `AB_CD` is
+        # off at the *last* `__`, its loop overwriting rather than breaking, so `AB_CD` is
         # the action and `KEY` the site key id:
         # https://github.com/tdlib/td/blob/022d60202e446ad1287b9fb68e687c8a0760788b/td/telegram/net/NetQueryDispatcher.cpp#L124-L130
         #

--- a/tests/unit/filters/test_update_attributes.py
+++ b/tests/unit/filters/test_update_attributes.py
@@ -161,7 +161,7 @@ async def test_message_filters_are_unchanged():
 async def test_chat_me_is_saved_messages_and_nothing_else():
     """`filters.chat("me")` means the chat whose id is your own user id.
 
-    It used to test the sender instead — `is_self and not outgoing` — which is
+    It used to test the sender instead (`is_self and not outgoing`), which is
     also true of an update you caused in a chat that is not Saved Messages.
     """
     assert await filters.chat("me")(CLIENT, Message(id=1, chat=SAVED_MESSAGES, from_user=MYSELF))
@@ -198,7 +198,7 @@ UPDATE_TYPES = [
 
 
 def carries(update_type, field: str) -> bool:
-    """Whether `update_type` answers `field` -- as an `__init__` argument or as a property.
+    """Whether `update_type` answers `field`, as an `__init__` argument or as a property.
 
     The property is looked up in the class dictionaries along the MRO rather than read off
     the class, so it is found as the descriptor it is instead of being evaluated.
@@ -302,7 +302,7 @@ def test_callback_query_chat_stays_out_of_the_serialized_form():
     """`chat` is derived, so it must not show up next to `message` in the output.
 
     `Object.default()` and `Object.__repr__()` walk `__dict__`, and `bind()`
-    documents `eval(repr(obj))` as supported — an attribute here would repeat the
+    documents `eval(repr(obj))` as supported, so an attribute here would repeat the
     whole chat in the JSON and feed `__init__` a keyword it does not take.
     """
     query = in_private(CallbackQuery, from_user=SOMEONE)

--- a/tests/unit/methods/test_save_file.py
+++ b/tests/unit/methods/test_save_file.py
@@ -97,7 +97,7 @@ async def test_a_finished_upload_describes_every_part(three_parts: str) -> None:
 async def test_a_part_the_server_refused_reaches_the_caller(three_parts: str) -> None:
     # The failure used to be logged inside the worker and nowhere else: `save_file()` handed back
     #  an `InputFile` for a file the server never received in full, and the send that followed
-    #  failed with an unrelated error — or, for a caller that stored the id, much later.
+    #  failed with an unrelated error (much later still, for a caller that stored the id).
     media = Media(rejects_part=1)
 
     with pytest.raises(ConnectionError):
@@ -111,7 +111,7 @@ async def test_the_parts_around_the_refused_one_are_still_sent(three_parts: str)
     with pytest.raises(ConnectionError):
         await Uploader(media).save_file(three_parts)
 
-    # The upload is not aborted mid-way — a worker that stops consuming leaves the producer
+    # The upload is not aborted mid-way: a worker that stops consuming leaves the producer
     #  blocked on a queue of size one, so every part is offered and only the answer is remembered.
     assert media.saved_parts == [0, 2]
 

--- a/tests/unit/raw/test_optional_vector.py
+++ b/tests/unit/raw/test_optional_vector.py
@@ -27,8 +27,8 @@ from pyrogram.raw.core import TLObject, Vector
 
 BLOCK = raw.types.PageBlockParagraph(text=raw.types.TextPlain(text="hi"))
 PHOTO = raw.types.InputPhoto(id=1, access_hash=2, file_reference=b"")
-# NOTE: `read()` gives a `flags.N?true` field `False`, never `None`, so the two `true` flags are
-#       spelled out here — otherwise the objects compare unequal for a reason this file is not about.
+# `read()` gives a `flags.N?true` field `False`, never `None`, so the two `true` flags are
+#  spelled out here, since otherwise the objects compare unequal for a reason this file is not about.
 USERNAME = raw.types.Username(username="name", editable=False, active=True)
 
 # One case per sub-type the generator branches on, plus a function and a class whose vector

--- a/tests/unit/test_file_id.py
+++ b/tests/unit/test_file_id.py
@@ -229,7 +229,7 @@ def test_photo_from_a_current_client():
     Twelve bytes trail `access_hash`: `01000000 02000000 6d000000`. Read against the pre-32 layout
     the first eight become `volume_id` and `6d000000` becomes the source, hence the reported
     `ValueError: Unknown thumbnail_source 109`. Read against the current one they are the source,
-    the thumbnail's own file type, and `chr(109)` — the size letter `m`.
+    the thumbnail's own file type, and `chr(109)`, the size letter `m`.
     """
     photo = "AgACAgIAAxkBAAIENGfeY4AfRquwTL2LpDrzqvFMVNt_AAIG9DEbXX3wSq3oI7t_PqQGAQADAgADbQADNgQ"
 


### PR DESCRIPTION

## What

Comments and docstrings only. No behaviour, no signatures, no names.

- Nine comments that opened with `NOTE:` now open with the sentence itself. Their
  continuation lines move from the hanging indent under the old tag to one space
  under the `#`.
- Thirteen places where a long dash or a `--` stood in for punctuation now use a
  comma, a colon or brackets.

## Why

`NOTE:` carries nothing the sentence does not, and every comment in the file is
already a note. It also forced the deep alignment that pushed the example code in
`file_id.py` eight columns to the right, so removing it is what lets that block
sit where a reader expects it.

The dashes are punctuation the rest of the codebase does not use, and `--` in
particular reads as a CLI flag beside the shell snippets some of these comments
quote.

## How to test

`make lint` and `make test-unit` (428 passed). Nothing else can change: the diff
touches comments, docstrings and one YAML header.