### PR TITLE
fix(rich-blocks): keep the `collapsed` flag `PageBlockBlockquote` carries

### DIFF
--- a/pyrogram/types/messages_and_media/rich_block.py
+++ b/pyrogram/types/messages_and_media/rich_block.py
@@ -186,6 +186,7 @@ class RichBlock(Object):
                     [RichBlockParagraph(text=await types.RichText._parse(client, rich_block.text))]
                 ),
                 credit=await types.RichText._parse(client, rich_block.caption),
+                expandable=rich_block.collapsed,
             )
         if isinstance(rich_block, raw.types.PageBlockPullquote):
             return RichBlockPullQuotation(
@@ -672,13 +673,22 @@ class RichBlockBlockQuotation(RichBlock):
 
         credit (:obj:`~pyrogram.types.RichText`, *optional*):
             Credit of the block.
+
+        expandable (``bool``, *optional*):
+            Whether the quotation is shown collapsed until the reader expands it.
     """
 
-    def __init__(self, blocks: List["types.RichBlock"], credit: Optional["types.RichText"] = None):
+    def __init__(
+        self,
+        blocks: List["types.RichBlock"],
+        credit: Optional["types.RichText"] = None,
+        expandable: Optional[bool] = None,
+    ) -> None:
         super().__init__()
 
         self.blocks = blocks
         self.credit = credit
+        self.expandable = expandable
 
 
 class RichBlockPullQuotation(RichBlock):

--- a/tests/unit/types/messages_and_media/test_rich_block.py
+++ b/tests/unit/types/messages_and_media/test_rich_block.py
@@ -1,0 +1,61 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Optional
+
+import pytest
+
+from pyrogram import raw, types
+
+
+async def _parse(block: "raw.base.PageBlock") -> "types.RichBlock":
+    return await types.RichBlock._parse(None, block, {}, {}, None, {}, {})
+
+
+@pytest.mark.parametrize(
+    ("collapsed", "expected"),
+    [
+        pytest.param(True, True, id="collapsed"),
+        pytest.param(None, None, id="not-collapsed"),
+    ],
+)
+async def test_a_blockquote_keeps_the_flag_the_schema_carries(
+    collapsed: Optional[bool],
+    *,
+    expected: Optional[bool],
+) -> None:
+    parsed = await _parse(
+        raw.types.PageBlockBlockquote(
+            text=raw.types.TextPlain(text="quoted"),
+            caption=raw.types.TextEmpty(),
+            collapsed=collapsed,
+        )
+    )
+
+    assert parsed.expandable is expected
+
+
+async def test_the_nested_blockquote_constructor_carries_no_flag() -> None:
+    parsed = await _parse(
+        raw.types.PageBlockBlockquoteBlocks(
+            blocks=[raw.types.PageBlockDivider()],
+            caption=raw.types.TextEmpty(),
+        )
+    )
+
+    assert parsed.expandable is None


### PR DESCRIPTION
## What

`pageBlockBlockquote` carries a flag saying the quotation is shown collapsed until
the reader expands it:

    pageBlockBlockquote#66d1670b flags:# collapsed:flags.0?true text:RichText caption:RichText = PageBlock;

`compiler/api/source/main_api.tl:956`. The generated type reads it, and
`RichBlock._parse` then drops it, so both kinds of quotation arrive as the same
object and a caller cannot tell them apart. On `dev`:

    plain      -> expandable=<no such field>
    collapsed  -> expandable=<no such field>

With this change:

    plain      -> expandable=None
    collapsed  -> expandable=True

The field is a flag on `RichBlockBlockQuotation` rather than a second class,
because that is the shape the schema declares and the shape this library already
uses for the same concept one directory over: a message entity spells an
expandable quotation as `BLOCKQUOTE` plus `expandable`, with no separate entity
type (`pyrogram/types/messages_and_media/message_entity.py:56`). The public name
follows that precedent too, so `collapsed` stays on the wire and `expandable` is
what callers read.

`PageBlockBlockquoteBlocks`, the constructor that nests whole blocks instead of
text, declares no such flag, so quotations parsed from it leave the field unset.

## How to test

`make test-unit`. The new tests cover both flag values and the nested
constructor. Against `dev` all three report:

    E       AttributeError: 'RichBlockBlockQuotation' object has no attribute 'expandable'
