### PR TITLE
fix(session): await the tasks `stop()` spawned instead of orphaning them

### DIFF
--- a/pyrogram/session/session.py
+++ b/pyrogram/session/session.py
@@ -23,7 +23,7 @@ import os
 from enum import Enum, auto
 from hashlib import sha1
 from io import BytesIO
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Coroutine, Dict, List, Optional, Set
 
 import pyrogram
 from pyrogram import raw, utils
@@ -82,6 +82,7 @@ class Result:
 
 class Session:
     START_TIMEOUT = 2
+    STOP_TIMEOUT = 2
     WAIT_TIMEOUT = 15
     SLEEP_THRESHOLD = 10
     MAX_RETRIES = 10
@@ -138,6 +139,8 @@ class Session:
 
         self.recv_task: Optional[asyncio.Task] = None
 
+        self.pending_tasks: Set[asyncio.Task] = set()
+
         self.is_started = asyncio.Event()
         self.restart_lock = asyncio.Lock()
 
@@ -153,6 +156,34 @@ class Session:
             self._state = new_state
 
             log.debug("Session state changed: %s -> %s", old_state.name, new_state.name)
+
+    def _create_tracked_task(self, coroutine: Coroutine[Any, Any, Any]) -> asyncio.Task:
+        # The set is what `stop()` waits on, and it is also the strong reference the
+        #  loop does not hold: an unreferenced task can be collected mid-execution.
+        #  https://docs.python.org/3/library/asyncio-task.html#creating-tasks
+        task = self.client.loop.create_task(coroutine)
+
+        self.pending_tasks.add(task)
+        task.add_done_callback(self.pending_tasks.discard)
+
+        return task
+
+    async def _wait_pending_tasks(self) -> None:
+        # A tracked `handle_packet` spawns a tracked `handle_updates`, so one round can
+        #  leave a task behind. Every level is already running, so the loop ends.
+        while self.pending_tasks:
+            round_tasks = set(self.pending_tasks)
+            _, running = await asyncio.wait(round_tasks, timeout=self.STOP_TIMEOUT)
+
+            # `invoke` first waits `WAIT_TIMEOUT` for `is_started`, which stopping has
+            #  just cleared, and then another one for an answer that is not coming, so
+            #  a task caught mid-request would hold the shutdown for half a minute.
+            for task in running:
+                task.cancel()
+
+            for result in await asyncio.gather(*round_tasks, return_exceptions=True):
+                if isinstance(result, Exception):
+                    log.error("Task failed while the session was stopping", exc_info=result)
 
     async def start(self):
         if self._state in (SessionState.STARTED, SessionState.STARTING):
@@ -269,6 +300,8 @@ class Session:
         if self.recv_task:
             await self.recv_task
             self.recv_task = None
+
+        await self._wait_pending_tasks()
 
         await self._set_state(SessionState.STOPPED)
 
@@ -388,7 +421,7 @@ class Session:
                 msg_id = msg.body.msg_id
             else:
                 if self.client is not None:
-                    self.client.loop.create_task(self.client.handle_updates(msg.body))
+                    self._create_tracked_task(self.client.handle_updates(msg.body))
 
             if msg_id in self.results:
                 self.results[msg_id].value = getattr(msg.body, "result", msg.body)
@@ -475,7 +508,7 @@ class Session:
 
                 break
 
-            self.client.loop.create_task(self.handle_packet(packet))
+            self._create_tracked_task(self.handle_packet(packet))
 
         log.info("NetworkTask stopped")
 

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -1,0 +1,132 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+import asyncio
+from typing import Final, Optional
+
+import pytest
+
+import pyrogram
+from pyrogram.session.session import Session, SessionState
+
+_DC_ID: Final[int] = 2
+_PORT: Final[int] = 443
+_AUTH_KEY: Final[bytes] = bytes(256)
+_PACKET: Final[bytes] = b"one packet"
+
+# Long enough that a `stop()` which does not wait would have returned several times
+#  over, short enough to keep the suite quick.
+_NOT_DONE_TIMEOUT: Final[float] = 0.1
+
+# What `Session.STOP_TIMEOUT` is replaced with, so a test of the cancelling path does
+#  not sit through the real grace period.
+_SHORT_STOP_TIMEOUT: Final[float] = 0.05
+
+
+class StubConnection:
+    def __init__(self) -> None:
+        self.closed = asyncio.Event()
+        self.packets = [_PACKET]
+
+    async def recv(self) -> Optional[bytes]:
+        if self.packets:
+            return self.packets.pop()
+
+        await self.closed.wait()
+        return None
+
+    async def close(self) -> None:
+        self.closed.set()
+
+
+def _started_session() -> Session:
+    client = pyrogram.Client("test", api_id=1, api_hash="0" * 32, in_memory=True)
+    session = Session(client, _DC_ID, "127.0.0.1", _PORT, _AUTH_KEY, test_mode=True)
+
+    session.connection = StubConnection()
+    session._state = SessionState.STARTED
+    session.is_started.set()
+
+    return session
+
+
+async def test_stop_waits_for_the_packet_it_is_still_handling() -> None:
+    session = _started_session()
+
+    release = asyncio.Event()
+    handled: bool = False
+
+    async def handle_packet(packet: bytes) -> None:
+        nonlocal handled
+
+        await release.wait()
+        handled = True
+
+    session.handle_packet = handle_packet
+    session.recv_task = session.client.loop.create_task(session.recv_worker())
+
+    await asyncio.sleep(0)
+
+    stopping = asyncio.ensure_future(session.stop())
+
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(asyncio.shield(stopping), _NOT_DONE_TIMEOUT)
+
+    assert not handled
+
+    release.set()
+    await stopping
+
+    assert handled
+    assert session.pending_tasks == set()
+
+
+async def test_stop_cancels_a_packet_that_will_not_finish(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(Session, "STOP_TIMEOUT", _SHORT_STOP_TIMEOUT)
+
+    session = _started_session()
+
+    async def handle_packet(packet: bytes) -> None:
+        await asyncio.Event().wait()
+
+    session.handle_packet = handle_packet
+    session.recv_task = session.client.loop.create_task(session.recv_worker())
+
+    await asyncio.sleep(0)
+
+    handling = next(iter(session.pending_tasks))
+
+    await session.stop()
+
+    assert handling.cancelled()
+    assert session.pending_tasks == set()
+
+
+async def test_a_finished_task_leaves_the_pending_set() -> None:
+    session = _started_session()
+
+    task = session._create_tracked_task(asyncio.sleep(0))
+
+    assert session.pending_tasks == {task}
+
+    await task
+    await asyncio.sleep(0)
+
+    assert session.pending_tasks == set()


### PR DESCRIPTION
## What

`Session` spawns two coroutines fire-and-forget and keeps no reference to
either: `handle_packet` for every packet `recv_worker` reads, and
`handle_updates` for every update inside a packet. `stop()` waits for
`ping_task` and `recv_task` and then returns, so whatever those two were doing
carries on afterwards, against a connection that is closed and a storage that is
not open any more.

Driving one packet through `recv_worker` and stopping the session while it is
still being handled, on `dev`:

    stop() returned; the packet it was handling had finished: False
    Task exception was never retrieved
    sqlite3.ProgrammingError: Cannot operate on a closed database.

With this change the same run reports:

    stop() returned; the packet it was handling had finished: True

The tasks now go into a set that `stop()` drains after `recv_task`. That set is
also the strong reference the loop does not keep: `asyncio` holds only weak ones,
so a task nobody references can be collected before it is done
(https://docs.python.org/3/library/asyncio-task.html#creating-tasks).

Draining is bounded, because waiting is not always finite. `invoke` first waits
`WAIT_TIMEOUT` for `is_started`, which `stop()` has just cleared, then another
`WAIT_TIMEOUT` for an answer that is not coming — so a task caught mid-request
would hold the shutdown for half a minute, and every reconnect goes through
`stop()`. Anything still running after `STOP_TIMEOUT` is cancelled and awaited,
so nothing outlives the call either way.

The five `restart()` spawns stay untracked on purpose: `restart()` calls
`stop()`, so tracking them would leave `stop()` waiting for the task that is
waiting for it.

## How to test

`make test-unit`. The three new tests cover the wait, the cancellation, and the
set not holding on to finished tasks. Against `dev` they report:

    E       Failed: DID NOT RAISE TimeoutError
    E       AttributeError: <class 'pyrogram.session.session.Session'> has no attribute 'STOP_TIMEOUT'
    E       AttributeError: 'Session' object has no attribute '_create_tracked_task'

    FAILED tests/unit/session/test_session.py::test_stop_waits_for_the_packet_it_is_still_handling
    FAILED tests/unit/session/test_session.py::test_stop_cancels_a_packet_that_will_not_finish
    FAILED tests/unit/session/test_session.py::test_a_finished_task_leaves_the_pending_set
