### PR TITLE
fix(docs): point the dead Sphinx cross-references at names that exist

### DIFF
--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -253,7 +253,7 @@ class Client(Methods):
         loop (:py:class:`asyncio.AbstractEventLoop`, *optional*):
             Event loop.
 
-        init_connection_params (``dict`` | :obj:`~pyrogram.raw.base.JsonValue`, *optional*):
+        init_connection_params (``dict`` | :obj:`~pyrogram.raw.base.JSONValue`, *optional*):
             Additional initConnection parameters.
             For now, only the tz_offset field is supported, for specifying timezone offset in seconds.
             A dict is converted on connect; an already built JsonValue is sent as it is.

--- a/pyrogram/handlers/business_connection_handler.py
+++ b/pyrogram/handlers/business_connection_handler.py
@@ -38,7 +38,7 @@ class BusinessConnectionHandler(Handler):
             Pass a function that will be called when a business connection has changed. It takes *(client, update)*
             as positional arguments (look at the section below for a detailed description).
 
-        filters (:obj:`Filters`):
+        filters (:obj:`~pyrogram.filters.Filter`):
             Pass one or more filters to allow only a subset of updates to be passed
             in your callback function.
 

--- a/pyrogram/handlers/business_message_handler.py
+++ b/pyrogram/handlers/business_message_handler.py
@@ -38,7 +38,7 @@ class BusinessMessageHandler(Handler):
             Pass a function that will be called when a new Message arrives. It takes *(client, message)*
             as positional arguments (look at the section below for a detailed description).
 
-        filters (:obj:`Filters`):
+        filters (:obj:`~pyrogram.filters.Filter`):
             Pass one or more filters to allow only a subset of messages to be passed
             in your callback function.
 

--- a/pyrogram/handlers/callback_query_handler.py
+++ b/pyrogram/handlers/callback_query_handler.py
@@ -37,7 +37,7 @@ class CallbackQueryHandler(Handler):
             Pass a function that will be called when a new CallbackQuery arrives. It takes *(client, callback_query)*
             as positional arguments (look at the section below for a detailed description).
 
-        filters (:obj:`Filters`):
+        filters (:obj:`~pyrogram.filters.Filter`):
             Pass one or more filters to allow only a subset of callback queries to be passed
             in your callback function.
 

--- a/pyrogram/handlers/chat_boost_handler.py
+++ b/pyrogram/handlers/chat_boost_handler.py
@@ -37,7 +37,7 @@ class ChatBoostHandler(Handler):
             Pass a function that will be called when a new boost applied. It takes *(client, boost)*
             as positional arguments (look at the section below for a detailed description).
 
-        filters (:obj:`Filters`):
+        filters (:obj:`~pyrogram.filters.Filter`):
             Pass one or more filters to allow only a subset of updates to be passed
             in your callback function.
 

--- a/pyrogram/handlers/chat_join_request_handler.py
+++ b/pyrogram/handlers/chat_join_request_handler.py
@@ -38,7 +38,7 @@ class ChatJoinRequestHandler(Handler):
             *(client, chat_join_request)* as positional arguments (look at the section below for a detailed
             description).
 
-        filters (:obj:`Filters`):
+        filters (:obj:`~pyrogram.filters.Filter`):
             Pass one or more filters to allow only a subset of updates to be passed in your callback function.
 
     Other parameters:

--- a/pyrogram/handlers/chat_member_updated_handler.py
+++ b/pyrogram/handlers/chat_member_updated_handler.py
@@ -38,7 +38,7 @@ class ChatMemberUpdatedHandler(Handler):
             *(client, chat_member_updated)* as positional arguments (look at the section below for a detailed
             description).
 
-        filters (:obj:`Filters`):
+        filters (:obj:`~pyrogram.filters.Filter`):
             Pass one or more filters to allow only a subset of updates to be passed in your callback function.
 
     Other parameters:

--- a/pyrogram/handlers/chosen_inline_result_handler.py
+++ b/pyrogram/handlers/chosen_inline_result_handler.py
@@ -38,7 +38,7 @@ class ChosenInlineResultHandler(Handler):
             It takes *(client, chosen_inline_result)* as positional arguments (look at the section below for a
             detailed description).
 
-        filters (:obj:`Filters`):
+        filters (:obj:`~pyrogram.filters.Filter`):
             Pass one or more filters to allow only a subset of chosen inline results to be passed
             in your callback function.
 

--- a/pyrogram/handlers/deleted_business_messages_handler.py
+++ b/pyrogram/handlers/deleted_business_messages_handler.py
@@ -40,7 +40,7 @@ class DeletedBusinessMessagesHandler(Handler):
             Pass a function that will be called when one or more messages have been deleted.
             It takes *(client, messages)* as positional arguments (look at the section below for a detailed description).
 
-        filters (:obj:`Filters`):
+        filters (:obj:`~pyrogram.filters.Filter`):
             Pass one or more filters to allow only a subset of messages to be passed
             in your callback function.
 

--- a/pyrogram/handlers/deleted_messages_handler.py
+++ b/pyrogram/handlers/deleted_messages_handler.py
@@ -39,7 +39,7 @@ class DeletedMessagesHandler(Handler):
             Pass a function that will be called when one or more messages have been deleted.
             It takes *(client, messages)* as positional arguments (look at the section below for a detailed description).
 
-        filters (:obj:`Filters`):
+        filters (:obj:`~pyrogram.filters.Filter`):
             Pass one or more filters to allow only a subset of messages to be passed
             in your callback function.
 

--- a/pyrogram/handlers/edited_business_message_handler.py
+++ b/pyrogram/handlers/edited_business_message_handler.py
@@ -38,7 +38,7 @@ class EditedBusinessMessageHandler(Handler):
             Pass a function that will be called when a new edited message arrives. It takes *(client, message)*
             as positional arguments (look at the section below for a detailed description).
 
-        filters (:obj:`Filters`):
+        filters (:obj:`~pyrogram.filters.Filter`):
             Pass one or more filters to allow only a subset of messages to be passed
             in your callback function.
 

--- a/pyrogram/handlers/edited_message_handler.py
+++ b/pyrogram/handlers/edited_message_handler.py
@@ -37,7 +37,7 @@ class EditedMessageHandler(Handler):
             Pass a function that will be called when a new edited message arrives. It takes *(client, message)*
             as positional arguments (look at the section below for a detailed description).
 
-        filters (:obj:`Filters`):
+        filters (:obj:`~pyrogram.filters.Filter`):
             Pass one or more filters to allow only a subset of messages to be passed
             in your callback function.
 

--- a/pyrogram/handlers/error_handler.py
+++ b/pyrogram/handlers/error_handler.py
@@ -44,7 +44,7 @@ class ErrorHandler(Handler):
             An exception type or a sequence of exception types that this handler should handle.
             If None, the handler will catch any exception that is a subclass of ``Exception``.
 
-        filters (:obj:`Filter`, *optional*):
+        filters (:obj:`~pyrogram.filters.Filter`, *optional*):
             Pass one or more filters to allow only a subset of updates to be passed
             in your callback function.
 

--- a/pyrogram/handlers/guest_message_handler.py
+++ b/pyrogram/handlers/guest_message_handler.py
@@ -37,7 +37,7 @@ class GuestMessageHandler(Handler):
             Pass a function that will be called when a new guest message arrives. It takes *(client, message)*
             as positional arguments (look at the section below for a detailed description).
 
-        filters (:obj:`Filters`):
+        filters (:obj:`~pyrogram.filters.Filter`):
             Pass one or more filters to allow only a subset of messages to be passed
             in your callback function.
 

--- a/pyrogram/handlers/inline_query_handler.py
+++ b/pyrogram/handlers/inline_query_handler.py
@@ -37,7 +37,7 @@ class InlineQueryHandler(Handler):
             Pass a function that will be called when a new InlineQuery arrives. It takes *(client, inline_query)*
             as positional arguments (look at the section below for a detailed description).
 
-        filters (:obj:`Filters`):
+        filters (:obj:`~pyrogram.filters.Filter`):
             Pass one or more filters to allow only a subset of inline queries to be passed
             in your callback function.
 

--- a/pyrogram/handlers/managed_bot_updated_handler.py
+++ b/pyrogram/handlers/managed_bot_updated_handler.py
@@ -36,7 +36,7 @@ class ManagedBotUpdatedHandler(Handler):
             Pass a function that will be called when a new managed bot creation update arrives. It takes *(client, managed_bot_updated)*
             as positional arguments (look at the section below for a detailed description).
 
-        filters (:obj:`Filters`):
+        filters (:obj:`~pyrogram.filters.Filter`):
             Pass one or more filters to allow only a subset of users to be passed in your callback function.
 
     Other parameters:

--- a/pyrogram/handlers/message_handler.py
+++ b/pyrogram/handlers/message_handler.py
@@ -37,7 +37,7 @@ class MessageHandler(Handler):
             Pass a function that will be called when a new Message arrives. It takes *(client, message)*
             as positional arguments (look at the section below for a detailed description).
 
-        filters (:obj:`Filters`):
+        filters (:obj:`~pyrogram.filters.Filter`):
             Pass one or more filters to allow only a subset of messages to be passed
             in your callback function.
 

--- a/pyrogram/handlers/message_reaction_count_handler.py
+++ b/pyrogram/handlers/message_reaction_count_handler.py
@@ -40,7 +40,7 @@ class MessageReactionCountHandler(Handler):
             *(client, reactions)* as positional arguments (look at the section below for a detailed
             description).
 
-        filters (:obj:`Filters`):
+        filters (:obj:`~pyrogram.filters.Filter`):
             Pass one or more filters to allow only a subset of updates to be passed in your callback function.
 
     Other parameters:

--- a/pyrogram/handlers/message_reaction_handler.py
+++ b/pyrogram/handlers/message_reaction_handler.py
@@ -40,7 +40,7 @@ class MessageReactionHandler(Handler):
             *(client, reactions)* as positional arguments (look at the section below for a detailed
             description).
 
-        filters (:obj:`Filters`):
+        filters (:obj:`~pyrogram.filters.Filter`):
             Pass one or more filters to allow only a subset of updates to be passed in your callback function.
 
     Other parameters:

--- a/pyrogram/handlers/poll_handler.py
+++ b/pyrogram/handlers/poll_handler.py
@@ -38,7 +38,7 @@ class PollHandler(Handler):
             Pass a function that will be called when a new poll update arrives. It takes *(client, poll)*
             as positional arguments (look at the section below for a detailed description).
 
-        filters (:obj:`Filters`):
+        filters (:obj:`~pyrogram.filters.Filter`):
             Pass one or more filters to allow only a subset of polls to be passed
             in your callback function.
 

--- a/pyrogram/handlers/pre_checkout_query_handler.py
+++ b/pyrogram/handlers/pre_checkout_query_handler.py
@@ -37,7 +37,7 @@ class PreCheckoutQueryHandler(Handler):
             Pass a function that will be called when a new PreCheckoutQuery arrives. It takes *(client, pre_checkout_query)*
             as positional arguments (look at the section below for a detailed description).
 
-        filters (:obj:`Filters`):
+        filters (:obj:`~pyrogram.filters.Filter`):
             Pass one or more filters to allow only a subset of callback queries to be passed
             in your callback function.
 

--- a/pyrogram/handlers/purchased_paid_media_handler.py
+++ b/pyrogram/handlers/purchased_paid_media_handler.py
@@ -37,7 +37,7 @@ class PurchasedPaidMediaHandler(Handler):
             Pass a function that will be called when a paid media purchased. It takes *(client, update)*
             as positional arguments (look at the section below for a detailed description).
 
-        filters (:obj:`Filters`):
+        filters (:obj:`~pyrogram.filters.Filter`):
             Pass one or more filters to allow only a subset of updates to be passed
             in your callback function.
 

--- a/pyrogram/handlers/raw_update_handler.py
+++ b/pyrogram/handlers/raw_update_handler.py
@@ -38,7 +38,7 @@ class RawUpdateHandler(Handler):
             *(client, update, users, chats)* as positional arguments (look at the section below for
             a detailed description).
 
-        filters (:obj:`Filters`):
+        filters (:obj:`~pyrogram.filters.Filter`):
             Pass one or more filters to allow only a subset of updates to be passed
             in your callback function.
 

--- a/pyrogram/handlers/shipping_query_handler.py
+++ b/pyrogram/handlers/shipping_query_handler.py
@@ -38,7 +38,7 @@ class ShippingQueryHandler(Handler):
             Pass a function that will be called when a new PreCheckoutQuery arrives. It takes *(client, query)*
             as positional arguments (look at the section below for a detailed description).
 
-        filters (:obj:`Filters`):
+        filters (:obj:`~pyrogram.filters.Filter`):
             Pass one or more filters to allow only a subset of callback queries to be passed
             in your callback function.
 

--- a/pyrogram/handlers/stopped_message_generation_handler.py
+++ b/pyrogram/handlers/stopped_message_generation_handler.py
@@ -36,7 +36,7 @@ class StoppedMessageGenerationHandler(Handler):
             Pass a function that will be called when a new update arrives. It takes *(client, stopped_message_generation)*
             as positional arguments (look at the section below for a detailed description).
 
-        filters (:obj:`Filters`):
+        filters (:obj:`~pyrogram.filters.Filter`):
             Pass one or more filters to allow only a subset of messages to be passed
             in your callback function.
 

--- a/pyrogram/handlers/story_handler.py
+++ b/pyrogram/handlers/story_handler.py
@@ -37,7 +37,7 @@ class StoryHandler(Handler):
             Pass a function that will be called when a new Stories arrives. It takes *(client, story)*
             as positional arguments (look at the section below for a detailed description).
 
-        filters (:obj:`Filters`):
+        filters (:obj:`~pyrogram.filters.Filter`):
             Pass one or more filters to allow only a subset of stories to be passed
             in your callback function.
 

--- a/pyrogram/handlers/user_status_handler.py
+++ b/pyrogram/handlers/user_status_handler.py
@@ -36,7 +36,7 @@ class UserStatusHandler(Handler):
             Pass a function that will be called when a new user status update arrives. It takes *(client, user)*
             as positional arguments (look at the section below for a detailed description).
 
-        filters (:obj:`Filters`):
+        filters (:obj:`~pyrogram.filters.Filter`):
             Pass one or more filters to allow only a subset of users to be passed in your callback function.
 
     Other parameters:

--- a/pyrogram/methods/advanced/invoke.py
+++ b/pyrogram/methods/advanced/invoke.py
@@ -43,13 +43,13 @@ class Invoke:
         """Invoke raw Telegram functions.
 
         This method makes it possible to manually call every single Telegram API method in a low-level manner.
-        Available functions are listed in the :obj:`functions <pyrogram.api.functions>` package and may accept compound
-        data types from :obj:`types <pyrogram.api.types>` as well as bare types such as ``int``, ``str``, etc...
+        Available functions are listed in the :obj:`functions <pyrogram.raw.functions>` package and may accept compound
+        data types from :obj:`types <pyrogram.raw.types>` as well as bare types such as ``int``, ``str``, etc...
 
         .. note::
 
             This is a utility method intended to be used **only** when working with raw
-            :obj:`functions <pyrogram.api.functions>` (i.e: a Telegram API method you wish to use which is not
+            :obj:`functions <pyrogram.raw.functions>` (i.e: a Telegram API method you wish to use which is not
             available yet in the Client class as an easy-to-use method).
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/pyrogram/methods/advanced/resolve_peer.py
+++ b/pyrogram/methods/advanced/resolve_peer.py
@@ -34,7 +34,7 @@ class ResolvePeer:
         .. note::
 
             This is a utility method intended to be used **only** when working with raw
-            :obj:`functions <pyrogram.api.functions>` (i.e: a Telegram API method you wish to use which is not
+            :obj:`functions <pyrogram.raw.functions>` (i.e: a Telegram API method you wish to use which is not
             available yet in the Client class as an easy-to-use method).
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/pyrogram/methods/advanced/save_file.py
+++ b/pyrogram/methods/advanced/save_file.py
@@ -50,7 +50,7 @@ class SaveFile:
         .. note::
 
             This is a utility method intended to be used **only** when working with raw
-            :obj:`functions <pyrogram.api.functions>` (i.e: a Telegram API method you wish to use which is not
+            :obj:`functions <pyrogram.raw.functions>` (i.e: a Telegram API method you wish to use which is not
             available yet in the Client class as an easy-to-use method).
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/pyrogram/methods/auth/resend_phone_number_code.py
+++ b/pyrogram/methods/auth/resend_phone_number_code.py
@@ -32,7 +32,7 @@ class ResendPhoneNumberCode:
         """Re-send the confirmation code using a different type.
 
         The type of the code to be re-sent is specified in the *next_type* attribute of the
-        :obj:`~pyrogram.types.SentCode` object returned by :meth:`send_phone_number_code`.
+        :obj:`~pyrogram.types.SentCode` object returned by :meth:`~pyrogram.Client.send_phone_number_code`.
 
         .. include:: /_includes/usable-by/users.rst
 

--- a/pyrogram/methods/bots/answer_shipping_query.py
+++ b/pyrogram/methods/bots/answer_shipping_query.py
@@ -44,7 +44,7 @@ class AnswerShippingQuery:
             ok (``bool``):
                 Specify True if everything is alright (goods are available, etc.) and the bot is ready to proceed with the order. Use False if there are any problems.
 
-            shipping_options (List of :obj:`~pyrogram.types.ShippingOptions`, *optional*):
+            shipping_options (List of :obj:`~pyrogram.types.ShippingOption`, *optional*):
                 Required if ok is True. A array of available shipping options.
 
             error_message (``str``, *optional*):

--- a/pyrogram/methods/chats/set_chat_discussion_group.py
+++ b/pyrogram/methods/chats/set_chat_discussion_group.py
@@ -41,7 +41,7 @@ class SetChatDiscussionGroup:
 
             discussion_chat_id (``int`` | ``str``, *optional*):
                 Unique identifier (int) or username (str) of a new channel's discussion group.
-                Use the method :meth:`get_suitable_discussion_chats` to find all suitable groups.
+                Use the method :meth:`~pyrogram.Client.get_suitable_discussion_chats` to find all suitable groups.
                 Pass None to remove the discussion group.
 
         Returns:

--- a/pyrogram/methods/invite_links/get_chat_admins_with_invite_links.py
+++ b/pyrogram/methods/invite_links/get_chat_admins_with_invite_links.py
@@ -39,7 +39,7 @@ class GetChatAdminsWithInviteLinks:
                 (in the format @username).
 
         Returns:
-            List of :obj:`~pyrogram.types.ChatAdminWithInviteLink`: On success, the list of admins that have exported
+            List of :obj:`~pyrogram.types.ChatAdminWithInviteLinks`: On success, the list of admins that have exported
             invite links is returned.
         """
         r = await self.invoke(

--- a/pyrogram/methods/messages/copy_message.py
+++ b/pyrogram/methods/messages/copy_message.py
@@ -62,7 +62,7 @@ class CopyMessage:
     ) -> Optional["types.Message"]:
         """Copy messages of any kind.
 
-        The method is analogous to the method :meth:`~Client.forward_messages`, but the copied message doesn't have a
+        The method is analogous to the method :meth:`~pyrogram.Client.forward_messages`, but the copied message doesn't have a
         link to the original message.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/pyrogram/methods/payments/suggest_birthday.py
+++ b/pyrogram/methods/payments/suggest_birthday.py
@@ -38,7 +38,7 @@ class SuggestBirthday:
                 Unique identifier (int) or username (str) of the target chat.
                 For a contact that exists in your Telegram address book you can use his phone number (str).
 
-            birthday (:obj:`types.Birthday`):
+            birthday (:obj:`~pyrogram.types.Birthday`):
                 Birthdate to suggest.
 
         Returns:

--- a/pyrogram/types/bots_and_keyboards/callback_query.py
+++ b/pyrogram/types/bots_and_keyboards/callback_query.py
@@ -62,7 +62,7 @@ class CallbackQuery(Object, Update):
 
         matches (List of regex Matches, *optional*):
             A list containing all `Match Objects <https://docs.python.org/3/library/re.html#match-objects>`_ that match
-            the data of this callback query. Only applicable when using :obj:`Filters.regex <pyrogram.Filters.regex>`.
+            the data of this callback query. Only applicable when using :obj:`filters.regex <pyrogram.filters.regex>`.
 
         chat (:obj:`~pyrogram.types.Chat`, *property*):
             The chat *message* was sent in. None for a button attached to an inline message, which carries

--- a/pyrogram/types/bots_and_keyboards/message_reaction_count_updated.py
+++ b/pyrogram/types/bots_and_keyboards/message_reaction_count_updated.py
@@ -40,7 +40,7 @@ class MessageReactionCountUpdated(Object, Update):
         date (:py:obj:`~datetime.datetime`):
             Date of change of the reaction.
 
-        reactions (:obj:`~pyrogram.types.ReactionCount`):
+        reactions (List of :obj:`~pyrogram.types.Reaction`):
             List of reactions that are present on the message.
     """
 

--- a/pyrogram/types/bots_and_keyboards/shipping_query.py
+++ b/pyrogram/types/bots_and_keyboards/shipping_query.py
@@ -104,7 +104,7 @@ class ShippingQuery(Object, Update):
             ok (``bool``):
                 Pass True if delivery to the specified address is possible and False if there are any problems (for example, if delivery to the specified address is not possible).
 
-            shipping_options (:obj:`~pyrogram.types.ShippingOptions`, *optional*):
+            shipping_options (:obj:`~pyrogram.types.ShippingOption`, *optional*):
                 Required if ok is True. A JSON-serialized array of available shipping options.
 
             error_message (``str``, *optional*):

--- a/pyrogram/types/inline_mode/chosen_inline_result.py
+++ b/pyrogram/types/inline_mode/chosen_inline_result.py
@@ -54,7 +54,7 @@ class ChosenInlineResult(Object, Update):
 
         matches (List of regex Matches, *optional*):
             A list containing all `Match Objects <https://docs.python.org/3/library/re.html#match-objects>`_ that match
-            the query of this chosen query. Only applicable when using :obj:`Filters.regex <pyrogram.Filters.regex>`.
+            the query of this chosen query. Only applicable when using :obj:`filters.regex <pyrogram.filters.regex>`.
     """
 
     def __init__(

--- a/pyrogram/types/inline_mode/inline_query.py
+++ b/pyrogram/types/inline_mode/inline_query.py
@@ -51,7 +51,7 @@ class InlineQuery(Object, Update):
 
         matches (List of regex Matches, *optional*):
             A list containing all `Match Objects <https://docs.python.org/3/library/re.html#match-objects>`_ that match
-            the query of this inline query. Only applicable when using :obj:`Filters.regex <pyrogram.Filters.regex>`.
+            the query of this inline query. Only applicable when using :obj:`filters.regex <pyrogram.filters.regex>`.
     """
 
     def __init__(

--- a/pyrogram/types/input_content/input_credentials.py
+++ b/pyrogram/types/input_content/input_credentials.py
@@ -26,9 +26,9 @@ class InputCredentials(Object):
 
     It should be one of:
 
-    - :obj:`~pyrogram.types.InputInvoiceApplePay`
-    - :obj:`~pyrogram.types.InputInvoiceGooglePay`
-    - :obj:`~pyrogram.types.InputInvoiceNew`
+    - :obj:`~pyrogram.types.InputCredentialsApplePay`
+    - :obj:`~pyrogram.types.InputCredentialsGooglePay`
+    - :obj:`~pyrogram.types.InputCredentialsNew`
     - :obj:`~pyrogram.types.InputCredentialsSaved`
     """
     def __init__(self):

--- a/pyrogram/types/input_content/input_phone_contact.py
+++ b/pyrogram/types/input_content/input_phone_contact.py
@@ -23,7 +23,7 @@ from ..object import Object
 
 class InputPhoneContact(Object):
     """A Phone Contact to be added in your Telegram address book.
-    It is intended to be used with :meth:`~pyrogram.Client.add_contacts()`
+    It is intended to be used with :meth:`~pyrogram.Client.import_contacts()`
 
     Parameters:
         phone (``str``):

--- a/pyrogram/types/input_content/input_poll_option.py
+++ b/pyrogram/types/input_content/input_poll_option.py
@@ -28,7 +28,7 @@ class InputPollOption(Object):
     """This object contains information about one answer option in a poll to be sent.
 
     Parameters:
-        text (``str`` | :obj:`~pyrogram.enums.FormattedText`, *optional*):
+        text (``str`` | :obj:`~pyrogram.types.FormattedText`, *optional*):
             Option text, 1-100 characters.
 
         media (:obj:`~pyrogram.types.InputPollOptionMedia`, *optional*):

--- a/pyrogram/types/messages_and_media/formatted_text.py
+++ b/pyrogram/types/messages_and_media/formatted_text.py
@@ -32,7 +32,7 @@ class FormattedText(Object):
         text (``str``):
             The text.
 
-        parse_mode (:obj:`~pyrogram.types.ParseMode`, *optional*):
+        parse_mode (:obj:`~pyrogram.enums.ParseMode`, *optional*):
             Parse mode of the text.
 
         entities (List of :obj:`~pyrogram.types.MessageEntity`, *optional*):

--- a/pyrogram/types/messages_and_media/invoice.py
+++ b/pyrogram/types/messages_and_media/invoice.py
@@ -85,7 +85,7 @@ class Invoice(Object):
         terms_url (``str``, *optional*):
             Terms of service URL.
 
-        raw (:obj:`~raw.base.payments.MessageMediaInvoice` | :obj:`~raw.base.Invoice`, *optional*):
+        raw (:obj:`~pyrogram.raw.types.MessageMediaInvoice` | :obj:`~pyrogram.raw.types.Invoice`, *optional*):
             The raw object, as received from the Telegram API.
     """
 

--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -385,7 +385,7 @@ class Message(Object, Update):
 
         matches (List of regex Matches, *optional*):
             A list containing all `Match Objects <https://docs.python.org/3/library/re.html#match-objects>`_ that match
-            the text of this message. Only applicable when using :obj:`Filters.regex <pyrogram.Filters.regex>`.
+            the text of this message. Only applicable when using :obj:`filters.regex <pyrogram.filters.regex>`.
 
         command (List of ``str``, *optional*):
             A list containing the command and its arguments, if any.
@@ -422,7 +422,7 @@ class Message(Object, Update):
         video_chat_ended (:obj:`~pyrogram.types.VideoChatEnded`, *optional*):
             Service message: the voice chat has ended.
 
-        video_chat_members_invited (:obj:`~pyrogram.types.VoiceChatParticipantsInvited`, *optional*):
+        video_chat_members_invited (:obj:`~pyrogram.types.VideoChatMembersInvited`, *optional*):
             Service message: new members were invited to the voice chat.
 
         phone_call_started (:obj:`~pyrogram.types.PhoneCallStarted`, *optional*):
@@ -570,7 +570,7 @@ class Message(Object, Update):
         chat_has_protected_content_toggled (:obj:`~pyrogram.types.ChatHasProtectedContentToggled`, *optional*):
             Service message: An ``has_protected_content`` setting was changed or request to change it was rejected in a chat.
 
-        chat_has_protected_content_disable_requested (:obj:`~pyrogram.types.ChatProtectedContentDisableRequested`, *optional*):
+        chat_has_protected_content_disable_requested (:obj:`~pyrogram.types.ChatHasProtectedContentDisableRequested`, *optional*):
             Service message: An process requested to disable ``has_protected_content`` in a chat.
 
         business_connection_id (``str``, *optional*):
@@ -4398,8 +4398,7 @@ class Message(Object, Update):
                 The number of Telegram Stars the user agreed to pay to send the messages.
 
         Returns:
-            On success, a :obj:`~pyrogram.types.Messages` object is returned containing all the
-            single messages sent.
+            List of :obj:`~pyrogram.types.Message`: On success, a list of the sent messages is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -4460,8 +4459,7 @@ class Message(Object, Update):
                 The number of Telegram Stars the user agreed to pay to send the messages.
 
         Returns:
-            On success, a :obj:`~pyrogram.types.Messages` object is returned containing all the
-            single messages sent.
+            List of :obj:`~pyrogram.types.Message`: On success, a list of the sent messages is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.
@@ -8756,8 +8754,8 @@ class Message(Object, Update):
 
         Returns:
             -   The result of :meth:`~pyrogram.Client.request_callback_answer` in case of inline callback button clicks.
-            -   ``None`` in case of normal button clicks: the label is sent with :meth:`~Message.reply()` or
-                :meth:`~Message.answer()`, whose result is not passed on.
+            -   ``None`` in case of normal button clicks: the label is sent with :meth:`~pyrogram.types.Message.reply` or
+                :meth:`~pyrogram.types.Message.answer`, whose result is not passed on.
             -   A string in case the inline button is a URL, a *switch_inline_query*,
                 *switch_inline_query_current_chat* or a *copy_text* button.
             -   A string URL with the user details, in case of a WebApp button.

--- a/pyrogram/types/messages_and_media/message_reactions.py
+++ b/pyrogram/types/messages_and_media/message_reactions.py
@@ -38,7 +38,7 @@ class MessageReactions(Object):
             Information about top users that added the paid reaction.
 
         can_get_added_reactions (``bool``, *optional*):
-            True, if the list of added reactions is available using :meth:`~pyrogram.Client.get_message_added_reactions`.
+            True, if the list of added reactions is available.
     """
 
     # TODO: Add get_message_added_reactions method

--- a/pyrogram/types/messages_and_media/payment_form.py
+++ b/pyrogram/types/messages_and_media/payment_form.py
@@ -76,7 +76,7 @@ class PaymentForm(Object):
         native_provider (``str``, *optional*):
             Payment provider name.
 
-        raw (:obj:`~raw.base.payments.PaymentForm`, *optional*):
+        raw (:obj:`~pyrogram.raw.base.payments.PaymentForm`, *optional*):
             The raw object, as received from the Telegram API.
     """
 

--- a/pyrogram/types/messages_and_media/story.py
+++ b/pyrogram/types/messages_and_media/story.py
@@ -974,8 +974,7 @@ class Story(Object, Update):
                 Users will receive a notification with no sound.
 
         Returns:
-            On success, a :obj:`~pyrogram.types.Messages` object is returned containing all the
-            single messages sent.
+            List of :obj:`~pyrogram.types.Message`: On success, a list of the sent messages is returned.
 
         Raises:
             RPCError: In case of a Telegram RPC error.

--- a/pyrogram/types/messages_and_media/successful_payment.py
+++ b/pyrogram/types/messages_and_media/successful_payment.py
@@ -46,8 +46,8 @@ class SuccessfulPayment(Object):
         shipping_option_id (``str``, *optional*):
             Identifier of the shipping option chosen by the user. Only available to the bot that received the payment.
 
-        payment_info (:obj:`~pyrogram.types.PaymentInfo`, *optional*):
-            Payment information provided by the user. Only available to the bot that received the payment.
+        order_info (:obj:`~pyrogram.types.OrderInfo`, *optional*):
+            Order information provided by the user. Only available to the bot that received the payment.
 
         is_recurring (``bool``, *optional*):
             True, if the payment is a recurring payment for a subscription.

--- a/pyrogram/types/messages_and_media/upgraded_gift_attribute_id.py
+++ b/pyrogram/types/messages_and_media/upgraded_gift_attribute_id.py
@@ -27,9 +27,9 @@ class UpgradedGiftAttributeId(Object):
 
     It can be one of:
 
-    - :obj:`~pyrogram.types.UpgradedfGiftAttributeIdModel`
-    - :obj:`~pyrogram.types.UpgradedfGiftAttributeIdSymbol`
-    - :obj:`~pyrogram.types.UpgradedfGiftAttributeIdBackdrop`
+    - :obj:`~pyrogram.types.UpgradedGiftAttributeIdModel`
+    - :obj:`~pyrogram.types.UpgradedGiftAttributeIdSymbol`
+    - :obj:`~pyrogram.types.UpgradedGiftAttributeIdBackdrop`
     """
 
     def __init__(

--- a/pyrogram/types/object.py
+++ b/pyrogram/types/object.py
@@ -34,7 +34,7 @@ class Object:
         """Bind a Client instance to this and to all nested Pyrogram objects.
 
         Parameters:
-            client (:obj:`~pyrogram.types.Client`):
+            client (:obj:`~pyrogram.Client`):
                 The Client instance to bind this object with. Useful to re-enable bound methods after serializing and
                 deserializing Pyrogram objects with ``repr`` and ``eval``.
         """

--- a/pyrogram/types/user_and_chats/business_connection.py
+++ b/pyrogram/types/user_and_chats/business_connection.py
@@ -42,8 +42,8 @@ class BusinessConnection(Object):
         is_enabled (``bool``, *optional*):
             True, if the connection is active.
 
-        permissions (:obj:`~pyrogram.types.BusinessBotPermissions`, *optional*):
-            Permissions for the business bot.
+        rights (:obj:`~pyrogram.types.BusinessBotRights`, *optional*):
+            Rights of the business bot.
     """
 
     def __init__(

--- a/pyrogram/types/user_and_chats/chat_event.py
+++ b/pyrogram/types/user_and_chats/chat_event.py
@@ -133,15 +133,15 @@ class ChatEvent(Object):
 
         created_forum_topic (:obj:`~pyrogram.types.ForumTopic`, *optional*):
             New forum topic.
-            For :obj:`~pyrogram.enums.ChatEvenAction.CREATED_FORUM_TOPIC` action only.
+            For :obj:`~pyrogram.enums.ChatEventAction.CREATED_FORUM_TOPIC` action only.
 
         old_forum_topic, new_forum_topic (:obj:`~pyrogram.types.ForumTopic`, *optional*):
             Edited forum topic.
-            For :obj:`~pyrogram.enums.ChatEvenAction.EDITED_FORUM_TOPIC` action only.
+            For :obj:`~pyrogram.enums.ChatEventAction.EDITED_FORUM_TOPIC` action only.
 
         deleted_forum_topic (:obj:`~pyrogram.types.ForumTopic`, *optional*):
             Deleted forum topic.
-            For :obj:`~pyrogram.enums.ChatEvenAction.DELETED_FORUM_TOPIC` action only.
+            For :obj:`~pyrogram.enums.ChatEventAction.DELETED_FORUM_TOPIC` action only.
     """
 
     def __init__(

--- a/pyrogram/types/user_and_chats/chat_folder_invite_link_info.py
+++ b/pyrogram/types/user_and_chats/chat_folder_invite_link_info.py
@@ -28,7 +28,7 @@ class ChatFolderInviteLinkInfo(Object):
     """Contains information about an invite link to a chat folder.
 
     Parameters:
-        chat_folder_info (:obj:`~pyrogram.types.ChatFolderInfo`):
+        chat_folder_info (:obj:`~pyrogram.types.Folder`):
             Basic information about the chat folder.
             Chat folder identifier will be None if the user didn't have the chat folder yet.
 

--- a/pyrogram/types/user_and_chats/chat_settings.py
+++ b/pyrogram/types/user_and_chats/chat_settings.py
@@ -73,7 +73,7 @@ class ChatSettings(Object):
         request_chat_date (:py:obj:`~datetime.datetime`, *optional*):
             Date when join request was sent.
 
-        business_bot (:obj:`types.User`, *optional*):
+        business_bot (:obj:`~pyrogram.types.User`, *optional*):
             Business bot that manages this chat.
 
         business_bot_manage_url (``str``, *optional*):

--- a/tests/unit/test_docstring_references.py
+++ b/tests/unit/test_docstring_references.py
@@ -1,0 +1,143 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Every Sphinx cross-reference in a docstring points at something that exists.
+
+Sphinx does not fail on a target it cannot resolve: it renders the text as a plain literal
+and carries on, so a dead reference looks almost right and nothing reports it.
+"""
+
+import ast
+import importlib
+import pathlib
+import re
+from typing import Final, Iterator, List, NamedTuple, Pattern, Set, Tuple
+
+_REPOSITORY_ROOT: Final[pathlib.Path] = pathlib.Path(__file__).resolve().parents[2]
+_PACKAGE_ROOT: Final[pathlib.Path] = _REPOSITORY_ROOT / "pyrogram"
+
+# The generated tree is rewritten wholesale by `make api` from the TL schema, so a repair
+#  there lives until the next schema update and no longer.
+_GENERATED_TREE: Final[pathlib.Path] = _PACKAGE_ROOT / "raw"
+
+# `:obj:`Message`` and `:py:obj:`Message`` are the same role, the second one naming the
+#  domain the first one inherits.
+#  https://www.sphinx-doc.org/en/master/usage/domains/python.html#cross-referencing-python-objects
+_CROSS_REFERENCE: Final[Pattern[str]] = re.compile(r":(?:py:)?(?:obj|class|meth|func|attr|data|mod|exc):`([^`]+)`")
+
+_DOCUMENTED_NODES: Final[Tuple[type, ...]] = (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+
+
+class Reference(NamedTuple):
+    target: str
+    path: pathlib.Path
+    line: int
+
+    def __str__(self) -> str:
+        return "{}:{}: {}".format(self.path.relative_to(_REPOSITORY_ROOT), self.line, self.target)
+
+
+def targets_in(text: str) -> Iterator[str]:
+    """Take the target out of every cross-reference in `text`, both of its two forms."""
+    for body in _CROSS_REFERENCE.findall(text):
+        # A reference is either a target with the text to print in front of it, or a bare
+        #  target that is both at once.
+        target = body.rpartition("<")[2].rstrip(">") if "<" in body else body
+
+        # A leading `~` prints the last component only and a leading `.` asks Sphinx to
+        #  search; neither is part of the name. Trailing `()` marks a callable.
+        yield target.strip().lstrip("~.").rstrip("()")
+
+
+def docstrings_of(path: pathlib.Path) -> Iterator[Tuple[str, int]]:
+    lines = path.read_text(encoding="utf-8").splitlines()
+
+    for node in ast.walk(ast.parse("\n".join(lines))):
+        if not isinstance(node, _DOCUMENTED_NODES) or not ast.get_docstring(node):
+            continue
+
+        literal = node.body[0].value
+        yield "\n".join(lines[literal.lineno - 1 : literal.end_lineno]), literal.lineno
+
+
+def hand_written_references() -> List[Reference]:
+    references: List[Reference] = []
+
+    for path in sorted(_PACKAGE_ROOT.rglob("*.py")):
+        if _GENERATED_TREE in path.parents:
+            continue
+
+        for docstring, first_line in docstrings_of(path):
+            for offset, line in enumerate(docstring.splitlines()):
+                for target in targets_in(line):
+                    references.append(Reference(target, path, first_line + offset))
+
+    return references
+
+
+def resolves(target: str) -> bool:
+    """Import the longest prefix of `target`, then walk the rest of it with `getattr`."""
+    parts = target.split(".")
+
+    for cut in range(len(parts), 0, -1):
+        try:
+            resolved = importlib.import_module(".".join(parts[:cut]))
+        except ImportError:
+            continue
+
+        for name in parts[cut:]:
+            if not hasattr(resolved, name):
+                return False
+
+            resolved = getattr(resolved, name)
+
+        return True
+
+    return False
+
+
+def test_every_cross_reference_in_a_docstring_resolves() -> None:
+    """A docstring is rendered on whichever page includes it, so its targets are absolute.
+
+    An unqualified target is resolved against the `currentmodule` of that page, which the
+    docstring cannot see: `Client.forward_messages` links on a method page and dies on a
+    type page.
+    """
+    dead = sorted({str(one) for one in hand_written_references() if not resolves(one.target)})
+
+    assert not dead, "{} cross-references point at nothing:\n{}".format(len(dead), "\n".join(dead))
+
+
+def test_the_sweep_reads_the_docstrings_it_claims_to() -> None:
+    """A regex that stopped matching would leave the test above passing over nothing."""
+    references = hand_written_references()
+    targets: Set[str] = {one.target for one in references}
+
+    assert len(targets) > 500
+    assert "pyrogram.types.Message" in targets
+    assert any(one.path.name == "get_chat_history.py" for one in references)
+
+
+def test_a_target_that_does_not_exist_does_not_resolve() -> None:
+    assert resolves("pyrogram.types.Message")
+    assert resolves("pyrogram.Client.forward_messages")
+    assert resolves("datetime.datetime")
+
+    assert not resolves("pyrogram.types.Message.no_such_method")
+    assert not resolves("pyrogram.types.NoSuchType")
+    assert not resolves("Message.reply")


### PR DESCRIPTION

## What

A `:obj:` whose target does not resolve is not an error for Sphinx. It renders the
text as a plain literal and moves on, so a dead reference looks almost right and
nothing in the build, the linter or the test suite reports it.

Both of these are on the published page for `answer_shipping_query`. The first
resolves and is a link; the second does not and is a grey box:

    <a class="reference internal" href="../../handlers/#pyrogram.handlers.ShippingQueryHandler"
       title="pyrogram.handlers.ShippingQueryHandler"><code class="xref py py-obj
       docutils literal notranslate"><span class="pre">ShippingQueryHandler</span></code></a>

    <strong>shipping_options</strong> (List of <code class="xref py py-obj docutils
       literal notranslate"><span class="pre">ShippingOptions</span></code>, <em>optional</em>)

The class is `ShippingOption`, singular. There is no `ShippingOptions`.

Resolving every `:obj:` / `:class:` / `:meth:` / `:func:` / `:attr:` / `:data:` /
`:mod:` / `:exc:` target in the hand-written docstrings against the imported
package finds **72 such uses, 39 distinct targets, across 57 files**:

    AssertionError: 72 cross-references point at nothing:
      pyrogram/client.py:256: pyrogram.raw.base.JsonValue
      pyrogram/handlers/business_connection_handler.py:41: Filters
      pyrogram/handlers/callback_query_handler.py:40: Filters
      pyrogram/methods/advanced/invoke.py:34: pyrogram.api.functions
      pyrogram/types/user_and_chats/chat_event.py:136: pyrogram.enums.ChatEvenAction.CREATED_FORUM_TOPIC
      pyrogram/types/messages_and_media/story.py:977: pyrogram.types.Messages
      ...

After this change:

    3 passed

They fall into five kinds:

- **Typos.** `ChatEvenAction` (missing the `t`), `UpgradedfGiftAttributeId*` (a
  stray `f`), `raw.base.JsonValue` (the export is `JSONValue`),
  `ChatAdminWithInviteLink` (missing the plural), `ShippingOptions` (the class is
  singular).
- **The pre-1.0 namespace.** `pyrogram.api.functions` and `pyrogram.api.types`,
  gone since 1.0; `pyrogram.Filters.regex`, which is `pyrogram.filters.regex`.
- **A name in the wrong module.** `types.ParseMode` is `enums.ParseMode`,
  `enums.FormattedText` is `types.FormattedText`, `types.Client` is
  `pyrogram.Client`.
- **A renamed type.** `VoiceChatParticipantsInvited` is
  `VideoChatMembersInvited`, `ChatFolderInfo` is `Folder`,
  `InputInvoice{ApplePay,GooglePay,New}` are `InputCredentials*`,
  `ChatProtectedContentDisableRequested` is
  `ChatHasProtectedContentDisableRequested`.
- **An unqualified target on a page whose `currentmodule` cannot resolve it.**
  ``:obj:`Filters` `` in every handler, ``:obj:`types.User` ``,
  ``:meth:`~Client.forward_messages` ``. A docstring is rendered on whichever
  page includes it, so its targets have to be absolute.

Three were not renames, because the docstring documented a parameter the class
does not have:

- `BusinessConnection` documented `permissions (BusinessBotPermissions)`; the
  parameter is `rights: Optional["types.BusinessBotRights"]`.
- `SuccessfulPayment` documented `payment_info (PaymentInfo)`; the parameter is
  `order_info: Optional["types.OrderInfo"]`.
- `MessageReactionCountUpdated` documented `reactions (ReactionCount)`; it is
  built from `types.Reaction._parse_count`, so it is a list of `Reaction`.

Two references were removed rather than guessed at:
`Client.get_message_added_reactions`, which has a `# TODO` for the method right
below it, and `types.Messages`, which never existed. The three sites returning a
list of messages now use the wording `send_media_group` already uses.

The second commit adds `tests/unit/test_docstring_references.py`, which is what
keeps this fixed: it extracts every cross-reference from every hand-written
docstring and resolves the dotted path by importing the longest prefix that
imports and walking the remainder with `getattr`, the same order Sphinx uses.
The generated `pyrogram/raw/**` is excluded with a one-line reason, since `make
api` rewrites that tree wholesale.

## Why

Renaming a type today silently breaks every docstring that named it, and the
build stays green. There are 39 such names in the tree right now.

## How to test

    make lint
    make test-unit

431 passed, 7 deselected. The new file adds three tests; the first one fails with
the list above when run against the tree before the first commit.
