### PR TITLE
fix(decorators): register the plugin handlers an unbound `@Client.on_*()` call declares

### DIFF
--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -1041,6 +1041,17 @@ class Client(Methods):
                                         self.name, type(handler).__name__, name, group, module_path))
 
                                     count += 1
+
+                                else:
+                                    log.warning(
+                                        '[%s] [LOAD] Ignoring "%s" from "%s": expected a handler '
+                                        'in an int group, got %s in %s',
+                                        self.name,
+                                        name,
+                                        module_path,
+                                        type(handler).__name__,
+                                        type(group).__name__,
+                                    )
             else:
                 for path, handlers in include:
                     module_path = root + "." + path
@@ -1073,6 +1084,17 @@ class Client(Methods):
                                         self.name, type(handler).__name__, name, group, module_path))
 
                                     count += 1
+
+                                else:
+                                    log.warning(
+                                        '[%s] [LOAD] Ignoring "%s" from "%s": expected a handler '
+                                        'in an int group, got %s in %s',
+                                        self.name,
+                                        name,
+                                        module_path,
+                                        type(handler).__name__,
+                                        type(group).__name__,
+                                    )
                         elif warn_non_existent_functions:
                             log.warning('[{}] [LOAD] Ignoring non-existent function "{}" from "{}"'.format(
                                 self.name, name, module_path))
@@ -1109,6 +1131,17 @@ class Client(Methods):
                                         self.name, type(handler).__name__, name, group, module_path))
 
                                     count -= 1
+
+                                else:
+                                    log.warning(
+                                        '[%s] [UNLOAD] Ignoring "%s" from "%s": expected a handler '
+                                        'in an int group, got %s in %s',
+                                        self.name,
+                                        name,
+                                        module_path,
+                                        type(handler).__name__,
+                                        type(group).__name__,
+                                    )
                         elif warn_non_existent_functions:
                             log.warning('[{}] [UNLOAD] Ignoring non-existent function "{}" from "{}"'.format(
                                 self.name, name, module_path))

--- a/pyrogram/methods/decorators/on_business_connection.py
+++ b/pyrogram/methods/decorators/on_business_connection.py
@@ -21,6 +21,7 @@ from typing import Callable, Optional, Union
 import pyrogram
 from pyrogram.filters import Filter
 from .handler_type import HandlerType
+from .unbound_arguments import unbound_arguments
 
 
 class OnBusinessConnection:
@@ -52,10 +53,12 @@ class OnBusinessConnection:
                 if not hasattr(func, "handlers"):
                     func.handlers = []
 
+                arguments = unbound_arguments(self, filters=filters, group=group)
+
                 func.handlers.append(
                     (
-                        pyrogram.handlers.BusinessConnectionHandler(func, self),
-                        group if filters is None else filters
+                        pyrogram.handlers.BusinessConnectionHandler(func, arguments.filters),
+                        arguments.group
                     )
                 )
 

--- a/pyrogram/methods/decorators/on_business_message.py
+++ b/pyrogram/methods/decorators/on_business_message.py
@@ -21,6 +21,7 @@ from typing import Callable, Optional, Union
 import pyrogram
 from pyrogram.filters import Filter
 from .handler_type import HandlerType
+from .unbound_arguments import unbound_arguments
 
 
 class OnBusinessMessage:
@@ -52,10 +53,12 @@ class OnBusinessMessage:
                 if not hasattr(func, "handlers"):
                     func.handlers = []
 
+                arguments = unbound_arguments(self, filters=filters, group=group)
+
                 func.handlers.append(
                     (
-                        pyrogram.handlers.BusinessMessageHandler(func, self),
-                        group if filters is None else filters
+                        pyrogram.handlers.BusinessMessageHandler(func, arguments.filters),
+                        arguments.group
                     )
                 )
 

--- a/pyrogram/methods/decorators/on_callback_query.py
+++ b/pyrogram/methods/decorators/on_callback_query.py
@@ -21,6 +21,7 @@ from typing import Callable, Optional, Union
 import pyrogram
 from pyrogram.filters import Filter
 from .handler_type import HandlerType
+from .unbound_arguments import unbound_arguments
 
 
 class OnCallbackQuery:
@@ -52,10 +53,12 @@ class OnCallbackQuery:
                 if not hasattr(func, "handlers"):
                     func.handlers = []
 
+                arguments = unbound_arguments(self, filters=filters, group=group)
+
                 func.handlers.append(
                     (
-                        pyrogram.handlers.CallbackQueryHandler(func, self),
-                        group if filters is None else filters
+                        pyrogram.handlers.CallbackQueryHandler(func, arguments.filters),
+                        arguments.group
                     )
                 )
 

--- a/pyrogram/methods/decorators/on_chat_boost.py
+++ b/pyrogram/methods/decorators/on_chat_boost.py
@@ -21,6 +21,7 @@ from typing import Callable, Optional, Union
 import pyrogram
 from pyrogram.filters import Filter
 from .handler_type import HandlerType
+from .unbound_arguments import unbound_arguments
 
 
 class OnChatBoost:
@@ -53,10 +54,12 @@ class OnChatBoost:
                 if not hasattr(func, "handlers"):
                     func.handlers = []
 
+                arguments = unbound_arguments(self, filters=filters, group=group)
+
                 func.handlers.append(
                     (
-                        pyrogram.handlers.ShippingQueryHandler(func, self),
-                        group if filters is None else filters
+                        pyrogram.handlers.ShippingQueryHandler(func, arguments.filters),
+                        arguments.group
                     )
                 )
 

--- a/pyrogram/methods/decorators/on_chat_join_request.py
+++ b/pyrogram/methods/decorators/on_chat_join_request.py
@@ -21,6 +21,7 @@ from typing import Callable, Optional, Union
 import pyrogram
 from pyrogram.filters import Filter
 from .handler_type import HandlerType
+from .unbound_arguments import unbound_arguments
 
 
 class OnChatJoinRequest:
@@ -51,10 +52,12 @@ class OnChatJoinRequest:
                 if not hasattr(func, "handlers"):
                     func.handlers = []
 
+                arguments = unbound_arguments(self, filters=filters, group=group)
+
                 func.handlers.append(
                     (
-                        pyrogram.handlers.ChatJoinRequestHandler(func, self),
-                        group if filters is None else filters
+                        pyrogram.handlers.ChatJoinRequestHandler(func, arguments.filters),
+                        arguments.group
                     )
                 )
 

--- a/pyrogram/methods/decorators/on_chat_member_updated.py
+++ b/pyrogram/methods/decorators/on_chat_member_updated.py
@@ -21,6 +21,7 @@ from typing import Callable, Optional, Union
 import pyrogram
 from pyrogram.filters import Filter
 from .handler_type import HandlerType
+from .unbound_arguments import unbound_arguments
 
 
 class OnChatMemberUpdated:
@@ -51,10 +52,12 @@ class OnChatMemberUpdated:
                 if not hasattr(func, "handlers"):
                     func.handlers = []
 
+                arguments = unbound_arguments(self, filters=filters, group=group)
+
                 func.handlers.append(
                     (
-                        pyrogram.handlers.ChatMemberUpdatedHandler(func, self),
-                        group if filters is None else filters
+                        pyrogram.handlers.ChatMemberUpdatedHandler(func, arguments.filters),
+                        arguments.group
                     )
                 )
 

--- a/pyrogram/methods/decorators/on_chosen_inline_result.py
+++ b/pyrogram/methods/decorators/on_chosen_inline_result.py
@@ -21,6 +21,7 @@ from typing import Callable, Optional, Union
 import pyrogram
 from pyrogram.filters import Filter
 from .handler_type import HandlerType
+from .unbound_arguments import unbound_arguments
 
 
 class OnChosenInlineResult:
@@ -52,10 +53,12 @@ class OnChosenInlineResult:
                 if not hasattr(func, "handlers"):
                     func.handlers = []
 
+                arguments = unbound_arguments(self, filters=filters, group=group)
+
                 func.handlers.append(
                     (
-                        pyrogram.handlers.ChosenInlineResultHandler(func, self),
-                        group if filters is None else filters
+                        pyrogram.handlers.ChosenInlineResultHandler(func, arguments.filters),
+                        arguments.group
                     )
                 )
 

--- a/pyrogram/methods/decorators/on_deleted_business_messages.py
+++ b/pyrogram/methods/decorators/on_deleted_business_messages.py
@@ -21,6 +21,7 @@ from typing import Callable, Optional, Union
 import pyrogram
 from pyrogram.filters import Filter
 from .handler_type import HandlerType
+from .unbound_arguments import unbound_arguments
 
 
 class OnDeletedBusinessMessages:
@@ -52,10 +53,12 @@ class OnDeletedBusinessMessages:
                 if not hasattr(func, "handlers"):
                     func.handlers = []
 
+                arguments = unbound_arguments(self, filters=filters, group=group)
+
                 func.handlers.append(
                     (
-                        pyrogram.handlers.DeletedBusinessMessagesHandler(func, self),
-                        group if filters is None else filters
+                        pyrogram.handlers.DeletedBusinessMessagesHandler(func, arguments.filters),
+                        arguments.group
                     )
                 )
 

--- a/pyrogram/methods/decorators/on_deleted_messages.py
+++ b/pyrogram/methods/decorators/on_deleted_messages.py
@@ -21,6 +21,7 @@ from typing import Callable, Optional, Union
 import pyrogram
 from pyrogram.filters import Filter
 from .handler_type import HandlerType
+from .unbound_arguments import unbound_arguments
 
 
 class OnDeletedMessages:
@@ -52,10 +53,12 @@ class OnDeletedMessages:
                 if not hasattr(func, "handlers"):
                     func.handlers = []
 
+                arguments = unbound_arguments(self, filters=filters, group=group)
+
                 func.handlers.append(
                     (
-                        pyrogram.handlers.DeletedMessagesHandler(func, self),
-                        group if filters is None else filters
+                        pyrogram.handlers.DeletedMessagesHandler(func, arguments.filters),
+                        arguments.group
                     )
                 )
 

--- a/pyrogram/methods/decorators/on_edited_business_message.py
+++ b/pyrogram/methods/decorators/on_edited_business_message.py
@@ -21,6 +21,7 @@ from typing import Callable, Optional, Union
 import pyrogram
 from pyrogram.filters import Filter
 from .handler_type import HandlerType
+from .unbound_arguments import unbound_arguments
 
 
 class OnEditedBusinessMessage:
@@ -52,10 +53,12 @@ class OnEditedBusinessMessage:
                 if not hasattr(func, "handlers"):
                     func.handlers = []
 
+                arguments = unbound_arguments(self, filters=filters, group=group)
+
                 func.handlers.append(
                     (
-                        pyrogram.handlers.EditedBusinessMessageHandler(func, self),
-                        group if filters is None else filters
+                        pyrogram.handlers.EditedBusinessMessageHandler(func, arguments.filters),
+                        arguments.group
                     )
                 )
 

--- a/pyrogram/methods/decorators/on_edited_message.py
+++ b/pyrogram/methods/decorators/on_edited_message.py
@@ -21,6 +21,7 @@ from typing import Callable, Optional, Union
 import pyrogram
 from pyrogram.filters import Filter
 from .handler_type import HandlerType
+from .unbound_arguments import unbound_arguments
 
 
 class OnEditedMessage:
@@ -52,10 +53,12 @@ class OnEditedMessage:
                 if not hasattr(func, "handlers"):
                     func.handlers = []
 
+                arguments = unbound_arguments(self, filters=filters, group=group)
+
                 func.handlers.append(
                     (
-                        pyrogram.handlers.EditedMessageHandler(func, self),
-                        group if filters is None else filters
+                        pyrogram.handlers.EditedMessageHandler(func, arguments.filters),
+                        arguments.group
                     )
                 )
 

--- a/pyrogram/methods/decorators/on_error.py
+++ b/pyrogram/methods/decorators/on_error.py
@@ -21,11 +21,12 @@ from typing import Callable, Optional, Sequence, Union
 import pyrogram
 from pyrogram.filters import Filter
 from .handler_type import HandlerType
+from .unbound_arguments import unbound_error_arguments
 
 
 class OnError:
     def on_error(
-        self: Optional[Union["OnError", Filter]] = None,
+        self: Optional[Union["OnError", Exception, Sequence[Exception]]] = None,
         exceptions: Optional[Union[Exception, Sequence[Exception]]] = None,
         filters: Optional[Filter] = None,
         group: int = 0,
@@ -57,8 +58,18 @@ class OnError:
                 if not hasattr(func, "handlers"):
                     func.handlers = []
 
+                arguments = unbound_error_arguments(
+                    self,
+                    exceptions=exceptions,
+                    filters=filters,
+                    group=group,
+                )
+
                 func.handlers.append(
-                    (pyrogram.handlers.ErrorHandler(func, exceptions, filters), group)
+                    (
+                        pyrogram.handlers.ErrorHandler(func, arguments.exceptions, arguments.filters),
+                        arguments.group
+                    )
                 )
 
             return func

--- a/pyrogram/methods/decorators/on_guest_message.py
+++ b/pyrogram/methods/decorators/on_guest_message.py
@@ -21,6 +21,7 @@ from typing import Callable, Optional, Union
 import pyrogram
 from pyrogram.filters import Filter
 from .handler_type import HandlerType
+from .unbound_arguments import unbound_arguments
 
 
 class OnGuestMessage:
@@ -52,10 +53,12 @@ class OnGuestMessage:
                 if not hasattr(func, "handlers"):
                     func.handlers = []
 
+                arguments = unbound_arguments(self, filters=filters, group=group)
+
                 func.handlers.append(
                     (
-                        pyrogram.handlers.GuestMessageHandler(func, self),
-                        group if filters is None else filters
+                        pyrogram.handlers.GuestMessageHandler(func, arguments.filters),
+                        arguments.group
                     )
                 )
 

--- a/pyrogram/methods/decorators/on_inline_query.py
+++ b/pyrogram/methods/decorators/on_inline_query.py
@@ -21,6 +21,7 @@ from typing import Callable, Optional, Union
 import pyrogram
 from pyrogram.filters import Filter
 from .handler_type import HandlerType
+from .unbound_arguments import unbound_arguments
 
 
 class OnInlineQuery:
@@ -52,10 +53,12 @@ class OnInlineQuery:
                 if not hasattr(func, "handlers"):
                     func.handlers = []
 
+                arguments = unbound_arguments(self, filters=filters, group=group)
+
                 func.handlers.append(
                     (
-                        pyrogram.handlers.InlineQueryHandler(func, self),
-                        group if filters is None else filters
+                        pyrogram.handlers.InlineQueryHandler(func, arguments.filters),
+                        arguments.group
                     )
                 )
 

--- a/pyrogram/methods/decorators/on_managed_bot.py
+++ b/pyrogram/methods/decorators/on_managed_bot.py
@@ -21,6 +21,7 @@ from typing import Callable, Optional, Union
 import pyrogram
 from pyrogram.filters import Filter
 from .handler_type import HandlerType
+from .unbound_arguments import unbound_arguments
 
 
 class OnManagedBot:
@@ -52,10 +53,12 @@ class OnManagedBot:
                 if not hasattr(func, "handlers"):
                     func.handlers = []
 
+                arguments = unbound_arguments(self, filters=filters, group=group)
+
                 func.handlers.append(
                     (
-                        pyrogram.handlers.ManagedBotUpdatedHandler(func, self),
-                        group if filters is None else filters
+                        pyrogram.handlers.ManagedBotUpdatedHandler(func, arguments.filters),
+                        arguments.group
                     )
                 )
 

--- a/pyrogram/methods/decorators/on_message.py
+++ b/pyrogram/methods/decorators/on_message.py
@@ -21,6 +21,7 @@ from typing import Callable, Optional, Union
 import pyrogram
 from pyrogram.filters import Filter
 from .handler_type import HandlerType
+from .unbound_arguments import unbound_arguments
 
 
 class OnMessage:
@@ -52,10 +53,12 @@ class OnMessage:
                 if not hasattr(func, "handlers"):
                     func.handlers = []
 
+                arguments = unbound_arguments(self, filters=filters, group=group)
+
                 func.handlers.append(
                     (
-                        pyrogram.handlers.MessageHandler(func, self),
-                        group if filters is None else filters
+                        pyrogram.handlers.MessageHandler(func, arguments.filters),
+                        arguments.group
                     )
                 )
 

--- a/pyrogram/methods/decorators/on_message_reaction.py
+++ b/pyrogram/methods/decorators/on_message_reaction.py
@@ -21,6 +21,7 @@ from typing import Callable, Optional, Union
 import pyrogram
 from pyrogram.filters import Filter
 from .handler_type import HandlerType
+from .unbound_arguments import unbound_arguments
 
 
 class OnMessageReaction:
@@ -51,10 +52,12 @@ class OnMessageReaction:
                 if not hasattr(func, "handlers"):
                     func.handlers = []
 
+                arguments = unbound_arguments(self, filters=filters, group=group)
+
                 func.handlers.append(
                     (
-                        pyrogram.handlers.MessageReactionHandler(func, self),
-                        group if filters is None else filters
+                        pyrogram.handlers.MessageReactionHandler(func, arguments.filters),
+                        arguments.group
                     )
                 )
 

--- a/pyrogram/methods/decorators/on_message_reaction_count.py
+++ b/pyrogram/methods/decorators/on_message_reaction_count.py
@@ -21,6 +21,7 @@ from typing import Callable, Optional, Union
 import pyrogram
 from pyrogram.filters import Filter
 from .handler_type import HandlerType
+from .unbound_arguments import unbound_arguments
 
 
 class OnMessageReactionCount:
@@ -51,10 +52,12 @@ class OnMessageReactionCount:
                 if not hasattr(func, "handlers"):
                     func.handlers = []
 
+                arguments = unbound_arguments(self, filters=filters, group=group)
+
                 func.handlers.append(
                     (
-                        pyrogram.handlers.MessageReactionCountHandler(func, self),
-                        group if filters is None else filters
+                        pyrogram.handlers.MessageReactionCountHandler(func, arguments.filters),
+                        arguments.group
                     )
                 )
 

--- a/pyrogram/methods/decorators/on_poll.py
+++ b/pyrogram/methods/decorators/on_poll.py
@@ -21,6 +21,7 @@ from typing import Callable, Optional, Union
 import pyrogram
 from pyrogram.filters import Filter
 from .handler_type import HandlerType
+from .unbound_arguments import unbound_arguments
 
 
 class OnPoll:
@@ -52,10 +53,12 @@ class OnPoll:
                 if not hasattr(func, "handlers"):
                     func.handlers = []
 
+                arguments = unbound_arguments(self, filters=filters, group=group)
+
                 func.handlers.append(
                     (
-                        pyrogram.handlers.PollHandler(func, self),
-                        group if filters is None else filters
+                        pyrogram.handlers.PollHandler(func, arguments.filters),
+                        arguments.group
                     )
                 )
 

--- a/pyrogram/methods/decorators/on_pre_checkout_query.py
+++ b/pyrogram/methods/decorators/on_pre_checkout_query.py
@@ -21,6 +21,7 @@ from typing import Callable, Optional, Union
 import pyrogram
 from pyrogram.filters import Filter
 from .handler_type import HandlerType
+from .unbound_arguments import unbound_arguments
 
 
 class OnPreCheckoutQuery:
@@ -52,10 +53,12 @@ class OnPreCheckoutQuery:
                 if not hasattr(func, "handlers"):
                     func.handlers = []
 
+                arguments = unbound_arguments(self, filters=filters, group=group)
+
                 func.handlers.append(
                     (
-                        pyrogram.handlers.PreCheckoutQueryHandler(func, self),
-                        group if filters is None else filters
+                        pyrogram.handlers.PreCheckoutQueryHandler(func, arguments.filters),
+                        arguments.group
                     )
                 )
 

--- a/pyrogram/methods/decorators/on_purchased_paid_media.py
+++ b/pyrogram/methods/decorators/on_purchased_paid_media.py
@@ -21,6 +21,7 @@ from typing import Callable, Optional, Union
 import pyrogram
 from pyrogram.filters import Filter
 from .handler_type import HandlerType
+from .unbound_arguments import unbound_arguments
 
 
 class OnPurchasedPaidMedia:
@@ -51,10 +52,12 @@ class OnPurchasedPaidMedia:
                 if not hasattr(func, "handlers"):
                     func.handlers = []
 
+                arguments = unbound_arguments(self, filters=filters, group=group)
+
                 func.handlers.append(
                     (
-                        pyrogram.handlers.PurchasedPaidMediaHandler(func, self),
-                        group if filters is None else filters
+                        pyrogram.handlers.PurchasedPaidMediaHandler(func, arguments.filters),
+                        arguments.group
                     )
                 )
 

--- a/pyrogram/methods/decorators/on_raw_update.py
+++ b/pyrogram/methods/decorators/on_raw_update.py
@@ -16,17 +16,18 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Callable, Optional
+from typing import Callable, Optional, Union
 
 import pyrogram
 from pyrogram.filters import Filter
 from .handler_type import HandlerType
+from .unbound_arguments import unbound_arguments
 
 
 class OnRawUpdate:
     def on_raw_update(
-        self: Optional["OnRawUpdate"] = None,
-        filters=None,
+        self: Union["OnRawUpdate", Filter, None] = None,
+        filters: Optional[Filter] = None,
         group: int = 0,
     ) -> Callable[[HandlerType], HandlerType]:
         """Decorator for handling raw updates.
@@ -52,10 +53,12 @@ class OnRawUpdate:
                 if not hasattr(func, "handlers"):
                     func.handlers = []
 
+                arguments = unbound_arguments(self, filters=filters, group=group)
+
                 func.handlers.append(
                     (
-                        pyrogram.handlers.RawUpdateHandler(func, self),
-                        group if filters is None else filters
+                        pyrogram.handlers.RawUpdateHandler(func, arguments.filters),
+                        arguments.group
                     )
                 )
 

--- a/pyrogram/methods/decorators/on_shipping_query.py
+++ b/pyrogram/methods/decorators/on_shipping_query.py
@@ -21,6 +21,7 @@ from typing import Callable, Optional, Union
 import pyrogram
 from pyrogram.filters import Filter
 from .handler_type import HandlerType
+from .unbound_arguments import unbound_arguments
 
 
 class OnShippingQuery:
@@ -53,10 +54,12 @@ class OnShippingQuery:
                 if not hasattr(func, "handlers"):
                     func.handlers = []
 
+                arguments = unbound_arguments(self, filters=filters, group=group)
+
                 func.handlers.append(
                     (
-                        pyrogram.handlers.ShippingQueryHandler(func, self),
-                        group if filters is None else filters
+                        pyrogram.handlers.ShippingQueryHandler(func, arguments.filters),
+                        arguments.group
                     )
                 )
 

--- a/pyrogram/methods/decorators/on_stopped_message_generation.py
+++ b/pyrogram/methods/decorators/on_stopped_message_generation.py
@@ -21,6 +21,7 @@ from typing import Callable, Optional, Union
 import pyrogram
 from pyrogram.filters import Filter
 from .handler_type import HandlerType
+from .unbound_arguments import unbound_arguments
 
 
 class OnStoppedMessageGeneration:
@@ -52,10 +53,12 @@ class OnStoppedMessageGeneration:
                 if not hasattr(func, "handlers"):
                     func.handlers = []
 
+                arguments = unbound_arguments(self, filters=filters, group=group)
+
                 func.handlers.append(
                     (
-                        pyrogram.handlers.StoppedMessageGenerationHandler(func, self),
-                        group if filters is None else filters
+                        pyrogram.handlers.StoppedMessageGenerationHandler(func, arguments.filters),
+                        arguments.group
                     )
                 )
 

--- a/pyrogram/methods/decorators/on_story.py
+++ b/pyrogram/methods/decorators/on_story.py
@@ -21,6 +21,7 @@ from typing import Callable, Optional, Union
 import pyrogram
 from pyrogram.filters import Filter
 from .handler_type import HandlerType
+from .unbound_arguments import unbound_arguments
 
 
 class OnStory:
@@ -52,10 +53,12 @@ class OnStory:
                 if not hasattr(func, "handlers"):
                     func.handlers = []
 
+                arguments = unbound_arguments(self, filters=filters, group=group)
+
                 func.handlers.append(
                     (
-                        pyrogram.handlers.StoryHandler(func, self),
-                        group if filters is None else filters
+                        pyrogram.handlers.StoryHandler(func, arguments.filters),
+                        arguments.group
                     )
                 )
 

--- a/pyrogram/methods/decorators/on_user_status.py
+++ b/pyrogram/methods/decorators/on_user_status.py
@@ -21,6 +21,7 @@ from typing import Callable, Optional, Union
 import pyrogram
 from pyrogram.filters import Filter
 from .handler_type import HandlerType
+from .unbound_arguments import unbound_arguments
 
 
 class OnUserStatus:
@@ -50,10 +51,12 @@ class OnUserStatus:
                 if not hasattr(func, "handlers"):
                     func.handlers = []
 
+                arguments = unbound_arguments(self, filters=filters, group=group)
+
                 func.handlers.append(
                     (
-                        pyrogram.handlers.UserStatusHandler(func, self),
-                        group if filters is None else filters
+                        pyrogram.handlers.UserStatusHandler(func, arguments.filters),
+                        arguments.group
                     )
                 )
 

--- a/pyrogram/methods/decorators/unbound_arguments.py
+++ b/pyrogram/methods/decorators/unbound_arguments.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import NamedTuple, Optional, Union
+from typing import NamedTuple, Optional, Sequence, Union
 
 from pyrogram.filters import Filter
 
@@ -42,3 +42,33 @@ def unbound_arguments(
         return UnboundArguments(receiver, filters)
 
     return UnboundArguments(receiver if isinstance(receiver, Filter) else filters, group)
+
+
+ExceptionsType = Union[Exception, Sequence[Exception], None]
+
+
+class UnboundErrorArguments(NamedTuple):
+    exceptions: ExceptionsType
+    filters: Optional[Filter]
+    group: int
+
+
+def unbound_error_arguments(
+    receiver: ExceptionsType,
+    *,
+    exceptions: Union[ExceptionsType, Filter],
+    filters: Union[Filter, int, None],
+    group: int,
+) -> UnboundErrorArguments:
+    """Read what `@Client.on_error(...)` was given, whichever way it was written.
+
+    `on_error` takes one argument more than its siblings, so an unbound call leaves the
+    exceptions in `self`, the filter in `exceptions` and the group in `filters`.
+    """
+    if receiver is None:
+        return UnboundErrorArguments(exceptions, filters if isinstance(filters, Filter) else None, group)
+
+    if isinstance(exceptions, Filter):
+        return UnboundErrorArguments(receiver, exceptions, filters if isinstance(filters, int) else group)
+
+    return UnboundErrorArguments(receiver, filters if isinstance(filters, Filter) else None, group)

--- a/pyrogram/methods/decorators/unbound_arguments.py
+++ b/pyrogram/methods/decorators/unbound_arguments.py
@@ -16,12 +16,14 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import NamedTuple, Optional, Sequence, Union
+from dataclasses import dataclass
+from typing import Optional, Sequence, Union
 
 from pyrogram.filters import Filter
 
 
-class UnboundArguments(NamedTuple):
+@dataclass(frozen=True)
+class UnboundArguments:
     filters: Optional[Filter]
     group: int
 
@@ -39,15 +41,19 @@ def unbound_arguments(
     keyword shifts nothing, and the two forms have to be told apart before either is read.
     """
     if isinstance(filters, int):
-        return UnboundArguments(receiver, filters)
+        return UnboundArguments(filters=receiver, group=filters)
 
-    return UnboundArguments(receiver if isinstance(receiver, Filter) else filters, group)
+    return UnboundArguments(
+        filters=receiver if isinstance(receiver, Filter) else filters,
+        group=group,
+    )
 
 
 ExceptionsType = Union[Exception, Sequence[Exception], None]
 
 
-class UnboundErrorArguments(NamedTuple):
+@dataclass(frozen=True)
+class UnboundErrorArguments:
     exceptions: ExceptionsType
     filters: Optional[Filter]
     group: int
@@ -66,9 +72,21 @@ def unbound_error_arguments(
     exceptions in `self`, the filter in `exceptions` and the group in `filters`.
     """
     if receiver is None:
-        return UnboundErrorArguments(exceptions, filters if isinstance(filters, Filter) else None, group)
+        return UnboundErrorArguments(
+            exceptions=exceptions,
+            filters=filters if isinstance(filters, Filter) else None,
+            group=group,
+        )
 
     if isinstance(exceptions, Filter):
-        return UnboundErrorArguments(receiver, exceptions, filters if isinstance(filters, int) else group)
+        return UnboundErrorArguments(
+            exceptions=receiver,
+            filters=exceptions,
+            group=filters if isinstance(filters, int) else group,
+        )
 
-    return UnboundErrorArguments(receiver, filters if isinstance(filters, Filter) else None, group)
+    return UnboundErrorArguments(
+        exceptions=receiver,
+        filters=filters if isinstance(filters, Filter) else None,
+        group=group,
+    )

--- a/pyrogram/methods/decorators/unbound_arguments.py
+++ b/pyrogram/methods/decorators/unbound_arguments.py
@@ -1,0 +1,44 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import NamedTuple, Optional, Union
+
+from pyrogram.filters import Filter
+
+
+class UnboundArguments(NamedTuple):
+    filters: Optional[Filter]
+    group: int
+
+
+def unbound_arguments(
+    receiver: Optional[Filter],
+    *,
+    filters: Union[Filter, int, None],
+    group: int,
+) -> UnboundArguments:
+    """Read what `@Client.on_*(...)` was given, whichever way it was written.
+
+    The decorator is a method, so an unbound call shifts every positional argument one
+    slot to the left: the filter lands in `self` and the group in `filters`. A call by
+    keyword shifts nothing, and the two forms have to be told apart before either is read.
+    """
+    if isinstance(filters, int):
+        return UnboundArguments(receiver, filters)
+
+    return UnboundArguments(receiver if isinstance(receiver, Filter) else filters, group)

--- a/tests/unit/methods/decorators/test_decorators.py
+++ b/tests/unit/methods/decorators/test_decorators.py
@@ -18,11 +18,12 @@
 
 import inspect
 from pathlib import Path
-from typing import Callable, List, Set
+from typing import Callable, Final, List, Set
 
 import pytest
 
 import pyrogram
+from pyrogram import filters
 from pyrogram.methods import decorators
 from pyrogram.methods.decorators.handler_type import HandlerType
 
@@ -36,6 +37,19 @@ def _decorator_names() -> List[str]:
                 names.add(method_name)
 
     return sorted(names)
+
+
+# `on_error` takes an `exceptions` argument between the two, so it shifts differently
+#  and is covered on its own below.
+_FILTERED_SIGNATURE: Final[List[str]] = ["self", "filters", "group"]
+
+
+def _filtered_decorator_names() -> List[str]:
+    return [
+        name
+        for name in _decorator_names()
+        if list(inspect.signature(getattr(pyrogram.Client, name)).parameters) == _FILTERED_SIGNATURE
+    ]
 
 
 def _module_names() -> List[str]:
@@ -65,3 +79,63 @@ def test_decorator_binds_the_callback_signature_to_one_type_variable(decorator_n
     decorator = getattr(pyrogram.Client, decorator_name)
 
     assert inspect.signature(decorator).return_annotation == Callable[[HandlerType], HandlerType]
+
+
+@pytest.fixture
+def handler() -> HandlerType:
+    async def callback(client: pyrogram.Client, update: pyrogram.types.Update) -> None: ...
+
+    return callback
+
+
+# The decorators are methods, so an unbound call shifts the arguments one slot to the left
+#  and a call by keyword does not. All three forms are documented, so all three are checked.
+@pytest.mark.parametrize("decorator_name", _filtered_decorator_names())
+def test_the_positional_form_stores_the_filter_and_the_group(
+    decorator_name: str,
+    handler: HandlerType,
+) -> None:
+    getattr(pyrogram.Client, decorator_name)(filters.text, 1)(handler)
+
+    (built, group), = handler.handlers
+
+    assert group == 1
+    assert built.filters is filters.text
+
+
+@pytest.mark.parametrize("decorator_name", _filtered_decorator_names())
+def test_the_mixed_form_stores_the_filter_and_the_group(
+    decorator_name: str,
+    handler: HandlerType,
+) -> None:
+    getattr(pyrogram.Client, decorator_name)(filters.text, group=1)(handler)
+
+    (built, group), = handler.handlers
+
+    assert group == 1
+    assert built.filters is filters.text
+
+
+@pytest.mark.parametrize("decorator_name", _filtered_decorator_names())
+def test_the_keyword_form_stores_the_filter_and_the_group(
+    decorator_name: str,
+    handler: HandlerType,
+) -> None:
+    getattr(pyrogram.Client, decorator_name)(filters=filters.text, group=1)(handler)
+
+    (built, group), = handler.handlers
+
+    assert group == 1
+    assert built.filters is filters.text
+
+
+@pytest.mark.parametrize("decorator_name", sorted(set(_decorator_names()) - set(_filtered_decorator_names())))
+def test_a_decorator_called_with_no_arguments_stores_the_default_group(
+    decorator_name: str,
+    handler: HandlerType,
+) -> None:
+    getattr(pyrogram.Client, decorator_name)()(handler)
+
+    (_, group), = handler.handlers
+
+    assert group == 0

--- a/tests/unit/methods/decorators/test_decorators.py
+++ b/tests/unit/methods/decorators/test_decorators.py
@@ -139,3 +139,35 @@ def test_a_decorator_called_with_no_arguments_stores_the_default_group(
     (_, group), = handler.handlers
 
     assert group == 0
+
+
+# `on_error` carries an `exceptions` argument its siblings do not, so an unbound call
+#  shifts three slots instead of two.
+def test_on_error_reads_the_positional_form(handler: HandlerType) -> None:
+    pyrogram.Client.on_error(ValueError, filters.text, 1)(handler)
+
+    (built, group), = handler.handlers
+
+    assert group == 1
+    assert built.exceptions == (ValueError,)
+    assert built.filters is filters.text
+
+
+def test_on_error_reads_the_keyword_form(handler: HandlerType) -> None:
+    pyrogram.Client.on_error(exceptions=ValueError, filters=filters.text, group=1)(handler)
+
+    (built, group), = handler.handlers
+
+    assert group == 1
+    assert built.exceptions == (ValueError,)
+    assert built.filters is filters.text
+
+
+def test_on_error_keeps_the_only_exception_it_was_given(handler: HandlerType) -> None:
+    pyrogram.Client.on_error(ValueError)(handler)
+
+    (built, group), = handler.handlers
+
+    assert group == 0
+    assert built.exceptions == (ValueError,)
+    assert built.filters is None

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -23,12 +23,13 @@ functions: a database handle, a client object, a lazily built proxy.
 """
 
 import asyncio
+import logging
 from pathlib import Path
-from typing import Final
+from typing import Final, Protocol
 
 import pytest
 
-from pyrogram import Client
+from pyrogram import Client, filters
 from pyrogram.client import _plugin_handlers
 from pyrogram.handlers import MessageHandler
 
@@ -52,22 +53,55 @@ async def greet(client, message):
 '''
 
 
-@pytest.fixture
-def plugin_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
-    root: Path = tmp_path / "plugins"
-    root.mkdir()
-    (root / "greeter.py").write_text(_PLUGIN_SOURCE)
+_KEYWORD_PLUGIN_SOURCE: Final[str] = '''
+from pyrogram import Client, filters
 
+
+@Client.on_message(filters=filters.text, group=1)
+async def greet(client, message):
+    pass
+'''
+
+_REFUSED_PLUGIN_SOURCE: Final[str] = '''
+async def greet(client, message):
+    pass
+
+
+greet.handlers = [("not a handler", 0)]
+'''
+
+
+class PluginWriter(Protocol):
+    def __call__(self, package: str, *, source: str) -> str: ...
+
+
+@pytest.fixture
+def write_plugin(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> PluginWriter:
     monkeypatch.chdir(tmp_path)
     monkeypatch.syspath_prepend(str(tmp_path))
 
-    return root.name
+    # Each test needs a package of its own: `import_module` caches by name, so a second
+    #  package sharing a name resolves to the first one's files.
+    def _write(package: str, *, source: str) -> str:
+        root: Path = tmp_path / package
+        root.mkdir()
+        (root / "handlers.py").write_text(source)
+
+        return package
+
+    return _write
 
 
-async def test_load_plugins_reads_past_an_attribute_proxy(plugin_root: str) -> None:
+def _plugin_client(root: str) -> Client:
     client = Client(name="plugin_probe", in_memory=True)
-    client.loop = asyncio.get_running_loop()
-    client.plugins = {"root": plugin_root, "enabled": True}
+    client.loop = asyncio.get_event_loop()
+    client.plugins = {"root": root, "enabled": True}
+
+    return client
+
+
+async def test_load_plugins_reads_past_an_attribute_proxy(write_plugin: PluginWriter) -> None:
+    client = _plugin_client(write_plugin("proxy_plugins", source=_PLUGIN_SOURCE))
 
     client.load_plugins()
     await asyncio.sleep(0)
@@ -98,3 +132,29 @@ def test_plugin_handlers_ignores_what_is_not_a_pair_list() -> None:
     assert _plugin_handlers(AnyAttribute()) is None
     assert _plugin_handlers(undecorated) is None
     assert _plugin_handlers(decorated) == decorated.handlers
+
+
+async def test_load_plugins_registers_a_handler_declared_by_keyword(write_plugin: PluginWriter) -> None:
+    client = _plugin_client(write_plugin("keyword_plugins", source=_KEYWORD_PLUGIN_SOURCE))
+
+    client.load_plugins()
+    await asyncio.sleep(0)
+
+    (handler,) = client.dispatcher.groups[1]
+
+    assert isinstance(handler, MessageHandler)
+    assert handler.filters is filters.text
+
+
+async def test_load_plugins_reports_the_pair_it_refuses(
+    write_plugin: PluginWriter,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    client = _plugin_client(write_plugin("refused_plugins", source=_REFUSED_PLUGIN_SOURCE))
+
+    with caplog.at_level(logging.WARNING, logger="pyrogram.client"):
+        client.load_plugins()
+        await asyncio.sleep(0)
+
+    assert client.dispatcher.groups == {}
+    assert "greet" in caplog.text

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -33,12 +33,12 @@ from pyrogram import Client, filters
 from pyrogram.client import _plugin_handlers
 from pyrogram.handlers import MessageHandler
 
-_PLUGIN_SOURCE: Final[str] = '''
+_PLUGIN_SOURCE: Final[str] = """
 from pyrogram import Client
 
 
 class AnyAttribute:
-    """Answers every attribute with another instance, the way a PyMongo collection does."""
+    # Answers every attribute with another instance, the way a PyMongo collection does.
 
     def __getattr__(self, name):
         return AnyAttribute()
@@ -50,25 +50,25 @@ collection = AnyAttribute()
 @Client.on_message()
 async def greet(client, message):
     pass
-'''
+"""
 
 
-_KEYWORD_PLUGIN_SOURCE: Final[str] = '''
+_KEYWORD_PLUGIN_SOURCE: Final[str] = """
 from pyrogram import Client, filters
 
 
 @Client.on_message(filters=filters.text, group=1)
 async def greet(client, message):
     pass
-'''
+"""
 
-_REFUSED_PLUGIN_SOURCE: Final[str] = '''
+_REFUSED_PLUGIN_SOURCE: Final[str] = """
 async def greet(client, message):
     pass
 
 
 greet.handlers = [("not a handler", 0)]
-'''
+"""
 
 
 class PluginWriter(Protocol):


### PR DESCRIPTION
## What

A plugin that declares its handler by keyword registered nothing at all, silently:

```python
# plugins/echo.py
from pyrogram import Client, filters


@Client.on_message(filters=filters.text, group=1)
async def greet(client, message):
    pass
```

```
# before
WARNING [probe] No plugin loaded from "plugins"

# after
INFO [probe] [LOAD] MessageHandler("greet") in group 1 from "plugins.echo"
INFO [probe] Successfully loaded 1 plugin from "plugins"
```

The decorators are methods, so an unbound call, the form plugins use, shifts every
positional argument one slot to the left: the filter lands in `self` and the group in
`filters`. The old code undid that shift unconditionally, so the keyword form, which
shifts nothing and is documented in every decorator's docstring, was mangled instead:

```
>>> (handler, group), = greet.handlers

>>> group                                                 # before
<pyrogram.filters.text_filter object at 0x7840104c89e0>
>>> handler.filters
None

>>> group                                                 # after
1
>>> handler.filters
<pyrogram.filters.text_filter object at 0x72f72b3ab8f0>
```

The handler carried no filters and the group slot held a `Filter`. `load_plugins()`
guards with `isinstance(handler, Handler) and isinstance(group, int)`, so the pair was
discarded, and until now with no log line of any kind.

Three changes:

- `pyrogram/methods/decorators/unbound_arguments.py` tells the two call forms apart
  before reading either, and is used by all 25 decorators taking `(self, filters, group)`.
  `on_raw_update` also had its annotations aligned with its siblings: its body already
  read `self` as a filter while its signature said it could not be one.
- `load_plugins()` now names the function in a warning when it refuses a pair, at all
  three places that can happen, instead of dropping it in silence.
- `on_error` takes an `exceptions` argument its siblings do not, so an unbound call
  shifts three slots, and its plugin branch never read `self` at all.
  `@Client.on_error(ValueError)` therefore registered a handler for everything:

```
>>> (handler, group), = only_value_errors.handlers

>>> handler.exceptions          # before
(<class 'Exception'>,)
>>> handler.exceptions          # after
(<class 'ValueError'>,)
```

## How to test

```
make lint
make test-unit
```

New tests cover the positional, mixed and keyword forms across every filtered decorator,
the three `on_error` forms, and `load_plugins()` both registering a keyword-declared
handler and reporting a pair it refuses. On `dev` they fail; here they pass.
