### PR TITLE
fix(plugins): read `handlers` only when it is a list of handler pairs

### DIFF
--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -71,17 +71,18 @@ from .session.internals import MsgId
 log = logging.getLogger(__name__)
 
 
-def plugin_handlers(target: Any) -> Optional[Sequence[Tuple[Handler, int]]]:
-    """The handler pairs a plugin function carries, or `None` when it carries none.
-
-    Asking `hasattr(target, "handlers")` is not enough. An object with a catch-all
-    `__getattr__`, such as a Motor or PyMongo collection left at module level, answers
-    every attribute with another proxy, and iterating that raises
-    `TypeError: 'Collection' object is not iterable`.
-    """
+def _plugin_handlers(target: Any) -> Optional[Sequence[Tuple[Handler, int]]]:
     handlers = getattr(target, "handlers", None)
 
-    return handlers if isinstance(handlers, (list, tuple)) else None
+    # `hasattr` is not enough here. An object with a catch-all `__getattr__`, such as a
+    #  PyMongo collection left at module level, answers every attribute with another
+    #  proxy of itself, so the loop below reaches `for handler, group in <proxy>` and
+    #  raises `TypeError: 'Collection' object is not iterable`. `__getattr__` cannot
+    #  influence the type of what it returned, so ask about that instead.
+    if not isinstance(handlers, (list, tuple)):
+        return None
+
+    return handlers
 
 
 class Client(Methods):
@@ -1031,7 +1032,7 @@ class Client(Methods):
                     for name in vars(module).keys():
                         # The name comes from the module's own `__dict__`, so it always resolves.
                         target_attr = getattr(module, name)
-                        target_handlers = plugin_handlers(target_attr)
+                        target_handlers = _plugin_handlers(target_attr)
 
                         if target_handlers is not None:
                             for handler, group in target_handlers:
@@ -1063,7 +1064,7 @@ class Client(Methods):
 
                     for name in handlers:
                         target_attr = getattr(module, name, None)
-                        target_handlers = plugin_handlers(target_attr)
+                        target_handlers = _plugin_handlers(target_attr)
 
                         if target_handlers is not None:
                             for handler, group in target_handlers:
@@ -1099,7 +1100,7 @@ class Client(Methods):
 
                     for name in handlers:
                         target_attr = getattr(module, name, None)
-                        target_handlers = plugin_handlers(target_attr)
+                        target_handlers = _plugin_handlers(target_attr)
 
                         if target_handlers is not None:
                             for handler, group in target_handlers:

--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -34,7 +34,7 @@ from importlib import import_module
 from io import BytesIO
 from mimetypes import MimeTypes
 from pathlib import Path
-from typing import Any, AsyncGenerator, Callable, List, Optional, Type, Union
+from typing import Any, AsyncGenerator, Callable, List, Optional, Sequence, Tuple, Type, Union
 
 import pyrogram
 from pyrogram import __license__, __version__, enums, raw, utils
@@ -69,6 +69,19 @@ from .parser import Parser
 from .session.internals import MsgId
 
 log = logging.getLogger(__name__)
+
+
+def plugin_handlers(target: Any) -> Optional[Sequence[Tuple[Handler, int]]]:
+    """The handler pairs a plugin function carries, or `None` when it carries none.
+
+    Asking `hasattr(target, "handlers")` is not enough. An object with a catch-all
+    `__getattr__`, such as a Motor or PyMongo collection left at module level, answers
+    every attribute with another proxy, and iterating that raises
+    `TypeError: 'Collection' object is not iterable`.
+    """
+    handlers = getattr(target, "handlers", None)
+
+    return handlers if isinstance(handlers, (list, tuple)) else None
 
 
 class Client(Methods):
@@ -1018,8 +1031,10 @@ class Client(Methods):
                     for name in vars(module).keys():
                         # The name comes from the module's own `__dict__`, so it always resolves.
                         target_attr = getattr(module, name)
-                        if hasattr(target_attr, "handlers"):
-                            for handler, group in target_attr.handlers:
+                        target_handlers = plugin_handlers(target_attr)
+
+                        if target_handlers is not None:
+                            for handler, group in target_handlers:
                                 if isinstance(handler, Handler) and isinstance(group, int):
                                     self.add_handler(handler, group)
 
@@ -1048,8 +1063,10 @@ class Client(Methods):
 
                     for name in handlers:
                         target_attr = getattr(module, name, None)
-                        if hasattr(target_attr, "handlers"):
-                            for handler, group in target_attr.handlers:
+                        target_handlers = plugin_handlers(target_attr)
+
+                        if target_handlers is not None:
+                            for handler, group in target_handlers:
                                 if isinstance(handler, Handler) and isinstance(group, int):
                                     self.add_handler(handler, group)
 
@@ -1082,8 +1099,10 @@ class Client(Methods):
 
                     for name in handlers:
                         target_attr = getattr(module, name, None)
-                        if hasattr(target_attr, "handlers"):
-                            for handler, group in target_attr.handlers:
+                        target_handlers = plugin_handlers(target_attr)
+
+                        if target_handlers is not None:
+                            for handler, group in target_handlers:
                                 if isinstance(handler, Handler) and isinstance(group, int):
                                     self.remove_handler(handler, group)
 

--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -74,11 +74,9 @@ log = logging.getLogger(__name__)
 def _plugin_handlers(target: Any) -> Optional[Sequence[Tuple[Handler, int]]]:
     handlers = getattr(target, "handlers", None)
 
-    # `hasattr` is not enough here. An object with a catch-all `__getattr__`, such as a
-    #  PyMongo collection left at module level, answers every attribute with another
-    #  proxy of itself, so the loop below reaches `for handler, group in <proxy>` and
-    #  raises `TypeError: 'Collection' object is not iterable`. `__getattr__` cannot
-    #  influence the type of what it returned, so ask about that instead.
+    # A PyMongo collection answers any attribute with a sub-collection, so `hasattr` is
+    #  `True` and the loop below raises `TypeError: 'Collection' object is not iterable`.
+    #  https://github.com/mongodb/mongo-python-driver/blob/77cd7ab9f6dc48e72a3bae94d2cca2e4200e6978/pymongo/synchronous/collection.py#L270
     if not isinstance(handlers, (list, tuple)):
         return None
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,0 +1,100 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+"""`Client.load_plugins()` reads a plugin package without tripping over what else lives in it.
+
+A plugin module is ordinary user code, so anything at all can sit beside the decorated
+functions: a database handle, a client object, a lazily built proxy.
+"""
+
+import asyncio
+from pathlib import Path
+from typing import Final
+
+import pytest
+
+from pyrogram import Client
+from pyrogram.client import plugin_handlers
+from pyrogram.handlers import MessageHandler
+
+_PLUGIN_SOURCE: Final[str] = '''
+from pyrogram import Client
+
+
+class AnyAttribute:
+    """Answers every attribute with another instance, the way a PyMongo collection does."""
+
+    def __getattr__(self, name):
+        return AnyAttribute()
+
+
+collection = AnyAttribute()
+
+
+@Client.on_message()
+async def greet(client, message):
+    pass
+'''
+
+
+@pytest.fixture
+def plugin_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    root: Path = tmp_path / "plugins"
+    root.mkdir()
+    (root / "greeter.py").write_text(_PLUGIN_SOURCE)
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    return root.name
+
+
+async def test_load_plugins_reads_past_an_attribute_proxy(plugin_root: str) -> None:
+    client = Client(name="plugin_probe", in_memory=True)
+    client.loop = asyncio.get_running_loop()
+    client.plugins = {"root": plugin_root, "enabled": True}
+
+    client.load_plugins()
+    await asyncio.sleep(0)
+
+    registered = [
+        handler
+        for group in client.dispatcher.groups.values()
+        for handler in group
+        if isinstance(handler, MessageHandler)
+    ]
+
+    assert len(registered) == 1
+
+
+def test_plugin_handlers_ignores_what_is_not_a_pair_list() -> None:
+    class AnyAttribute:
+        def __getattr__(self, name: str) -> "AnyAttribute":
+            return AnyAttribute()
+
+    def undecorated() -> None:
+        pass
+
+    def decorated() -> None:
+        pass
+
+    decorated.handlers = [(MessageHandler(decorated), 0)]
+
+    assert plugin_handlers(AnyAttribute()) is None
+    assert plugin_handlers(undecorated) is None
+    assert plugin_handlers(decorated) == decorated.handlers

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -29,7 +29,7 @@ from typing import Final
 import pytest
 
 from pyrogram import Client
-from pyrogram.client import plugin_handlers
+from pyrogram.client import _plugin_handlers
 from pyrogram.handlers import MessageHandler
 
 _PLUGIN_SOURCE: Final[str] = '''
@@ -95,6 +95,6 @@ def test_plugin_handlers_ignores_what_is_not_a_pair_list() -> None:
 
     decorated.handlers = [(MessageHandler(decorated), 0)]
 
-    assert plugin_handlers(AnyAttribute()) is None
-    assert plugin_handlers(undecorated) is None
-    assert plugin_handlers(decorated) == decorated.handlers
+    assert _plugin_handlers(AnyAttribute()) is None
+    assert _plugin_handlers(undecorated) is None
+    assert _plugin_handlers(decorated) == decorated.handlers


### PR DESCRIPTION
## What

`Client.load_plugins()` decides whether a module-level name is a decorated
handler by asking `hasattr(target_attr, "handlers")`, then iterating whatever
comes back. An object with a catch-all `__getattr__` answers every attribute
with another proxy of itself, so the check passes and the iteration raises.

A plugin module is ordinary user code, so anything can sit beside the decorated
functions. A PyMongo or Motor collection left at module level is the common
case: `Collection.__getattr__` returns a sub-collection for any name that does
not start with `_`, and `handlers` does not.

https://github.com/mongodb/mongo-python-driver/blob/77cd7ab9f6dc48e72a3bae94d2cca2e4200e6978/pymongo/synchronous/collection.py#L270

A plugin package holding one decorated function and one such object, loaded
with `plugins = {"root": "plugins"}`:

    Traceback (most recent call last):
      File "probe.py", line 34, in main
        client.load_plugins()
      File "pyrogram/client.py", line 1022, in load_plugins
        for handler, group in target_attr.handlers:
                              ^^^^^^^^^^^^^^^^^^^^
    TypeError: 'AnyAttribute' object is not iterable

The whole plugin tree fails to load, and the traceback names the user's object
rather than the loader. With this change the same package loads:

    handlers registered: 1

The three call sites now read the attribute through one helper that asks about
the value's type instead of about the name. `__getattr__` decides what an
attribute lookup returns; it cannot change the type of what it returned, so
`isinstance` is the question that cannot be answered by a proxy.

The helper returns `None` rather than an empty list on purpose. In the
`include` and `exclude` branches the `elif` below logs
`Ignoring non-existent function`, and an empty list would make that warning
fire for a genuinely decorated function whose handler list happens to be empty.

The per-pair `isinstance(handler, Handler) and isinstance(group, int)` guard
inside the loop is untouched: it already validates the contents, and a second
copy in the helper would be the same check written twice.

## How to test

`make test-unit`. The new file covers both halves: a plugin package with an
attribute proxy sitting next to a decorated function, which fails to load
without this change, and the helper itself against a proxy, an undecorated
function and a decorated one.
