### PR TITLE
feat(message): accept the target's remaining parameters in the `reply_*`/`answer_*` shortcuts

### DIFF
--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -3704,6 +3704,7 @@ class Message(Object, Update):
         game_short_name: str,
         disable_notification: Optional[bool] = None,
         effect_id: int = Optional[None],
+        protect_content: Optional[bool] = None,
         allow_paid_broadcast: Optional[bool] = None,
         reply_markup: Optional[
             Union[
@@ -3737,6 +3738,9 @@ class Message(Object, Update):
                 Unique identifier of the message effect.
                 For private chats only.
 
+            protect_content (``bool``, *optional*):
+                Protects the contents of the sent message from forwarding and saving.
+
             allow_paid_broadcast (``bool``, *optional*):
                 If True, you will be allowed to send up to 1000 messages per second.
                 Ignoring broadcasting limits for a fee of 0.1 Telegram Stars per message.
@@ -3761,6 +3765,7 @@ class Message(Object, Update):
             message_thread_id=self.message_thread_id,
             effect_id=effect_id,
             reply_parameters=types.ReplyParameters(message_id=self.id),
+            protect_content=protect_content,
             allow_paid_broadcast=allow_paid_broadcast,
             reply_markup=reply_markup,
         )
@@ -3771,6 +3776,7 @@ class Message(Object, Update):
         disable_notification: Optional[bool] = None,
         effect_id: int = Optional[None],
         reply_parameters: Optional["types.ReplyParameters"] = None,
+        protect_content: Optional[bool] = None,
         allow_paid_broadcast: Optional[bool] = None,
         reply_markup: Optional[
             Union[
@@ -3810,6 +3816,9 @@ class Message(Object, Update):
             reply_parameters (:obj:`~pyrogram.types.ReplyParameters`, *optional*):
                 Describes reply parameters for the message that is being sent.
 
+            protect_content (``bool``, *optional*):
+                Protects the contents of the sent message from forwarding and saving.
+
             allow_paid_broadcast (``bool``, *optional*):
                 If True, you will be allowed to send up to 1000 messages per second.
                 Ignoring broadcasting limits for a fee of 0.1 Telegram Stars per message.
@@ -3834,6 +3843,7 @@ class Message(Object, Update):
             message_thread_id=self.message_thread_id,
             effect_id=effect_id,
             reply_parameters=reply_parameters,
+            protect_content=protect_content,
             allow_paid_broadcast=allow_paid_broadcast,
             reply_markup=reply_markup
         )
@@ -4478,6 +4488,9 @@ class Message(Object, Update):
         media: List[Union["types.InputMediaPhoto", "types.InputMediaVideo"]],
         disable_notification: Optional[bool] = None,
         effect_id: Optional[int] = None,
+        schedule_date: Optional[datetime] = None,
+        protect_content: Optional[bool] = None,
+        show_caption_above_media: Optional[bool] = None,
         allow_paid_broadcast: Optional[bool] = None,
         paid_message_star_count: Optional[int] = None,
     ) -> List["types.Message"]:
@@ -4503,6 +4516,15 @@ class Message(Object, Update):
                 Unique identifier of the message effect.
                 For private chats only.
 
+            schedule_date (:py:obj:`~datetime.datetime`, *optional*):
+                Date when the message will be automatically sent.
+
+            protect_content (``bool``, *optional*):
+                Protects the contents of the sent message from forwarding and saving.
+
+            show_caption_above_media (``bool``, *optional*):
+                Pass True, if the caption must be shown above the message media.
+
             allow_paid_broadcast (``bool``, *optional*):
                 If True, you will be allowed to send up to 1000 messages per second.
                 Ignoring broadcasting limits for a fee of 0.1 Telegram Stars per message.
@@ -4526,6 +4548,9 @@ class Message(Object, Update):
             direct_messages_topic_id=self.direct_messages_topic_id,
             effect_id=effect_id,
             reply_parameters=types.ReplyParameters(message_id=self.id),
+            schedule_date=schedule_date,
+            protect_content=protect_content,
+            show_caption_above_media=show_caption_above_media,
             allow_paid_broadcast=allow_paid_broadcast,
             paid_message_star_count=paid_message_star_count,
             business_connection_id=self.business_connection_id,
@@ -4537,6 +4562,9 @@ class Message(Object, Update):
         disable_notification: Optional[bool] = None,
         effect_id: Optional[int] = None,
         reply_parameters: Optional["types.ReplyParameters"] = None,
+        schedule_date: Optional[datetime] = None,
+        protect_content: Optional[bool] = None,
+        show_caption_above_media: Optional[bool] = None,
         allow_paid_broadcast: Optional[bool] = None,
         paid_message_star_count: Optional[int] = None
     ) -> List["types.Message"]:
@@ -4564,6 +4592,15 @@ class Message(Object, Update):
             reply_parameters (:obj:`~pyrogram.types.ReplyParameters`, *optional*):
                 Describes reply parameters for the message that is being sent.
 
+            schedule_date (:py:obj:`~datetime.datetime`, *optional*):
+                Date when the message will be automatically sent.
+
+            protect_content (``bool``, *optional*):
+                Protects the contents of the sent message from forwarding and saving.
+
+            show_caption_above_media (``bool``, *optional*):
+                Pass True, if the caption must be shown above the message media.
+
             allow_paid_broadcast (``bool``, *optional*):
                 If True, you will be allowed to send up to 1000 messages per second.
                 Ignoring broadcasting limits for a fee of 0.1 Telegram Stars per message.
@@ -4587,6 +4624,9 @@ class Message(Object, Update):
             direct_messages_topic_id=self.direct_messages_topic_id,
             effect_id=effect_id,
             reply_parameters=reply_parameters,
+            schedule_date=schedule_date,
+            protect_content=protect_content,
+            show_caption_above_media=show_caption_above_media,
             allow_paid_broadcast=allow_paid_broadcast,
             paid_message_star_count=paid_message_star_count,
             business_connection_id=self.business_connection_id
@@ -7879,6 +7919,11 @@ class Message(Object, Update):
         parse_mode: Optional["enums.ParseMode"] = None,
         caption_entities: Optional[List["types.MessageEntity"]] = None,
         disable_notification: Optional[bool] = None,
+        schedule_date: Optional[datetime] = None,
+        protect_content: Optional[bool] = None,
+        has_spoiler: Optional[bool] = None,
+        effect_id: Optional[int] = None,
+        show_caption_above_media: Optional[bool] = None,
         allow_paid_broadcast: Optional[bool] = None,
         paid_message_star_count: Optional[int] = None,
         suggested_post_parameters: Optional["types.SuggestedPostParameters"] = None,
@@ -7918,6 +7963,22 @@ class Message(Object, Update):
                 Sends the message silently.
                 Users will receive a notification with no sound.
 
+            schedule_date (:py:obj:`~datetime.datetime`, *optional*):
+                Date when the message will be automatically sent.
+
+            protect_content (``bool``, *optional*):
+                Protects the contents of the sent message from forwarding and saving.
+
+            has_spoiler (``bool``, *optional*):
+                True, if the message media is covered by a spoiler animation.
+
+            effect_id (``int``, *optional*):
+                Unique identifier of the message effect.
+                For private chats only.
+
+            show_caption_above_media (``bool``, *optional*):
+                Pass True, if the caption must be shown above the message media.
+
             allow_paid_broadcast (``bool``, *optional*):
                 If True, you will be allowed to send up to 1000 messages per second.
                 Ignoring broadcasting limits for a fee of 0.1 Telegram Stars per message.
@@ -7951,6 +8012,11 @@ class Message(Object, Update):
             message_thread_id=self.message_thread_id,
             direct_messages_topic_id=self.direct_messages_topic_id,
             reply_parameters=types.ReplyParameters(message_id=self.id),
+            schedule_date=schedule_date,
+            protect_content=protect_content,
+            has_spoiler=has_spoiler,
+            effect_id=effect_id,
+            show_caption_above_media=show_caption_above_media,
             business_connection_id=self.business_connection_id,
             allow_paid_broadcast=allow_paid_broadcast,
             paid_message_star_count=paid_message_star_count,
@@ -7966,6 +8032,11 @@ class Message(Object, Update):
         caption_entities: Optional[List["types.MessageEntity"]] = None,
         disable_notification: Optional[bool] = None,
         reply_parameters: Optional["types.ReplyParameters"] = None,
+        schedule_date: Optional[datetime] = None,
+        protect_content: Optional[bool] = None,
+        has_spoiler: Optional[bool] = None,
+        effect_id: Optional[int] = None,
+        show_caption_above_media: Optional[bool] = None,
         allow_paid_broadcast: Optional[bool] = None,
         paid_message_star_count: Optional[int] = None,
         suggested_post_parameters: Optional["types.SuggestedPostParameters"] = None,
@@ -8007,6 +8078,22 @@ class Message(Object, Update):
             reply_parameters (:obj:`~pyrogram.types.ReplyParameters`, *optional*):
                 Describes reply parameters for the message that is being sent.
 
+            schedule_date (:py:obj:`~datetime.datetime`, *optional*):
+                Date when the message will be automatically sent.
+
+            protect_content (``bool``, *optional*):
+                Protects the contents of the sent message from forwarding and saving.
+
+            has_spoiler (``bool``, *optional*):
+                True, if the message media is covered by a spoiler animation.
+
+            effect_id (``int``, *optional*):
+                Unique identifier of the message effect.
+                For private chats only.
+
+            show_caption_above_media (``bool``, *optional*):
+                Pass True, if the caption must be shown above the message media.
+
             allow_paid_broadcast (``bool``, *optional*):
                 If True, you will be allowed to send up to 1000 messages per second.
                 Ignoring broadcasting limits for a fee of 0.1 Telegram Stars per message.
@@ -8040,6 +8127,11 @@ class Message(Object, Update):
             message_thread_id=self.message_thread_id,
             direct_messages_topic_id=self.direct_messages_topic_id,
             reply_parameters=reply_parameters,
+            schedule_date=schedule_date,
+            protect_content=protect_content,
+            has_spoiler=has_spoiler,
+            effect_id=effect_id,
+            show_caption_above_media=show_caption_above_media,
             business_connection_id=self.business_connection_id,
             allow_paid_broadcast=allow_paid_broadcast,
             paid_message_star_count=paid_message_star_count,
@@ -8096,6 +8188,7 @@ class Message(Object, Update):
         result_id: str,
         disable_notification: Optional[bool] = None,
         paid_message_star_count: Optional[int] = None,
+        schedule_date: Optional[datetime] = None,
     ) -> Optional["Message"]:
         """Shortcut for method :obj:`~pyrogram.Client.send_inline_bot_result` will automatically fill method attributes:
 
@@ -8118,6 +8211,9 @@ class Message(Object, Update):
             paid_message_star_count (``int``, *optional*):
                 The number of Telegram Stars the user agreed to pay to send the messages.
 
+            schedule_date (:py:obj:`~datetime.datetime`, *optional*):
+                Date when the message will be automatically sent.
+
         Returns:
             :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
             server answered with no message, None is returned.
@@ -8134,6 +8230,7 @@ class Message(Object, Update):
             direct_messages_topic_id=self.direct_messages_topic_id,
             reply_parameters=types.ReplyParameters(message_id=self.id),
             paid_message_star_count=paid_message_star_count,
+            schedule_date=schedule_date,
         )
 
     async def answer_inline_bot_result(
@@ -8142,7 +8239,8 @@ class Message(Object, Update):
         result_id: str,
         disable_notification: Optional[bool] = None,
         reply_parameters: Optional["types.ReplyParameters"] = None,
-        paid_message_star_count: Optional[int] = None
+        paid_message_star_count: Optional[int] = None,
+        schedule_date: Optional[datetime] = None
     ) -> Optional["Message"]:
         """Shortcut for method :obj:`~pyrogram.Client.send_inline_bot_result` will automatically fill method attributes:
 
@@ -8167,6 +8265,9 @@ class Message(Object, Update):
             paid_message_star_count (``int``, *optional*):
                 The number of Telegram Stars the user agreed to pay to send the messages.
 
+            schedule_date (:py:obj:`~datetime.datetime`, *optional*):
+                Date when the message will be automatically sent.
+
         Returns:
             :obj:`~pyrogram.types.Message` | ``None``: On success, the sent message is returned, otherwise, in case the
             server answered with no message, None is returned.
@@ -8182,7 +8283,8 @@ class Message(Object, Update):
             message_thread_id=self.message_thread_id,
             direct_messages_topic_id=self.direct_messages_topic_id,
             reply_parameters=reply_parameters,
-            paid_message_star_count=paid_message_star_count
+            paid_message_star_count=paid_message_star_count,
+            schedule_date=schedule_date
         )
 
     async def reply_checklist(

--- a/tests/unit/types/messages_and_media/test_message_parity.py
+++ b/tests/unit/types/messages_and_media/test_message_parity.py
@@ -1,0 +1,121 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Every `Message.reply_*` and `Message.answer_*` shortcut accepts what its target accepts.
+
+A shortcut that omits a parameter of the `Client.send_*` it wraps cannot reach that feature at
+all, and nothing else reports the gap: both signatures are valid on their own, and the omission
+only shows up as a caller wondering why the option has no effect.
+"""
+
+import inspect
+import re
+import sys
+from types import ModuleType
+from typing import Final, Iterator, List, NamedTuple, Set
+
+import pytest
+
+from pyrogram import Client, types
+
+
+class Shortcut(NamedTuple):
+    """A bound method on `Message` and the client method its docstring says it wraps."""
+
+    name: str
+    target_name: str
+
+
+_TARGET: Final["re.Pattern[str]"] = re.compile(r"Shortcut for method :obj:`~pyrogram\.Client\.(\w+)`")
+
+# The shortcut's own docstring lists what it fills from `self`, one bullet per attribute.
+_FILLED_FROM_SELF: Final["re.Pattern[str]"] = re.compile(r"^\* (\w+)$", re.MULTILINE)
+
+# Each `send_*` module warns about its own retired parameters with this exact wording, so which
+#  ones are retired is read off the target rather than listed here. A name can be deprecated in
+#  one target and current in another: `parse_mode` only feeds `quote_parse_mode` in
+#  `send_contact`, while in `send_photo` it parses the caption.
+_DEPRECATED: Final["re.Pattern[str]"] = re.compile(r"`(\w+)` is deprecated")
+
+
+def shortcut_names() -> List[str]:
+    return sorted(name for name in vars(types.Message) if name.startswith(("reply_", "answer_")))
+
+
+def shortcuts() -> Iterator[Shortcut]:
+    for name in shortcut_names():
+        match = _TARGET.search(inspect.getdoc(vars(types.Message)[name]) or "")
+
+        if match is not None:
+            yield Shortcut(name, match.group(1))
+
+
+_SHORTCUTS: Final[List[Shortcut]] = list(shortcuts())
+
+
+def filled_from_self(shortcut: Shortcut) -> Set[str]:
+    return set(_FILLED_FROM_SELF.findall(inspect.getdoc(getattr(types.Message, shortcut.name)) or ""))
+
+
+def deprecated_in(module: ModuleType) -> Set[str]:
+    return set(_DEPRECATED.findall(inspect.getsource(module)))
+
+
+def parameters_the_caller_must_supply(shortcut: Shortcut) -> List[str]:
+    target = getattr(Client, shortcut.target_name)
+    ignored: Set[str] = filled_from_self(shortcut) | deprecated_in(sys.modules[target.__module__]) | {"self"}
+
+    return [name for name in inspect.signature(target).parameters if name not in ignored]
+
+
+def test_every_shortcut_is_discovered() -> None:
+    # The scan reads the docstring, so a reworded first line would quietly drop a method from
+    #  every check below and leave the suite green.
+    discovered = {shortcut.name for shortcut in _SHORTCUTS}
+
+    assert sorted(discovered) == shortcut_names()
+
+
+@pytest.mark.parametrize("shortcut", _SHORTCUTS, ids=[shortcut.name for shortcut in _SHORTCUTS])
+def test_a_shortcut_names_a_client_method_that_exists(shortcut: Shortcut) -> None:
+    assert hasattr(Client, shortcut.target_name)
+
+
+@pytest.mark.parametrize("shortcut", _SHORTCUTS, ids=[shortcut.name for shortcut in _SHORTCUTS])
+def test_a_shortcut_accepts_everything_its_target_accepts(shortcut: Shortcut) -> None:
+    accepted = set(inspect.signature(getattr(types.Message, shortcut.name)).parameters)
+    missing = [name for name in parameters_the_caller_must_supply(shortcut) if name not in accepted]
+
+    assert not missing
+
+
+@pytest.mark.parametrize("shortcut", _SHORTCUTS, ids=[shortcut.name for shortcut in _SHORTCUTS])
+def test_a_shortcut_forwards_everything_it_accepts(shortcut: Shortcut) -> None:
+    # A parameter in the signature that the call never passes on is worse than a missing one:
+    #  the caller gets no error and the option is dropped.
+    source = inspect.getsource(getattr(types.Message, shortcut.name))
+    accepted = inspect.signature(getattr(types.Message, shortcut.name)).parameters
+    wanted = set(parameters_the_caller_must_supply(shortcut))
+
+    dropped = [
+        name
+        for name in accepted
+        if name in wanted and not re.search(rf"^\s+{name}={name},?$", source, re.MULTILINE)
+    ]
+
+    assert not dropped


### PR DESCRIPTION
## What

Eight `Message` shortcuts omit parameters their `Client.send_*` target accepts, so the
feature is unreachable through the shortcut and the caller gets a `TypeError` rather than a
hint about where it went:

    >>> await message.reply_cached_media("file-id", protect_content=True, has_spoiler=True)
    TypeError: Message.reply_cached_media() got an unexpected keyword argument 'protect_content'

After:

    >>> await message.reply_cached_media("file-id", protect_content=True, has_spoiler=True)
    reply_cached_media forwarded: {'protect_content': True, 'has_spoiler': True}

Twenty parameters in all:

| Shortcut pair | Added |
| --- | --- |
| `reply_game` / `answer_game` | `protect_content` |
| `reply_media_group` / `answer_media_group` | `schedule_date`, `protect_content`, `show_caption_above_media` |
| `reply_cached_media` / `answer_cached_media` | `schedule_date`, `protect_content`, `has_spoiler`, `effect_id`, `show_caption_above_media` |
| `reply_inline_bot_result` / `answer_inline_bot_result` | `schedule_date` |

Each one sits where its target puts it and carries the target's own docstring text, so the
shortcuts keep mirroring the client signature.

## Why the test is shaped this way

`test_message_parity.py` pairs every `reply_*` and `answer_*` with the client method its own
docstring names, subtracts the attributes that docstring lists as filled from `self`, and
subtracts whatever the target's module marks deprecated — so a name deprecated in one target
and current in another is handled per target rather than by a hand-written list. What is left
must be accepted and must be forwarded.

Both halves matter. Run against the tree before this change it reports exactly these twenty;
deleting a single `protect_content=protect_content,` forwarding line fails
`test_a_shortcut_forwards_everything_it_accepts[reply_game]`, which is the failure mode a
signature-only check misses: the caller passes the argument, gets no error, and the option is
dropped. A third check asserts the named client method exists at all.

## Not in here

Ten shortcuts order their shared parameters differently from their target. All of them
forward by keyword, so nothing is broken, and reordering would break callers who pass
positionally — left alone deliberately.

## How to test

`make lint` and `make test-unit` (579 passed).
