### PR TITLE
fix(typing): stream_media return type annotation to AsyncGenerator

### DIFF
--- a/pyrogram/methods/messages/stream_media.py
+++ b/pyrogram/methods/messages/stream_media.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import math
-from typing import AsyncIterator, Union
+from typing import AsyncGenerator, Union
 
 import pyrogram
 from pyrogram import types
@@ -30,7 +30,7 @@ class StreamMedia:
         message: Union["types.Message", str],
         limit: int = 0,
         offset: int = 0
-    ) -> AsyncIterator[bytes]:
+    ) -> AsyncGenerator[bytes, None]:
         """Stream the media from a message chunk by chunk.
 
         You can use this method to partially download a file into memory or to selectively download chunks of file.


### PR DESCRIPTION
## Summary

`stream_media()` is implemented with `yield` (it delegates to `get_file`, also a generator), so it returns an `AsyncGenerator[bytes, None]` at runtime — not just an `AsyncIterator[bytes]`, which is what it's currently annotated to return.

`AsyncIterator` only guarantees `__anext__`/`__aiter__`; it has no `aclose()`. `AsyncGenerator` does.

This matters for consumers that need to release resources early — e.g. an HTTP video-streaming proxy where the client seeks and abandons the current byte range mid-download. Calling `.aclose()` on the returned object is the correct way to stop consuming and release `get_file_semaphore` (bounded by `max_concurrent_transmissions`) immediately, instead of waiting for the generator to be garbage-collected. Static type checkers correctly reject `.aclose()` given the current `AsyncIterator[bytes]` annotation, forcing callers to `cast()` around it.

Fixes #386

## Test plan

- [x] `from typing import AsyncGenerator` compiles, no other usages of `AsyncIterator` left in the file
- [x] Signature-only change — no behavioral difference at runtime (`stream_media` still works exactly as before; only the static type improves)