### PR TITLE
feat(messages): add `skip_empty` and `skip_service` to `get_chat_history()`

### DIFF
--- a/pyrogram/methods/messages/get_chat_history.py
+++ b/pyrogram/methods/messages/get_chat_history.py
@@ -81,6 +81,8 @@ class GetChatHistory:
         min_id: int = 0,
         max_id: int = 0,
         reverse: bool = False,
+        skip_empty: bool = False,
+        skip_service: bool = False,
     ) -> AsyncIterator["types.Message"]:
         """Get messages from a chat history.
 
@@ -97,6 +99,7 @@ class GetChatHistory:
             limit (``int``, *optional*):
                 Limits the number of messages to be retrieved.
                 By default, no limit is applied and all messages are returned.
+                The messages left out by *skip_empty* or *skip_service* do not count towards it.
 
             offset (``int``, *optional*):
                 Sequential number of the first message to be returned.
@@ -120,6 +123,16 @@ class GetChatHistory:
 
             reverse (``bool``, *optional*):
                 Pass True to retrieve the messages from oldest to newest.
+
+            skip_empty (``bool``, *optional*):
+                Pass True to leave out the messages that came back empty, that is, the ones that
+                were deleted or that this account is not allowed to see.
+                Defaults to False.
+
+            skip_service (``bool``, *optional*):
+                Pass True to leave out service messages, such as a member joining the chat or a
+                message being pinned.
+                Defaults to False.
 
         Returns:
             ``Generator``: A generator yielding :obj:`~pyrogram.types.Message` objects.
@@ -167,6 +180,12 @@ class GetChatHistory:
 
             offset_id = messages[-1].id + (1 if reverse else 0)
             for message in messages:
+                if skip_empty and message.empty:
+                    continue
+
+                if skip_service and message.service:
+                    continue
+
                 yield message
 
                 current += 1

--- a/tests/unit/methods/test_get_chat_history.py
+++ b/tests/unit/methods/test_get_chat_history.py
@@ -1,0 +1,113 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Any, AsyncIterator, List, Protocol
+
+import pytest
+
+from pyrogram import enums, types
+from pyrogram.methods.messages import get_chat_history
+from pyrogram.methods.messages.get_chat_history import GetChatHistory
+
+
+class SetHistory(Protocol):
+    def __call__(self, *chunks: List[types.Message]) -> None: ...
+
+
+@pytest.fixture
+def history(monkeypatch: pytest.MonkeyPatch) -> SetHistory:
+    """Hand `get_chat_history()` the given chunks, one call after another, then nothing."""
+
+    def set_history(*chunks: List[types.Message]) -> None:
+        remaining = list(chunks)
+
+        # The stand-in answers whatever `get_chunk()` is asked, so it takes the whole
+        #  keyword signature without naming it.
+        async def one_chunk(*args: Any, **kwargs: Any) -> List[types.Message]:
+            return remaining.pop(0) if remaining else []
+
+        monkeypatch.setattr(get_chat_history, "get_chunk", one_chunk)
+
+    return set_history
+
+
+def a_chat_of_every_kind() -> List[types.Message]:
+    return [
+        types.Message(id=1, empty=True),
+        types.Message(id=2, service=enums.MessageServiceType.NEW_CHAT_MEMBERS),
+        types.Message(id=3, text="a message"),
+    ]
+
+
+async def ids_of(messages: AsyncIterator[types.Message]) -> List[int]:
+    return [message.id async for message in messages]
+
+
+@pytest.mark.asyncio
+async def test_every_message_comes_back_by_default(history: SetHistory) -> None:
+    history(a_chat_of_every_kind())
+
+    assert await ids_of(GetChatHistory().get_chat_history("a_chat")) == [1, 2, 3]
+
+
+@pytest.mark.asyncio
+async def test_skip_empty_leaves_out_the_deleted_messages(history: SetHistory) -> None:
+    history(a_chat_of_every_kind())
+
+    assert await ids_of(GetChatHistory().get_chat_history("a_chat", skip_empty=True)) == [2, 3]
+
+
+@pytest.mark.asyncio
+async def test_skip_service_leaves_out_the_service_messages(history: SetHistory) -> None:
+    history(a_chat_of_every_kind())
+
+    assert await ids_of(GetChatHistory().get_chat_history("a_chat", skip_service=True)) == [1, 3]
+
+
+@pytest.mark.asyncio
+async def test_both_flags_leave_only_the_messages_someone_wrote(history: SetHistory) -> None:
+    history(a_chat_of_every_kind())
+
+    messages = GetChatHistory().get_chat_history("a_chat", skip_empty=True, skip_service=True)
+
+    assert await ids_of(messages) == [3]
+
+
+@pytest.mark.asyncio
+async def test_the_skipped_messages_do_not_count_towards_the_limit(history: SetHistory) -> None:
+    history([
+        types.Message(id=1, empty=True),
+        types.Message(id=2, text="the first one"),
+        types.Message(id=3, text="the second one"),
+    ])
+
+    messages = GetChatHistory().get_chat_history("a_chat", limit=2, skip_empty=True)
+
+    assert await ids_of(messages) == [2, 3]
+
+
+@pytest.mark.asyncio
+async def test_a_chunk_that_is_skipped_whole_does_not_stop_the_walk(history: SetHistory) -> None:
+    history(
+        [types.Message(id=1, empty=True), types.Message(id=2, empty=True)],
+        [types.Message(id=3, text="behind the deleted ones")],
+    )
+
+    messages = GetChatHistory().get_chat_history("a_chat", skip_empty=True)
+
+    assert await ids_of(messages) == [3]


### PR DESCRIPTION

## What

Two optional flags on `get_chat_history()`, both `False` by default:

- `skip_empty` leaves out the messages that came back empty, that is, the ones that were
  deleted or that this account is not allowed to see.
- `skip_service` leaves out service messages, such as a member joining the chat or a
  message being pinned.

Walking a chat for its actual conversation currently means filtering on the caller's side,
and doing that correctly is not obvious: the empty and service messages still consume the
`limit`, so `limit=100` gives fewer than a hundred real messages by an amount the caller
cannot predict. There is no server-side filter for either kind, so the work has to happen
here.

## How it behaves

The filter sits in the yielding loop, after `offset_id` is taken from the last message of
the chunk. Two consequences, both deliberate and both covered by a test:

- **A skipped message does not count towards `limit`.** `limit=10, skip_service=True`
  yields ten real messages, not ten minus however many service ones the chat happened to
  hold. The docstring of `limit` says so.
- **A chunk skipped in full still advances the walk.** `offset_id` comes from the raw
  chunk rather than from what was yielded, so a run of deleted messages does not stall the
  iteration.

A caller that passes neither flag sees no change at all.

## How to test

`make lint` and `make test-unit` (434 passed).

The six new tests in `tests/unit/methods/test_get_chat_history.py` replace `get_chunk()`
with a stand-in that hands back fixed chunks, which is the only seam the method has. They
cover each flag alone, both together, the default, the `limit` interaction and the
skipped-whole-chunk case.
