### PR TITLE
fix(typing): declare what `save_file()` and `InputChatPhoto.write()` actually return

### DIFF
--- a/pyrogram/methods/advanced/save_file.py
+++ b/pyrogram/methods/advanced/save_file.py
@@ -25,7 +25,7 @@ import math
 import os
 from hashlib import md5
 from pathlib import PurePath
-from typing import List, Union, BinaryIO, Callable, Optional
+from typing import List, Union, BinaryIO, Callable, Optional, overload
 
 import pyrogram
 from pyrogram import StopTransmission
@@ -36,9 +36,43 @@ log = logging.getLogger(__name__)
 
 
 class SaveFile:
+    # The three shapes below are what the body already does. They are spelled out so a caller
+    #  storing the result into a required `InputFile` field is not asked to handle a `None`
+    #  the arguments it passed cannot produce. They leave `self` bare because `Client`
+    #  inherits this mixin, so the binding is the same without the annotation below.
+    @overload
+    async def save_file(
+        self,
+        path: None,
+        file_id: Optional[int] = None,
+        file_part: int = 0,
+        progress: Optional[Callable] = None,
+        progress_args: tuple = ()
+    ) -> None: ...
+
+    @overload
+    async def save_file(
+        self,
+        path: Union[str, BinaryIO],
+        file_id: int,
+        file_part: int = 0,
+        progress: Optional[Callable] = None,
+        progress_args: tuple = ()
+    ) -> None: ...
+
+    @overload
+    async def save_file(
+        self,
+        path: Union[str, BinaryIO],
+        file_id: None = None,
+        file_part: int = 0,
+        progress: Optional[Callable] = None,
+        progress_args: tuple = ()
+    ) -> Union["raw.types.InputFile", "raw.types.InputFileBig"]: ...
+
     async def save_file(
         self: "pyrogram.Client",
-        path: Union[str, BinaryIO],
+        path: Optional[Union[str, BinaryIO]],
         file_id: Optional[int] = None,
         file_part: int = 0,
         progress: Optional[Callable] = None,

--- a/pyrogram/types/input_content/input_chat_photo.py
+++ b/pyrogram/types/input_content/input_chat_photo.py
@@ -54,7 +54,7 @@ class InputChatPhotoPrevious(InputChatPhoto):
     """
     def __init__(
         self,
-        chat_photo_file_id: int
+        chat_photo_file_id: str
     ):
         super().__init__()
 

--- a/pyrogram/types/input_content/input_chat_photo.py
+++ b/pyrogram/types/input_content/input_chat_photo.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import BinaryIO, Optional, Union
+from typing import BinaryIO, Optional, Union, cast
 
 import pyrogram
 from pyrogram import raw, utils
@@ -41,7 +41,7 @@ class InputChatPhoto(Object):
     ):
         super().__init__()
 
-    async def write(self, client: "pyrogram.Client") -> "raw.base.InputFile":
+    async def write(self, client: "pyrogram.Client") -> Union["raw.base.InputFile", "raw.base.InputPhoto"]:
         raise NotImplementedError
 
 
@@ -60,10 +60,12 @@ class InputChatPhotoPrevious(InputChatPhoto):
 
         self.chat_photo_file_id = chat_photo_file_id
 
-    async def write(self, client: "pyrogram.Client") -> "raw.types.InputPhoto":
+    async def write(self, client: "pyrogram.Client") -> "raw.base.InputPhoto":
         photo = utils.get_input_media_from_file_id(self.chat_photo_file_id, FileType.PHOTO)
-        
-        return photo.id
+
+        # The helper rejects any other file type when it is given one to expect, so the
+        #  document half of its return type is unreachable from here.
+        return cast("raw.types.InputMediaPhoto", photo).id
 
 
 class InputChatPhotoStatic(InputChatPhoto):


### PR DESCRIPTION
## What

`Client.save_file()` was annotated `Optional[...]` for every call, but the body
returns `None` only in two cases: when `path` is `None`, and when it is
re-uploading a single missing part (`file_id` given). Every other caller was
being asked to handle a `None` its own arguments cannot produce:

    $ mypy probe.py
    probe.py:7: note: Revealed type is "InputFile | InputFileBig | None"
    probe.py:8: note: Revealed type is "InputFile | InputFileBig | None"
    probe.py:9: note: Revealed type is "InputFile | InputFileBig | None"
    probe.py:10: note: Revealed type is "InputFile | InputFileBig | None"
    probe.py:14: error: Argument "file" to "InputMediaUploadedPhoto" has
                        incompatible type "InputFile | InputFileBig | None";
                        expected "InputFile | InputFileBig | InputFileStoryDocument"

Three `@overload` stubs now spell the three shapes out. Same probe, same calls:

    $ mypy probe.py
    probe.py:7: note: Revealed type is "InputFile | InputFileBig"
    probe.py:8: note: Revealed type is "InputFile | InputFileBig | None"   # path: Optional[str]
    probe.py:9: note: Revealed type is "None"                              # file_id=1
    probe.py:10: note: Revealed type is "None"                             # path=None
    Success: no issues found in 1 source file

The runtime behaviour is untouched: the body is the same function, and the
overloads only describe it.

`InputChatPhoto.write()` had three separate problems in one file, all of them
annotations disagreeing with the code:

    $ mypy pyrogram/types/input_content/input_chat_photo.py
    input_chat_photo.py:63: error: Return type "Coroutine[Any, Any, InputPhoto]" of "write"
        incompatible with return type "Coroutine[Any, Any, InputFile | InputFileBig |
        InputFileStoryDocument]" in supertype "InputChatPhoto"
    input_chat_photo.py:64: error: Argument 1 to "get_input_media_from_file_id" has
        incompatible type "int"; expected "str"
    input_chat_photo.py:66: error: Incompatible return value type (got "InputPhoto |
        InputPhotoEmpty | InputDocument | InputDocumentEmpty", expected "InputPhoto")
    input_chat_photo.py:85: error: Incompatible return value type (got "InputFile |
        InputFileBig | None", expected "InputFile | InputFileBig | InputFileStoryDocument")
    input_chat_photo.py:113: error: same
    Found 5 errors in 1 file

    $ mypy pyrogram/types/input_content/input_chat_photo.py   # after
    Success: no issues found in 1 source file

The base class declared `InputFile`, but `set_profile_photo()` calls
`InputChatPhotoPrevious.write()` for `UpdateProfilePhoto(id=...)`, which takes an
`InputPhoto` — so the base type is the union of the two, and the override is
declared as the `InputPhoto` it returns.

`chat_photo_file_id` was annotated `int` while its own docstring says `str`, and
`str` is what the code needs. Anyone following the annotation got:

    >>> await types.InputChatPhotoPrevious(12345).write(client)
    ValueError: Failed to decode "12345". The value does not represent an existing
    local file, HTTP URL, or valid file id.

## How to test

`make lint` and `make test-unit` (588 passed). Nothing at runtime changes; the
evidence above is `mypy` on the two files, run against `dev` and against this
branch.
