### PR TITLE
fix(keyboards): send `KeyboardInlineButtonRow` in `ReplyInlineMarkup`

### DIFF
--- a/pyrogram/types/bots_and_keyboards/inline_keyboard_markup.py
+++ b/pyrogram/types/bots_and_keyboards/inline_keyboard_markup.py
@@ -64,7 +64,7 @@ class InlineKeyboardMarkup(Object):
             for b in r:
                 buttons.append(await b.write(client))
 
-            rows.append(raw.types.KeyboardButtonRow(buttons=buttons))
+            rows.append(raw.types.KeyboardInlineButtonRow(buttons=buttons))
 
         return raw.types.ReplyInlineMarkup(rows=rows, force_reply=self.force_reply)
 

--- a/tests/unit/types/bots_and_keyboards/__init__.py
+++ b/tests/unit/types/bots_and_keyboards/__init__.py
@@ -1,0 +1,17 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.

--- a/tests/unit/types/bots_and_keyboards/test_inline_keyboard_markup.py
+++ b/tests/unit/types/bots_and_keyboards/test_inline_keyboard_markup.py
@@ -1,0 +1,49 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+"""`InlineKeyboardMarkup.write()` builds the constructors the current layer declares.
+
+The expected names are read out of the generated schema rather than spelled out here, so a
+layer that renames either constructor fails this test instead of silently going out on the
+wire as the previous layer's shape.
+"""
+
+from typing import get_args
+
+from pyrogram import raw, types
+
+
+def declared_constructor(tl_type: type, *, field: str) -> str:
+    """Name of the constructor the schema declares for a vector field of `tl_type`."""
+    (forward_ref,) = get_args(tl_type.__init__.__annotations__[field])
+    return forward_ref.__forward_arg__.rsplit(".", 1)[-1]
+
+
+async def test_write_builds_the_constructors_the_schema_declares() -> None:
+    markup = types.InlineKeyboardMarkup(
+        [[types.InlineKeyboardButton("text", callback_data="data")]]
+    )
+
+    built = await markup.write(client=None)
+
+    assert [type(row).__name__ for row in built.rows] == [
+        declared_constructor(raw.types.ReplyInlineMarkup, field="rows")
+    ]
+    assert [type(button).__name__ for button in built.rows[0].buttons] == [
+        declared_constructor(raw.types.KeyboardInlineButtonRow, field="buttons")
+    ]


### PR DESCRIPTION
## What

Layer 229 changed the row type inside `ReplyInlineMarkup` and added a dedicated
constructor for it:

    layer 228: replyInlineMarkup#48a30254 rows:Vector<KeyboardButtonRow> = ReplyMarkup;

    layer 229: replyInlineMarkup#b2b15770 flags:# force_reply:flags.5?true rows:Vector<KeyboardInlineButtonRow> = ReplyMarkup;
               keyboardInlineButtonRow#19420af6 buttons:Vector<KeyboardInlineButton> = KeyboardInlineButtonRow;

The buttons were migrated to `KeyboardInlineButton` at the time, the row wrapping
them was not. So `InlineKeyboardMarkup.write()` still builds the previous layer's
row constructor and fills it with the current layer's button type:

    ReplyInlineMarkup.rows[0]     -> KeyboardButtonRow#77608b83
    KeyboardButtonRow.buttons[0]  -> KeyboardInlineButton#11c1a322

With this change it builds what the schema declares:

    ReplyInlineMarkup.rows[0]           -> KeyboardInlineButtonRow#19420af6
    KeyboardInlineButtonRow.buttons[0]  -> KeyboardInlineButton#11c1a322

`pyrogram/raw/all.py` sets `layer = 229` and `Session` sends it through
`InvokeWithLayer`, so every inline keyboard currently goes out announcing layer
229 while carrying a row constructor from layer 228.

Two neighbours deliberately left alone: `ReplyKeyboardMarkup`, because
`replyKeyboardMarkup` still declares `rows:Vector<KeyboardButtonRow>`, and
`InlineKeyboardMarkup.read()`, which iterates `row.buttons` without naming a
constructor.

## How to test

`make test-unit`. The new test reads both expected constructor names out of the
generated schema rather than spelling them out, so a later layer that renames
either one fails here instead of reaching the wire. Against `dev` it reports:

    E   AssertionError: assert ['KeyboardButtonRow'] == ['KeyboardInlineButtonRow']
