### PR TITLE
fix(filters): read the sender and sender chat the remaining update types already carry

### DIFF
--- a/pyrogram/filters.py
+++ b/pyrogram/filters.py
@@ -178,8 +178,34 @@ _WITH_A_SENDER_CHAT = (Message, Story)
 
 _CAN_BE_OUTGOING = (Message, Story)
 
+# Three more shapes, one update type each, that the tuples above cannot express: the
+#  attribute is there, but not under the name the tuples read.
+#
+#  `UpdateUserStatus` is parsed into the `User` whose status changed and nothing else
+#  (`User._parse_user_status`), so that update *is* its own sender; `MessageReactionUpdated`
+#  spells the reacting user `user` and the anonymous one `actor_chat`; `ChatBoostUpdated`
+#  keeps the booster one level down, in `boost.from_user`.
+#
+#  Reading them here rather than renaming the attributes leaves the public API untouched.
+_IS_ITS_OWN_SENDER = (User,)
+
+_WITH_A_SENDER_NAMED_USER = (MessageReactionUpdated,)
+
+_WITH_A_SENDER_CHAT_NAMED_ACTOR_CHAT = (MessageReactionUpdated,)
+
+_WITH_A_BOOSTER = (ChatBoostUpdated,)
+
 
 def _sender_of(update: Update) -> Optional[User]:
+    if isinstance(update, _IS_ITS_OWN_SENDER):
+        return update
+
+    if isinstance(update, _WITH_A_SENDER_NAMED_USER):
+        return update.user
+
+    if isinstance(update, _WITH_A_BOOSTER):
+        return update.boost.from_user if update.boost else None
+
     return update.from_user if isinstance(update, _WITH_A_SENDER) else None
 
 
@@ -188,7 +214,17 @@ def _chat_of(update: Update) -> Optional[Chat]:
 
 
 def _sender_chat_of(update: Update) -> Optional[Chat]:
-    return update.sender_chat if isinstance(update, _WITH_A_SENDER_CHAT) else None
+    if isinstance(update, _WITH_A_SENDER_CHAT):
+        return update.sender_chat
+
+    if isinstance(update, _WITH_A_SENDER_CHAT_NAMED_ACTOR_CHAT):
+        return update.actor_chat
+
+    # A callback query carries no sender chat of its own, but the message the button sits
+    #  under does, by the same route `business`, `linked_channel` and `topic` take below.
+    message = _message_of(update)
+
+    return message.sender_chat if message else None
 
 
 def _is_outgoing(update: Update) -> bool:

--- a/pyrogram/filters.py
+++ b/pyrogram/filters.py
@@ -223,7 +223,6 @@ def _sender_chat_of(update: Update) -> Optional[Chat]:
     # A callback query carries no sender chat of its own, but the message the button sits
     #  under does, by the same route `business`, `linked_channel` and `topic` take below.
     message = _message_of(update)
-
     return message.sender_chat if message else None
 
 

--- a/pyrogram/filters.py
+++ b/pyrogram/filters.py
@@ -18,7 +18,7 @@
 
 import inspect
 import re
-from typing import Callable, List, Optional, Pattern, Union
+from typing import Callable, Final, FrozenSet, List, Optional, Pattern, Tuple, Type, Union
 
 import pyrogram
 from pyrogram import enums
@@ -137,20 +137,20 @@ class OrFilter(Filter):
         return x or y
 
 
-CUSTOM_FILTER_NAME = "CustomFilter"
+CUSTOM_FILTER_NAME: Final[str] = "CustomFilter"
 
 # Aliases for the client account itself, the same pair `resolve_peer` accepts.
 # `__init__` stores `_ME`, but the container is public and `filters.user().add("self")`
 # skips it, so membership goes against the aliases rather than against the stored one.
-_ME = "me"
-_SELF = "self"
-_ME_ALIASES = frozenset({_ME, _SELF})
+_ME: Final[str] = "me"
+_SELF: Final[str] = "self"
+_ME_ALIASES: Final[FrozenSet[str]] = frozenset({_ME, _SELF})
 
 
 # NOTE: `Update` declares none of these -- an inline query happens in no chat, a poll update
 #       has no sender -- so each field names the types that carry it. Kept in sync by
 #       `test_the_filters_name_every_update_type_that_carries_the_field`.
-_WITH_A_SENDER = (
+_WITH_A_SENDER: Final[Tuple[Type[Update], ...]] = (
     CallbackQuery,
     ChatJoinRequest,
     ChatMemberUpdated,
@@ -162,7 +162,7 @@ _WITH_A_SENDER = (
     Story,
 )
 
-_WITH_A_CHAT = (
+_WITH_A_CHAT: Final[Tuple[Type[Update], ...]] = (
     CallbackQuery,
     ChatBoostUpdated,
     ChatJoinRequest,
@@ -174,9 +174,9 @@ _WITH_A_CHAT = (
     Story,
 )
 
-_WITH_A_SENDER_CHAT = (Message, Story)
+_WITH_A_SENDER_CHAT: Final[Tuple[Type[Update], ...]] = (Message, Story)
 
-_CAN_BE_OUTGOING = (Message, Story)
+_CAN_BE_OUTGOING: Final[Tuple[Type[Update], ...]] = (Message, Story)
 
 # Three more shapes, one update type each, that the tuples above cannot express: the
 #  attribute is there, but not under the name the tuples read.
@@ -187,13 +187,13 @@ _CAN_BE_OUTGOING = (Message, Story)
 #  keeps the booster one level down, in `boost.from_user`.
 #
 #  Reading them here rather than renaming the attributes leaves the public API untouched.
-_IS_ITS_OWN_SENDER = (User,)
+_IS_ITS_OWN_SENDER: Final[Tuple[Type[Update], ...]] = (User,)
 
-_WITH_A_SENDER_NAMED_USER = (MessageReactionUpdated,)
+_WITH_A_SENDER_NAMED_USER: Final[Tuple[Type[Update], ...]] = (MessageReactionUpdated,)
 
-_WITH_A_SENDER_CHAT_NAMED_ACTOR_CHAT = (MessageReactionUpdated,)
+_WITH_A_SENDER_CHAT_NAMED_ACTOR_CHAT: Final[Tuple[Type[Update], ...]] = (MessageReactionUpdated,)
 
-_WITH_A_BOOSTER = (ChatBoostUpdated,)
+_WITH_A_BOOSTER: Final[Tuple[Type[Update], ...]] = (ChatBoostUpdated,)
 
 
 def _sender_of(update: Update) -> Optional[User]:
@@ -235,7 +235,7 @@ def _is_outgoing(update: Update) -> bool:
 #       filters that read them cannot take the field off the update the way the ones above do.
 #       They go through the message the update is about instead, which is the same message the
 #       user is looking at when a button under it is pressed.
-_WITH_A_MESSAGE = (CallbackQuery,)
+_WITH_A_MESSAGE: Final[Tuple[Type[Update], ...]] = (CallbackQuery,)
 
 
 def _message_of(update: Update) -> Optional[Message]:

--- a/tests/unit/filters/test_update_attributes.py
+++ b/tests/unit/filters/test_update_attributes.py
@@ -18,6 +18,7 @@
 
 import inspect
 from datetime import datetime
+from typing import Optional
 
 import pytest
 
@@ -217,6 +218,9 @@ def carries(update_type, field: str) -> bool:
         ("sender_chat", filters._WITH_A_SENDER_CHAT),
         ("outgoing", filters._CAN_BE_OUTGOING),
         ("message", filters._WITH_A_MESSAGE),
+        ("user", filters._WITH_A_SENDER_NAMED_USER),
+        ("actor_chat", filters._WITH_A_SENDER_CHAT_NAMED_ACTOR_CHAT),
+        ("boost", filters._WITH_A_BOOSTER),
     ],
 )
 def test_the_filters_name_every_update_type_that_carries_the_field(field, declared):
@@ -309,3 +313,83 @@ def test_callback_query_chat_stays_out_of_the_serialized_form():
 
     assert "chat" not in query.__dict__
     assert repr(query).count("Chat(") == 1
+
+
+def a_reaction(
+    *,
+    user: Optional[User] = None,
+    actor_chat: Optional[Chat] = None,
+) -> types.MessageReactionUpdated:
+    return types.MessageReactionUpdated(
+        chat=CHANNEL,
+        message_id=1,
+        date=DATE,
+        old_reaction=[],
+        new_reaction=[],
+        user=user,
+        actor_chat=actor_chat,
+    )
+
+
+def a_boost(from_user: User) -> types.ChatBoostUpdated:
+    return types.ChatBoostUpdated(
+        chat=CHANNEL,
+        boost=types.ChatBoost(id="1", date=DATE, expire_date=DATE, multiplier=1, from_user=from_user),
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_user_status_update_is_its_own_sender() -> None:
+    """`UpdateUserStatus` is parsed into the `User` it is about and nothing else.
+
+    So `@app.on_user_status(filters.user(42))` had no sender to read and never fired,
+    even though the update names the user it is about.
+    """
+    assert await filters.user(42)(CLIENT, SOMEONE)
+    assert await filters.user("someone")(CLIENT, SOMEONE)
+    assert not await filters.user("nobody")(CLIENT, SOMEONE)
+
+    assert await filters.me(CLIENT, MYSELF)
+    assert await filters.bot(CLIENT, A_BOT)
+
+
+@pytest.mark.asyncio
+async def test_a_reaction_reads_the_user_that_reacted() -> None:
+    assert await filters.user(42)(CLIENT, a_reaction(user=SOMEONE))
+    assert await filters.user("someone")(CLIENT, a_reaction(user=SOMEONE))
+    assert await filters.bot(CLIENT, a_reaction(user=A_BOT))
+    assert not await filters.user(42)(CLIENT, a_reaction(actor_chat=CHANNEL))
+
+
+@pytest.mark.asyncio
+async def test_a_reaction_left_anonymously_reads_the_chat_it_was_left_as() -> None:
+    assert await filters.sender_chat(CLIENT, a_reaction(actor_chat=CHANNEL))
+    assert not await filters.sender_chat(CLIENT, a_reaction(user=SOMEONE))
+
+    # The chat the message lives in keeps answering, whoever reacted.
+    assert await filters.channel(CLIENT, a_reaction(user=SOMEONE))
+
+
+@pytest.mark.asyncio
+async def test_a_boost_reads_the_user_that_boosted() -> None:
+    assert await filters.user(42)(CLIENT, a_boost(SOMEONE))
+    assert await filters.user("someone")(CLIENT, a_boost(SOMEONE))
+    assert await filters.me(CLIENT, a_boost(MYSELF))
+    assert not await filters.user(42)(CLIENT, types.ChatBoostUpdated(chat=CHANNEL, boost=None))
+
+
+@pytest.mark.asyncio
+async def test_a_callback_query_reads_the_sender_chat_of_its_message() -> None:
+    """A button under a channel post: the post has a sender chat, the query has none of its own."""
+    posted_as_the_channel = Message(id=1, chat=CHANNEL, sender_chat=CHANNEL)
+
+    assert await filters.sender_chat(CLIENT, CallbackQuery(id="1", from_user=SOMEONE, message=posted_as_the_channel))
+    assert not await filters.sender_chat(CLIENT, in_private(CallbackQuery, from_user=SOMEONE))
+    assert not await filters.sender_chat(CLIENT, CallbackQuery(id="1", from_user=SOMEONE))
+
+
+def test_the_filters_name_every_update_type_that_is_a_user() -> None:
+    """`_IS_ITS_OWN_SENDER` cannot be checked by field, the way the tuples above are."""
+    assert {one.__name__ for one in UPDATE_TYPES if issubclass(one, User)} == {
+        one.__name__ for one in filters._IS_ITS_OWN_SENDER
+    }


### PR DESCRIPTION

## What

`_sender_of()` and `_sender_chat_of()` dispatch on tuples of update types keyed by the
field name they read. Four shapes could not be expressed that way, because the attribute
is there under a different name:

- `UpdateUserStatus` is parsed into the `User` whose status changed and nothing else
  (`User._parse_user_status`), so that update *is* its own sender.
- `MessageReactionUpdated` spells the reacting user `user`, and the anonymous one
  `actor_chat`.
- `ChatBoostUpdated` keeps the booster one level down, in `boost.from_user`.

So `filters.user(...)`, `filters.me`, `filters.bot` and `filters.sender_chat` answered
"not applicable" for updates that do have an answer, and a handler like
`@app.on_user_status(filters.user(42))` never fired.

The fields are read where the tuples already live rather than renamed on the types, so the
public API is untouched.

### One behaviour change beyond the new types

`filters.sender_chat` now matches a `CallbackQuery` whose message was posted as a channel.
A callback query carries no sender chat of its own, but the message the button sits under
does, and it is reached by the same route `business`, `linked_channel` and `topic` already
take. Before this it always answered `False` for a callback query.

## Why the tests are shaped this way

`test_the_filters_name_every_update_type_that_carries_the_field` compares the set of update
types actually carrying a field against the set the tuple names, in both directions, over
every `Update` subclass found in `pyrogram.types`. Three rows join it (`user`, `actor_chat`,
`boost`), so a new update type carrying one of those fields fails the suite instead of
silently going unmatched.

`_IS_ITS_OWN_SENDER` cannot be checked by field, since its members are `User` subclasses
rather than types holding one, so it gets its own equivalent test.

Six behavioural tests cover what the completeness tests cannot: which field is read, and
the `boost is None` case.

## Also in here

The second commit annotates the thirteen module constants of `filters.py` with `Final`,
including the nine type tuples, which are now `Tuple[Type[Update], ...]`. Nothing about the
values changes.

## How to test

`make lint` and `make test-unit` (437 passed).