### PR TITLE
fix(typing): default `effect_id` and `is_enabled` to `None`, not to the `NoneType` class

### DIFF
--- a/pyrogram/methods/chats/set_chat_direct_messages_group.py
+++ b/pyrogram/methods/chats/set_chat_direct_messages_group.py
@@ -27,7 +27,7 @@ class SetChatDirectMessagesGroup:
         self: "pyrogram.Client",
         chat_id: Union[int, str],
         paid_message_star_count: int = 0,
-        is_enabled: bool = Optional[None],
+        is_enabled: Optional[bool] = None,
     ) -> bool:
         """Change direct messages group settings for a channel chat.
 

--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -3703,7 +3703,7 @@ class Message(Object, Update):
         self,
         game_short_name: str,
         disable_notification: Optional[bool] = None,
-        effect_id: int = Optional[None],
+        effect_id: Optional[int] = None,
         allow_paid_broadcast: Optional[bool] = None,
         reply_markup: Optional[
             Union[
@@ -3769,7 +3769,7 @@ class Message(Object, Update):
         self,
         game_short_name: str,
         disable_notification: Optional[bool] = None,
-        effect_id: int = Optional[None],
+        effect_id: Optional[int] = None,
         reply_parameters: Optional["types.ReplyParameters"] = None,
         allow_paid_broadcast: Optional[bool] = None,
         reply_markup: Optional[


### PR DESCRIPTION
## What

Three parameters were written `name: T = Optional[None]` — the annotation landed on the
right of the `=`, so the default is not `None` but `typing.Optional[None]`, which evaluates
to the `NoneType` class. That class is truthy, so a caller who passes nothing gets a class
where the schema wants a value:

    >>> await message.reply_game("lumberjack")
    AttributeError: type object 'NoneType' has no attribute 'to_bytes'

    >>> await app.set_chat_direct_messages_group(-1001, paid_message_star_count=5)
    broadcast_messages_allowed=<class 'NoneType'>, flag bit 0 set=True

After:

    >>> await message.reply_game("lumberjack")
    serialised 116 bytes, effect=None

    >>> await app.set_chat_direct_messages_group(-1001, paid_message_star_count=5)
    broadcast_messages_allowed=None, flag bit 0 set=False

`effect_id` in `Message.reply_game` and `Message.answer_game` feeds `effect`, a
`flags.N?long`, so the writer calls `.to_bytes` on the class and every call raises.
`is_enabled` in `Client.set_chat_direct_messages_group` feeds `broadcast_messages_allowed`,
a `flags.0?true`, so the bit went out set on every call that left the parameter alone.

Both are annotated `Optional[...]` and default to `None` now. Nothing else changes; the
three lines are the whole diff.

## How to test

`make lint` and `make test-unit` (440 passed).
