### PR TITLE
fix(types): make `repr()` of a `List` work for items that are not `Object`s

### DIFF
--- a/tests/unit/types/test_list.py
+++ b/tests/unit/types/test_list.py
@@ -16,18 +16,19 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from .object import Object
+from pyrogram import types
 
 
-class List(list):
-    __slots__ = []
+def test_a_list_of_plain_values_is_representable() -> None:
+    assert repr(types.List([1, "two"])) == "pyrogram.types.List([1,'two'])"
 
-    def __str__(self):
-        # noinspection PyCallByClass
-        return Object.__str__(self)
 
-    def __repr__(self) -> str:
-        # `Object.__repr__` reads `__dict__`, which only an `Object` has, so it raised
-        #  `AttributeError` on a list of ids or of nested `List`s. Every `Object` inherits
-        #  that same `__repr__` and none overrides it, so `repr` reaches it anyway.
-        return f"pyrogram.types.List([{','.join(repr(item) for item in self)}])"
+def test_a_nested_list_is_representable() -> None:
+    assert repr(types.List([types.List([1])])) == "pyrogram.types.List([pyrogram.types.List([1])])"
+
+
+def test_an_object_still_reports_its_own_shape() -> None:
+    username = types.Username(username="someone", active=True)
+
+    assert repr(types.List([username])) == f"pyrogram.types.List([{username!r}])"
+    assert "pyrogram.types.Username(" in repr(username)


### PR DESCRIPTION
## What

`List.__repr__` sends every item through `Object.__repr__`, which reads `__dict__`
off it. Only an `Object` has one, so any list of plain values raises, and so does a
list of nested `List`s (a `List` declares `__slots__` and has no `__dict__` either).
Both are ordinary: methods return lists of ids, of usernames, and of lists.

On `dev`:

    >>> repr(types.List([1, "two"]))
    AttributeError: 'int' object has no attribute '__dict__'
    >>> repr(types.List([types.List([1])]))
    AttributeError: 'List' object has no attribute '__dict__'

With this change:

    >>> repr(types.List([1, "two"]))
    "pyrogram.types.List([1,'two'])"
    >>> repr(types.List([types.List([1])]))
    'pyrogram.types.List([pyrogram.types.List([1])])'

The fix is to call `repr` rather than reaching past it: every `Object` inherits
`Object.__repr__` and none of them overrides it, so an `Object` renders exactly as
before, while everything else renders instead of raising. That is also what the raw
layer already does for the same case, one guard further down
(`pyrogram/raw/core/tl_object.py:74`).

`__str__` is unaffected and already worked, because it goes through the `json`
encoder and its `default` hook fires only for what the encoder cannot handle.

## How to test

`make test-unit`. Of the three new tests, the two above fail on `dev`; the third
pins the `Object` rendering that must not change.
