### PR TITLE
fix(session): keep a queued `restart()` from reconnecting a stopped session

### DIFF
--- a/pyrogram/session/session.py
+++ b/pyrogram/session/session.py
@@ -144,6 +144,10 @@ class Session:
         self.is_started = asyncio.Event()
         self.restart_lock = asyncio.Lock()
 
+        # Never cleared: a stopped session is replaced rather than started again, since
+        #  every caller that stops one then asks for a new one (`pyrogram/client.py:1428`).
+        self._must_stay_stopped: bool = False
+
     @property
     def state(self) -> SessionState:
         """Get current session state"""
@@ -276,6 +280,14 @@ class Session:
                 log.exception(e)
 
     async def stop(self):
+        # `restart()` reads this, and the flag is set before the state check below so a
+        #  stop that arrives while a restart is already between its own `stop()` and
+        #  `start()` still counts.
+        self._must_stay_stopped = True
+
+        await self._stop()
+
+    async def _stop(self) -> None:
         if self._state in (SessionState.STOPPED, SessionState.STOPPING):
             log.debug("Session already stopped")
             return
@@ -318,8 +330,18 @@ class Session:
             if self.stored_msg_ids:
                self.recent_msg_ids = self.stored_msg_ids[:30]
 
-            await self.stop()
+            await self._stop()
+
+            if self._must_stay_stopped:
+                return
+
             await self.start()
+
+            # `stop()` does not take `restart_lock`, because `start()` calls `stop()` on
+            #  failure and would deadlock on it. So a stop landing inside `start()` is
+            #  undone here rather than prevented.
+            if self._must_stay_stopped:
+                await self._stop()
 
     async def handle_packet(self, packet):
         try:

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -130,3 +130,52 @@ async def test_a_finished_task_leaves_the_pending_set() -> None:
     await asyncio.sleep(0)
 
     assert session.pending_tasks == set()
+
+
+async def test_a_restart_queued_before_stop_does_not_reconnect() -> None:
+    session = _started_session()
+
+    started: bool = False
+
+    async def start() -> None:
+        nonlocal started
+
+        started = True
+
+    session.start = start
+
+    # The task is only scheduled here: it runs once the loop is yielded to, which is
+    #  after the stop below, and that is the order the client shuts down in.
+    restarting = session.client.loop.create_task(session.restart())
+
+    await session.stop()
+    await restarting
+
+    assert not started
+    assert session.state is SessionState.STOPPED
+
+
+async def test_a_restart_already_starting_is_stopped_again() -> None:
+    session = _started_session()
+
+    starting = asyncio.Event()
+    release = asyncio.Event()
+
+    async def start() -> None:
+        starting.set()
+        await release.wait()
+
+        session._state = SessionState.STARTED
+        session.is_started.set()
+
+    session.start = start
+    restarting = session.client.loop.create_task(session.restart())
+
+    await starting.wait()
+    await session.stop()
+
+    release.set()
+    await restarting
+
+    assert session.state is SessionState.STOPPED
+    assert not session.is_started.is_set()


### PR DESCRIPTION
## What

`restart()` is spawned as a bare task from five places, and it is `stop()`
followed by `start()` with nothing in between that asks whether the session is
still wanted. So a reconnect queued moments before the client shuts down runs
after `Client.stop()` has returned: its `stop()` sees `STOPPED` and returns at
once, and its `start()` opens a fresh connection, `recv_task` and `ping_task`.

Driving `recv_worker` onto its reconnect path (a null packet from the server)
and stopping the session while that task is still queued, on `dev`:

    [probe] Restarting session due to - Server sent a null packet.
    [probe] Session stopped
    client stopped; session state: STOPPED
    start() ran after the client had stopped: True

With this change the same run reports:

    start() ran after the client had stopped: False

`stop()` now records that the session is meant to stay stopped, and `restart()`
reads that before it starts anything. The flag is set before the state check,
so a stop that arrives while a restart is already between its own `stop()` and
`start()` still counts; the body of `stop()` moved to `_stop()`, which is what
`restart()` calls, so the restart's own teardown does not set the flag.

`stop()` deliberately does not take `restart_lock`: `start()` calls `stop()` on
failure, so a restart holding the lock would deadlock on it. A stop can
therefore land anywhere inside `start()`, and `restart()` checks the flag again
afterwards and undoes the reconnect rather than preventing it. In that window a
connection is opened and closed again; what the change rules out is one that
outlives the call.

## How to test

`make test-unit`. The two new tests cover a restart queued before the stop and
a restart that was already starting when the stop landed. Against `dev` they
report:

    E       assert not True
    E       assert <SessionState.STARTED: 2> is <SessionState.STOPPED: 4>

    FAILED tests/unit/session/test_session.py::test_a_restart_queued_before_stop_does_not_reconnect
    FAILED tests/unit/session/test_session.py::test_a_restart_already_starting_is_stopped_again
