### PR TITLE
fix(typing): annotate the async generators as `AsyncGenerator[T, None]`, not `AsyncIterator[T]`

### DIFF
--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -34,7 +34,7 @@ from importlib import import_module
 from io import BytesIO
 from mimetypes import MimeTypes
 from pathlib import Path
-from typing import Any, AsyncIterator, Callable, List, Optional, Type, Union
+from typing import Any, AsyncGenerator, Callable, List, Optional, Type, Union
 
 import pyrogram
 from pyrogram import __license__, __version__, enums, raw, utils
@@ -1138,7 +1138,7 @@ class Client(Methods):
         offset: int = 0,
         progress: Optional[Callable] = None,
         progress_args: tuple = ()
-    ) -> AsyncIterator[bytes]:
+    ) -> AsyncGenerator[bytes, None]:
         async with self.get_file_semaphore:
             file_type = file_id.file_type
 

--- a/pyrogram/methods/business/get_business_account_gifts.py
+++ b/pyrogram/methods/business/get_business_account_gifts.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import AsyncIterator, Optional
+from typing import AsyncGenerator, Optional
 
 import pyrogram
 from pyrogram import raw, types
@@ -39,7 +39,7 @@ class GetBusinessAccountGifts:
         sort_by_price: Optional[bool] = None,
         limit: int = 0,
         offset: str = "",
-    ) -> AsyncIterator["types.Gift"]:
+    ) -> AsyncGenerator["types.Gift", None]:
         """Return the gifts received and owned by a managed business account.
 
         .. note::

--- a/pyrogram/methods/chats/get_chat_event_log.py
+++ b/pyrogram/methods/chats/get_chat_event_log.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, List, AsyncIterator, Optional
+from typing import Union, List, AsyncGenerator, Optional
 
 import pyrogram
 from pyrogram import raw
@@ -32,7 +32,7 @@ class GetChatEventLog:
         limit: int = 0,
         filters: Optional["types.ChatEventFilter"] = None,
         user_ids: Optional[List[Union[int, str]]] = None
-    ) -> AsyncIterator["types.ChatEvent"]:
+    ) -> AsyncGenerator["types.ChatEvent", None]:
         """Get the actions taken by chat members and administrators in the last 48h.
 
         Only available for supergroups and channels. Requires administrator rights.

--- a/pyrogram/methods/chats/get_chat_members.py
+++ b/pyrogram/methods/chats/get_chat_members.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from typing import Union, Optional, AsyncIterator
+from typing import Union, Optional, AsyncGenerator
 
 import pyrogram
 from pyrogram import raw, types, enums
@@ -64,7 +64,7 @@ class GetChatMembers:
         query: str = "",
         limit: int = 0,
         filter: "enums.ChatMembersFilter" = enums.ChatMembersFilter.SEARCH
-    ) -> AsyncIterator["types.ChatMember"]:
+    ) -> AsyncGenerator["types.ChatMember", None]:
         """Get the members list of a chat.
 
         A chat can be either a basic group, a supergroup or a channel.

--- a/pyrogram/methods/chats/get_dialogs.py
+++ b/pyrogram/methods/chats/get_dialogs.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import AsyncIterator, Optional
+from typing import AsyncGenerator, Optional
 
 import pyrogram
 from pyrogram import raw, types, utils
@@ -28,7 +28,7 @@ class GetDialogs:
         limit: int = 0,
         exclude_pinned: Optional[bool] = None,
         from_archive: Optional[bool] = None
-    ) -> AsyncIterator["types.Dialog"]:
+    ) -> AsyncGenerator["types.Dialog", None]:
         """Get a user's dialogs sequentially.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/chats/get_direct_messages_topics.py
+++ b/pyrogram/methods/chats/get_direct_messages_topics.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import AsyncIterator, Optional, Union
+from typing import AsyncGenerator, Optional, Union
 
 import pyrogram
 from pyrogram import raw, types, utils
@@ -28,7 +28,7 @@ class GetDirectMessagesTopics:
         chat_id: Union[int, str],
         limit: int = 0,
         exclude_pinned: Optional[bool] = None
-    ) -> AsyncIterator["types.DirectMessagesTopic"]:
+    ) -> AsyncGenerator["types.DirectMessagesTopic", None]:
         """Get one or more topic from a direct messages channel chat.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/chats/get_forum_topics.py
+++ b/pyrogram/methods/chats/get_forum_topics.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import AsyncIterator, Union
+from typing import AsyncGenerator, Union
 
 import pyrogram
 from pyrogram import raw, types, utils
@@ -27,7 +27,7 @@ class GetForumTopics:
         self: "pyrogram.Client",
         chat_id: Union[int, str],
         limit: int = 0
-    ) -> AsyncIterator["types.ForumTopic"]:
+    ) -> AsyncGenerator["types.ForumTopic", None]:
         """Get one or more topic from a chat.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/chats/get_top_chats.py
+++ b/pyrogram/methods/chats/get_top_chats.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import AsyncIterator
+from typing import AsyncGenerator
 
 import pyrogram
 from pyrogram import enums, raw, types, utils
@@ -27,7 +27,7 @@ class GetTopChats:
         self: "pyrogram.Client",
         category: "enums.TopChatCategory",
         limit: int = 0,
-    ) -> AsyncIterator["types.Chat"]:
+    ) -> AsyncGenerator["types.Chat", None]:
         """Returns a list of frequently used chats.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/contacts/get_blocked_message_senders.py
+++ b/pyrogram/methods/contacts/get_blocked_message_senders.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import AsyncIterator
+from typing import AsyncGenerator
 
 import pyrogram
 from pyrogram import enums, raw, types, utils
@@ -28,7 +28,7 @@ class GetBlockedMessageSenders:
         block_list: "enums.BlockList" = enums.BlockList.MAIN,
         offset: int = 0,
         limit: int = 0,
-    ) -> AsyncIterator["types.Chat"]:
+    ) -> AsyncGenerator["types.Chat", None]:
         """Returns users and chats that were blocked by the current user.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/invite_links/get_chat_admin_invite_links.py
+++ b/pyrogram/methods/invite_links/get_chat_admin_invite_links.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, Optional, AsyncIterator
+from typing import Union, Optional, AsyncGenerator
 
 import pyrogram
 from pyrogram import raw
@@ -30,7 +30,7 @@ class GetChatAdminInviteLinks:
         admin_id: Union[int, str],
         revoked: bool = False,
         limit: int = 0,
-    ) -> AsyncIterator["types.ChatInviteLink"]:
+    ) -> AsyncGenerator["types.ChatInviteLink", None]:
         """Get the invite links created by an administrator in a chat.
 
         .. note::

--- a/pyrogram/methods/invite_links/get_chat_invite_link_joiners.py
+++ b/pyrogram/methods/invite_links/get_chat_invite_link_joiners.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, Optional, AsyncIterator
+from typing import Union, Optional, AsyncGenerator
 
 import pyrogram
 from pyrogram import raw
@@ -29,7 +29,7 @@ class GetChatInviteLinkJoiners:
         chat_id: Union[int, str],
         invite_link: str,
         limit: int = 0
-    ) -> AsyncIterator["types.ChatJoiner"]:
+    ) -> AsyncGenerator["types.ChatJoiner", None]:
         """Get the members who joined the chat with the invite link.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/invite_links/get_chat_join_requests.py
+++ b/pyrogram/methods/invite_links/get_chat_join_requests.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, Optional, AsyncIterator
+from typing import Union, Optional, AsyncGenerator
 
 import pyrogram
 from pyrogram import raw
@@ -29,7 +29,7 @@ class GetChatJoinRequests:
         chat_id: Union[int, str],
         limit: int = 0,
         query: str = ""
-    ) -> AsyncIterator["types.ChatJoiner"]:
+    ) -> AsyncGenerator["types.ChatJoiner", None]:
         """Get the pending join requests of a chat.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/messages/get_chat_history.py
+++ b/pyrogram/methods/messages/get_chat_history.py
@@ -18,7 +18,7 @@
 
 import logging
 from datetime import datetime
-from typing import AsyncIterator, Union, List, Optional
+from typing import AsyncGenerator, Union, List, Optional
 
 import pyrogram
 from pyrogram import raw, types, utils
@@ -81,7 +81,7 @@ class GetChatHistory:
         min_id: int = 0,
         max_id: int = 0,
         reverse: bool = False,
-    ) -> AsyncIterator["types.Message"]:
+    ) -> AsyncGenerator["types.Message", None]:
         """Get messages from a chat history.
 
         The messages are returned in reverse chronological order.

--- a/pyrogram/methods/messages/get_direct_messages_chat_topic_history.py
+++ b/pyrogram/methods/messages/get_direct_messages_chat_topic_history.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 from datetime import datetime
-from typing import AsyncIterator, Union
+from typing import AsyncGenerator, Union
 
 import pyrogram
 from pyrogram import raw, types, utils
@@ -71,7 +71,7 @@ class GetDirectMessagesChatTopicHistory:
         min_id: int = 0,
         max_id: int = 0,
         reverse: bool = False
-    ) -> AsyncIterator["types.Message"]:
+    ) -> AsyncGenerator["types.Message", None]:
         """Return messages in the topic in a channel direct messages chat administered by the current user.
 
         The messages are returned in reverse chronological order.

--- a/pyrogram/methods/messages/get_discussion_replies.py
+++ b/pyrogram/methods/messages/get_discussion_replies.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, Optional, AsyncIterator
+from typing import Union, Optional, AsyncGenerator
 
 import pyrogram
 from pyrogram import types, raw
@@ -28,7 +28,7 @@ class GetDiscussionReplies:
         chat_id: Union[int, str],
         message_id: int,
         limit: int = 0,
-    ) -> AsyncIterator["types.Message"]:
+    ) -> AsyncGenerator["types.Message", None]:
         """Get the message replies of a discussion thread.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/messages/get_user_personal_chat_messages.py
+++ b/pyrogram/methods/messages/get_user_personal_chat_messages.py
@@ -17,7 +17,7 @@
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-from typing import AsyncIterator, Union
+from typing import AsyncGenerator, Union
 
 import pyrogram
 from pyrogram import raw, types, utils
@@ -32,7 +32,7 @@ class GetUserPersonalChatMessages:
         limit: int = 0,
         min_id: int = 0,
         max_id: int = 0,
-    ) -> AsyncIterator["types.Message"]:
+    ) -> AsyncGenerator["types.Message", None]:
         """Use this method to get the last messages from the personal chat (i.e., the chat currently added to their profile) of a given user.
 
         The messages are returned in reverse chronological order.

--- a/pyrogram/methods/messages/search_global.py
+++ b/pyrogram/methods/messages/search_global.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import AsyncIterator, Optional
+from typing import AsyncGenerator, Optional
 
 import pyrogram
 from pyrogram import raw, enums
@@ -33,7 +33,7 @@ class SearchGlobal:
         groups_only: Optional[bool] = None,
         users_only: Optional[bool] = None,
         limit: int = 0,
-    ) -> AsyncIterator["types.Message"]:
+    ) -> AsyncGenerator["types.Message", None]:
         """Search messages globally from all of your chats.
 
         If you want to get the messages count only, see :meth:`~pyrogram.Client.search_global_count`.

--- a/pyrogram/methods/messages/search_messages.py
+++ b/pyrogram/methods/messages/search_messages.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, List, AsyncIterator, Optional
+from typing import Union, List, AsyncGenerator, Optional
 from datetime import datetime
 
 import pyrogram
@@ -81,7 +81,7 @@ class SearchMessages:
         limit: Optional[int] = 0,
         from_user: Optional[Union[int, str]] = None,
         message_thread_id: Optional[int] = None
-    ) -> AsyncIterator["types.Message"]:
+    ) -> AsyncGenerator["types.Message", None]:
         """Search for text and media messages inside a specific chat.
 
         If you want to get the messages count only, see :meth:`~pyrogram.Client.search_messages_count`.

--- a/pyrogram/methods/messages/search_posts.py
+++ b/pyrogram/methods/messages/search_posts.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import AsyncIterator
+from typing import AsyncGenerator
 
 import pyrogram
 from pyrogram import raw
@@ -29,7 +29,7 @@ class SearchPosts:
         self: "pyrogram.Client",
         hashtag: str,
         limit: int = 0,
-    ) -> AsyncIterator["types.Message"]:
+    ) -> AsyncGenerator["types.Message", None]:
         """Search posts globally by hashtag.
 
         If you want to get the posts count only, see :meth:`~pyrogram.Client.search_posts_count`.

--- a/pyrogram/methods/payments/get_chat_gifts.py
+++ b/pyrogram/methods/payments/get_chat_gifts.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, Union, AsyncIterator
+from typing import Optional, Union, AsyncGenerator
 
 import pyrogram
 from pyrogram import raw, types, utils
@@ -38,7 +38,7 @@ class GetChatGifts:
         sort_by_price: Optional[bool] = None,
         limit: int = 0,
         offset: str = ""
-    ) -> AsyncIterator["types.Gift"]:
+    ) -> AsyncGenerator["types.Gift", None]:
         """Get all gifts owned by specified chat.
 
         .. include:: /_includes/usable-by/users-bots.rst

--- a/pyrogram/methods/payments/get_gifts_for_crafting.py
+++ b/pyrogram/methods/payments/get_gifts_for_crafting.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import AsyncIterator
+from typing import AsyncGenerator
 
 import pyrogram
 from pyrogram import raw, types
@@ -27,7 +27,7 @@ class GetGiftsForCrafting:
         self: "pyrogram.Client",
         regular_gift_id: int,
         limit: int = 0
-    ) -> AsyncIterator["types.Gift"]:
+    ) -> AsyncGenerator["types.Gift", None]:
         """Returns upgraded gifts of the current user that can be used to craft another gifts.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/payments/search_gifts_for_resale.py
+++ b/pyrogram/methods/payments/search_gifts_for_resale.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import List, Optional, AsyncIterator
+from typing import List, Optional, AsyncGenerator
 
 import pyrogram
 from pyrogram import enums, raw, types
@@ -32,7 +32,7 @@ class SearchGiftsForResale:
         attributes: Optional[List["types.UpgradedGiftAttributeId"]] = None,
         limit: int = 0,
         offset: str = ""
-    ) -> AsyncIterator["types.Gift"]:
+    ) -> AsyncGenerator["types.Gift", None]:
         """Get upgraded gifts that can be bought from other owners.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/phone/get_call_members.py
+++ b/pyrogram/methods/phone/get_call_members.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Union, AsyncIterator
+from typing import Union, AsyncGenerator
 
 import pyrogram
 from pyrogram import types, raw
@@ -27,7 +27,7 @@ class GetCallMembers:
         self: "pyrogram.Client",
         chat_id: Union[int, str],
         limit: int = 0
-    ) -> AsyncIterator["types.GroupCallMember"]:
+    ) -> AsyncGenerator["types.GroupCallMember", None]:
         """Get the members list of a chat call.
 
         A chat can be either a basic group or a supergroup.

--- a/pyrogram/methods/stories/get_all_stories.py
+++ b/pyrogram/methods/stories/get_all_stories.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import AsyncIterator, Optional
+from typing import AsyncGenerator, Optional
 
 import pyrogram
 from pyrogram import raw
@@ -29,7 +29,7 @@ class GetAllStories:
         next: Optional[bool] = None,
         hidden: Optional[bool] = None,
         state: Optional[str] = None,
-    ) -> AsyncIterator["types.Story"]:
+    ) -> AsyncGenerator["types.Story", None]:
         """Get all active or hidden stories that displayed on the action bar on the homescreen.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/stories/get_archived_stories.py
+++ b/pyrogram/methods/stories/get_archived_stories.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import AsyncIterator, Union
+from typing import AsyncGenerator, Union
 
 import pyrogram
 from pyrogram import raw, types
@@ -28,7 +28,7 @@ class GetArchivedStories:
         chat_id: Union[int, str],
         limit: int = 0,
         offset_id: int = 0
-    ) -> AsyncIterator["types.Story"]:
+    ) -> AsyncGenerator["types.Story", None]:
         """Get all archived stories from a chat by using chat identifier.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/stories/get_chat_stories.py
+++ b/pyrogram/methods/stories/get_chat_stories.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import AsyncIterator, Union
+from typing import AsyncGenerator, Union
 
 import pyrogram
 from pyrogram import raw
@@ -27,7 +27,7 @@ class GetChatStories:
     async def get_chat_stories(
         self: "pyrogram.Client",
         chat_id: Union[int, str]
-    ) -> AsyncIterator["types.Story"]:
+    ) -> AsyncGenerator["types.Story", None]:
         """Get all non expired stories from a chat by using chat identifier.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/stories/get_pinned_stories.py
+++ b/pyrogram/methods/stories/get_pinned_stories.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import AsyncIterator, Union
+from typing import AsyncGenerator, Union
 
 import pyrogram
 from pyrogram import raw
@@ -30,7 +30,7 @@ class GetPinnedStories:
         chat_id: Union[int, str],
         offset_id: int = 0,
         limit: int = 0,
-    ) -> AsyncIterator["types.Story"]:
+    ) -> AsyncGenerator["types.Story", None]:
         """Get all pinned stories from a chat by using chat identifier.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/stories/get_story_views.py
+++ b/pyrogram/methods/stories/get_story_views.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import AsyncIterator, Optional, Union
+from typing import AsyncGenerator, Optional, Union
 
 import pyrogram
 from pyrogram import raw, types
@@ -33,7 +33,7 @@ class GetStoryViews:
         reactions_first: Optional[bool] = None,
         forwards_first: Optional[bool] = None,
         query: Optional[str] = None
-    ) -> AsyncIterator["types.StoryView"]:
+    ) -> AsyncGenerator["types.StoryView", None]:
         """Obtain the list of users that have viewed a specific story we posted.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/users/get_chat_audios.py
+++ b/pyrogram/methods/users/get_chat_audios.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import AsyncIterator, Union
+from typing import AsyncGenerator, Union
 
 import pyrogram
 from pyrogram import raw, types
@@ -27,7 +27,7 @@ class GetChatAudios:
         self: "pyrogram.Client",
         chat_id: Union[int, str],
         limit: int = 0,
-    ) -> AsyncIterator["types.Audio"]:
+    ) -> AsyncGenerator["types.Audio", None]:
         """Get a user profile audios sequentially.
 
         .. include:: /_includes/usable-by/users.rst

--- a/pyrogram/methods/users/get_chat_photos.py
+++ b/pyrogram/methods/users/get_chat_photos.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import AsyncIterator, List, Union
+from typing import AsyncGenerator, List, Union
 
 import pyrogram
 from pyrogram import raw, types, utils
@@ -73,7 +73,7 @@ class GetChatPhotos:
         self: "pyrogram.Client",
         chat_id: Union[int, str],
         limit: int = 0,
-    ) -> AsyncIterator["types.ChatPhoto"]:
+    ) -> AsyncGenerator["types.ChatPhoto", None]:
         """Get a chat or a user profile photos sequentially.
         Personal and public photo aren't returned.
 

--- a/pyrogram/types/user_and_chats/chat.py
+++ b/pyrogram/types/user_and_chats/chat.py
@@ -18,7 +18,7 @@
 
 import logging
 from datetime import datetime
-from typing import AsyncIterator, BinaryIO, Dict, List, Optional, Union
+from typing import AsyncGenerator, BinaryIO, Dict, List, Optional, Union
 
 import pyrogram
 from pyrogram import enums, raw, types, utils
@@ -1937,7 +1937,7 @@ class Chat(Object):
         query: str = "",
         limit: int = 0,
         filter: "enums.ChatMembersFilter" = enums.ChatMembersFilter.SEARCH,
-    ) -> AsyncIterator["types.ChatMember"]:
+    ) -> AsyncGenerator["types.ChatMember", None]:
         """Bound method *get_members* of :obj:`~pyrogram.types.Chat`.
 
         Use as a shortcut for:

--- a/tests/integrations/connection/transport/tcp/conftest.py
+++ b/tests/integrations/connection/transport/tcp/conftest.py
@@ -29,7 +29,7 @@ import time
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import AsyncIterator, Final, List, NamedTuple, Optional, Type
+from typing import AsyncGenerator, AsyncIterator, Final, List, NamedTuple, Optional, Type
 
 import pytest
 
@@ -209,7 +209,7 @@ def unauthorized_client(relay_proxy: WebProxy) -> Client:
 
 
 @pytest.fixture()
-async def client(session_copy: Path, relay_proxy: WebProxy) -> AsyncIterator[Client]:
+async def client(session_copy: Path, relay_proxy: WebProxy) -> AsyncGenerator[Client, None]:
     async with _started_client(session_copy, proxy=relay_proxy) as client:
         yield client
 
@@ -220,7 +220,7 @@ def unauthorized_mtproxy_client(mtproxy_proxy: MTProxy) -> Client:
 
 
 @pytest.fixture()
-async def mtproxy_client(session_copy: Path, mtproxy_proxy: MTProxy) -> AsyncIterator[Client]:
+async def mtproxy_client(session_copy: Path, mtproxy_proxy: MTProxy) -> AsyncGenerator[Client, None]:
     async with _started_client(session_copy, proxy=mtproxy_proxy) as client:
         yield client
 


### PR DESCRIPTION

## What

Every streaming method is an `async def` with `yield`, so it hands back an async generator,
which carries `aclose()`, `asend()` and `athrow()` on top of `__anext__`. Thirty-one are
still annotated `AsyncIterator[T]`, which promises `__anext__` and nothing else, so a caller
that wants to stop consuming early cannot say so without a `cast()`:

    # consume.py
    async def consume() -> None:
        dialogs = client.get_dialogs()
        await dialogs.__anext__()
        await dialogs.aclose()

Before:

    $ mypy --ignore-missing-imports --follow-imports=silent consume.py
    consume.py:9: error: "AsyncIterator[Dialog]" has no attribute "aclose"  [attr-defined]
    Found 1 error in 1 file (checked 1 source file)

After:

    $ mypy --ignore-missing-imports --follow-imports=silent consume.py
    Success: no issues found in 1 source file

That early stop is not hypothetical: `Client.get_file` holds `get_file_semaphore` for its
whole body, so a consumer that abandons a byte range keeps a transmission slot until the
generator is finalized. The paginators hold an open request loop the same way.

The change is the return annotation and the `typing` import, twice per file, and nothing
else. Widening the promise is backward compatible for every caller.

## Why not the other way round

`AsyncIterator[T]` is the right annotation in two places, and neither is one of these:

- **A parameter.** A function that consumes a stream should accept the widest thing that can
  be iterated, so a hand-written class implementing only `__anext__` is not rejected. There
  are no such parameters in the library today.
- **A return that is not a generator** — a hand-written iterator, or a value whose shape is
  not fixed. `_started_client` in the transport tests is `@asynccontextmanager`, which
  `typeshed` types as taking `Callable[_P, AsyncIterator[_T_co]]`, so it keeps its
  annotation.

The second parameter of `AsyncGenerator` is the type `asend()` accepts, not a return type:
an async generator cannot return a value at all, and `return x` inside one is a
`SyntaxError`. `None` there is the ordinary "nothing is ever sent in" case.

## How to test

    make lint
    make test-unit

Then check any streaming method against the runtime object:

    >>> import inspect, pyrogram
    >>> inspect.isasyncgenfunction(inspect.unwrap(pyrogram.Client.get_dialogs))
    True
