### PR TITLE
fix(typing): name the types the seven dead annotations were meant to name

### DIFF
--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -268,7 +268,7 @@ class Client(Methods):
         init_connection_params (``dict`` | :obj:`~pyrogram.raw.base.JSONValue`, *optional*):
             Additional initConnection parameters.
             For now, only the tz_offset field is supported, for specifying timezone offset in seconds.
-            A dict is converted on connect; an already built JsonValue is sent as it is.
+            A dict is converted on connect; an already built JSONValue is sent as it is.
     """
 
     APP_VERSION = f"Pyrogram {__version__}"
@@ -339,7 +339,7 @@ class Client(Methods):
         fetch_topics: Optional[bool] = True,
         fetch_stories: Optional[bool] = True,
         fetch_stickers: Optional[bool] = True,
-        init_connection_params: Optional[Union[dict, "raw.base.JsonValue"]] = None,
+        init_connection_params: Optional[Union[dict, "raw.base.JSONValue"]] = None,
         connection_factory: Type[Connection] = Connection,
         protocol_factory: Type[TCP] = TCPAbridged,
         loop: Optional[asyncio.AbstractEventLoop] = None

--- a/pyrogram/types/bots_and_keyboards/message_reaction_count_updated.py
+++ b/pyrogram/types/bots_and_keyboards/message_reaction_count_updated.py
@@ -51,7 +51,7 @@ class MessageReactionCountUpdated(Object, Update):
         chat: "types.Chat",
         message_id: int,
         date: datetime,
-        reactions: List["types.ReactionCount"]
+        reactions: List["types.Reaction"]
     ):
         super().__init__(client)
 

--- a/pyrogram/types/bots_and_keyboards/shipping_query.py
+++ b/pyrogram/types/bots_and_keyboards/shipping_query.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional
+from typing import List, Optional
 
 import pyrogram
 from pyrogram import types, raw
@@ -81,7 +81,7 @@ class ShippingQuery(Object, Update):
     async def answer(
         self,
         ok: bool,
-        shipping_options: Optional["types.ShippingOptions"] = None,
+        shipping_options: Optional[List["types.ShippingOption"]] = None,
         error_message: Optional[str] = None
     ) -> bool:
         """Bound method *answer* of :obj:`~pyrogram.types.ShippingQuery`.
@@ -104,7 +104,7 @@ class ShippingQuery(Object, Update):
             ok (``bool``):
                 Pass True if delivery to the specified address is possible and False if there are any problems (for example, if delivery to the specified address is not possible).
 
-            shipping_options (:obj:`~pyrogram.types.ShippingOption`, *optional*):
+            shipping_options (List of :obj:`~pyrogram.types.ShippingOption`, *optional*):
                 Required if ok is True. A JSON-serialized array of available shipping options.
 
             error_message (``str``, *optional*):

--- a/pyrogram/types/user_and_chats/chat_folder_invite_link_info.py
+++ b/pyrogram/types/user_and_chats/chat_folder_invite_link_info.py
@@ -42,7 +42,7 @@ class ChatFolderInviteLinkInfo(Object):
     def __init__(
         self,
         *,
-        chat_folder_info: "types.ChatFolderInfo",
+        chat_folder_info: "types.Folder",
         missing_chats: Optional[List["types.Chat"]] = None,
         added_chats: Optional[List["types.Chat"]] = None,
     ):

--- a/pyrogram/types/user_and_chats/privacy_rule.py
+++ b/pyrogram/types/user_and_chats/privacy_rule.py
@@ -39,7 +39,7 @@ class PrivacyRule(Object):
 
     def __init__(
         self, *,
-        type: "types.PrivacyRuleType",
+        type: "enums.PrivacyRuleType",
         users: Optional[List["types.User"]] = None,
         chats: Optional[List["types.Chat"]] = None
     ):

--- a/pyrogram/utils.py
+++ b/pyrogram/utils.py
@@ -739,7 +739,7 @@ def from_inline_bytes(data: bytes, file_name: Optional[str] = None) -> BytesIO:
     return b
 
 
-def obj_to_jsonvalue(obj) -> "raw.base.JsonValue":
+def obj_to_jsonvalue(obj) -> "raw.base.JSONValue":
     if obj is None:
         return raw.types.JsonNull()
     elif isinstance(obj, bool):
@@ -756,7 +756,7 @@ def obj_to_jsonvalue(obj) -> "raw.base.JsonValue":
     raise TypeError(f"Unsupported type: {type(obj)}")
 
 
-def jsonvalue_to_obj(obj: "raw.base.JsonValue"):
+def jsonvalue_to_obj(obj: "raw.base.JSONValue"):
     if isinstance(obj, raw.types.JsonNull):
         return None
     elif isinstance(obj, raw.types.JsonBool):

--- a/tests/unit/name_resolution.py
+++ b/tests/unit/name_resolution.py
@@ -1,0 +1,70 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Reading a dotted name against the package, shared by the docstring and annotation sweeps.
+
+Both ask the same question of a different kind of text: does this name exist. Neither can
+answer it statically, because the tree is one import cycle wide and half the names it
+writes are only bound under `TYPE_CHECKING`, so both resolve against the imported package.
+"""
+
+import importlib
+import pathlib
+from typing import Any, Final, Iterator, Sequence
+
+REPOSITORY_ROOT: Final[pathlib.Path] = pathlib.Path(__file__).resolve().parents[2]
+PACKAGE_ROOT: Final[pathlib.Path] = REPOSITORY_ROOT / "pyrogram"
+
+# The generated tree is rewritten wholesale by `make api` from the TL schema, so a repair
+#  there lives until the next schema update and no longer.
+GENERATED_TREE: Final[pathlib.Path] = PACKAGE_ROOT / "raw"
+
+
+def hand_written_files() -> Iterator[pathlib.Path]:
+    """Every module of the package a person wrote and a person can repair."""
+    for path in sorted(PACKAGE_ROOT.rglob("*.py")):
+        if GENERATED_TREE not in path.parents:
+            yield path
+
+
+def attribute_chain(root: Any, *, names: Sequence[str]) -> bool:
+    """Walk `names` from `root` with `getattr`, answering whether every step exists."""
+    resolved = root
+
+    for name in names:
+        if not hasattr(resolved, name):
+            return False
+
+        resolved = getattr(resolved, name)
+
+    return True
+
+
+def resolves(target: str) -> bool:
+    """Import the longest prefix of `target`, then walk the rest of it with `getattr`."""
+    parts = target.split(".")
+
+    for cut in range(len(parts), 0, -1):
+        try:
+            resolved = importlib.import_module(".".join(parts[:cut]))
+        except ImportError:
+            continue
+
+        return attribute_chain(resolved, names=parts[cut:])
+
+    return False

--- a/tests/unit/test_annotation_references.py
+++ b/tests/unit/test_annotation_references.py
@@ -1,0 +1,284 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Every name an annotation writes exists where the annotation is written.
+
+Almost every annotation in this tree is a string, so nothing evaluates it: a name that does
+not exist reaches an IDE and a type checker as though it did, and no part of the build says
+otherwise.
+"""
+
+import ast
+import builtins
+import importlib
+import pathlib
+from dataclasses import dataclass
+from types import ModuleType
+from typing import Any, Dict, Iterator, List, Optional, Sequence, Set, Tuple
+
+import pyrogram
+from tests.unit.name_resolution import REPOSITORY_ROOT, attribute_chain, hand_written_files
+
+
+@dataclass(frozen=True)
+class Annotation:
+    name: Tuple[str, ...]
+    path: pathlib.Path
+    line: int
+
+    def __str__(self) -> str:
+        return "{}:{}: {}".format(self.path.relative_to(REPOSITORY_ROOT), self.line, ".".join(self.name))
+
+
+def module_name_of(path: pathlib.Path) -> str:
+    parts = list(path.relative_to(REPOSITORY_ROOT).with_suffix("").parts)
+
+    if parts[-1] == "__init__":
+        parts.pop()
+
+    return ".".join(parts)
+
+
+def annotations_of(tree: ast.Module) -> Iterator[ast.expr]:
+    """Every annotation a module writes: on a parameter, on a return, on an assignment."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AnnAssign):
+            yield node.annotation
+            continue
+
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+
+        arguments = node.args
+        every: List[Optional[ast.arg]] = [
+            *arguments.posonlyargs,
+            *arguments.args,
+            *arguments.kwonlyargs,
+            arguments.vararg,
+            arguments.kwarg,
+        ]
+
+        for argument in every:
+            if argument is not None and argument.annotation is not None:
+                yield argument.annotation
+
+        if node.returns is not None:
+            yield node.returns
+
+
+def dotted_name(node: ast.expr) -> Optional[Tuple[str, ...]]:
+    """The components of `a.b.c`, or `None` for anything that is not a plain dotted name."""
+    parts: List[str] = []
+
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+
+    if not isinstance(node, ast.Name):
+        return None
+
+    parts.append(node.id)
+
+    return tuple(reversed(parts))
+
+
+def subscript_of(node: ast.Subscript) -> ast.expr:
+    """What sits inside `X[...]`, whichever way this Python spells it.
+
+    Python 3.9 stopped wrapping a subscript in `ast.Index`, and 3.8 is still supported.
+    The wrapper is read by name rather than by `isinstance`, because `ast.Index` has been
+    deprecated since 3.9 and touching it raises a `DeprecationWarning`.
+    https://docs.python.org/3/whatsnew/3.9.html#deprecated
+    """
+    inner = node.slice
+
+    return getattr(inner, "value", inner) if inner.__class__.__name__ == "Index" else inner
+
+
+def names_in(node: ast.expr, *, line: int) -> Iterator[Tuple[Tuple[str, ...], int]]:
+    """Every name an annotation mentions, with the line it was written on.
+
+    A string annotation holds a whole type expression rather than a bare name, so it is
+    parsed and walked like any other: `Optional[List["types.Chat"]]` names `types.Chat`.
+    """
+    if isinstance(node, ast.Subscript):
+        head = dotted_name(node.value)
+
+        yield from names_in(node.value, line=line)
+
+        # `Literal["png", "jpg"]` holds values, and a value is not a name.
+        #  https://docs.python.org/3/library/typing.html#typing.Literal
+        if head is not None and head[-1] == "Literal":
+            return
+
+        yield from names_in(subscript_of(node), line=line)
+        return
+
+    if isinstance(node, (ast.Tuple, ast.List)):
+        for element in node.elts:
+            yield from names_in(element, line=line)
+
+        return
+
+    if isinstance(node, ast.BinOp):
+        yield from names_in(node.left, line=line)
+        yield from names_in(node.right, line=line)
+        return
+
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        try:
+            inner = ast.parse(node.value.strip(), mode="eval").body
+
+        # A string annotation is not required to be an expression, and one that is not is
+        #  a defect of its own rather than a dead name.
+        except SyntaxError:
+            return
+
+        yield from names_in(inner, line=node.lineno)
+        return
+
+    parts = dotted_name(node)
+
+    if parts is not None:
+        yield parts, line
+
+
+def type_checking_imports(tree: ast.Module, *, package: str) -> Dict[str, Any]:
+    """The names a module binds under `if TYPE_CHECKING:`, imported for real.
+
+    Most of this package imports `pyrogram`, `types`, `raw` and `enums` only there, to break
+    the import cycle they would otherwise close. Those names are absent from the imported
+    module at runtime, so a namespace built from it alone reports every annotation that uses
+    one as dead.
+    """
+    bindings: Dict[str, Any] = {}
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If) or (dotted_name(node.test) or ("",))[-1] != "TYPE_CHECKING":
+            continue
+
+        for statement in ast.walk(node):
+            if isinstance(statement, ast.Import):
+                for alias in statement.names:
+                    root = alias.name.split(".")[0]
+                    bindings[alias.asname or root] = importlib.import_module(root)
+
+            elif isinstance(statement, ast.ImportFrom):
+                source = importlib.import_module("." * statement.level + (statement.module or ""), package)
+
+                for alias in statement.names:
+                    bindings[alias.asname or alias.name] = getattr(source, alias.name)
+
+    return bindings
+
+
+def namespace_of(module: ModuleType, *, tree: ast.Module) -> Dict[str, Any]:
+    namespace = dict(vars(module))
+    namespace.update(type_checking_imports(tree, package=module.__name__.rpartition(".")[0]))
+
+    return namespace
+
+
+def annotations_in(path: pathlib.Path) -> Iterator[Tuple[Annotation, Dict[str, Any]]]:
+    module = importlib.import_module(module_name_of(path))
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    namespace = namespace_of(module, tree=tree)
+
+    for annotation in annotations_of(tree):
+        for name, line in names_in(annotation, line=annotation.lineno):
+            yield Annotation(name, path, line), namespace
+
+
+def resolves_where_written(name: Sequence[str], *, namespace: Dict[str, Any]) -> bool:
+    # A builtin is in scope everywhere and in no module's namespace, so `int` and `str` would
+    #  otherwise read as dead names.
+    root = namespace.get(name[0], getattr(builtins, name[0], None))
+
+    return root is not None and attribute_chain(root, names=name[1:])
+
+
+def dead_annotations() -> List[Annotation]:
+    return [
+        annotation
+        for path in hand_written_files()
+        for annotation, namespace in annotations_in(path)
+        if not resolves_where_written(annotation.name, namespace=namespace)
+    ]
+
+
+def test_every_name_in_an_annotation_resolves_where_it_is_written() -> None:
+    """A dead name in an annotation is what an IDE offers the caller as the type to pass."""
+    dead = sorted(str(one) for one in dead_annotations())
+
+    assert not dead, "{} annotations name something that does not exist:\n{}".format(len(dead), "\n".join(dead))
+
+
+def test_the_sweep_reads_the_annotations_it_claims_to() -> None:
+    """A walk that stopped descending would leave the test above passing over nothing."""
+    read: List[Annotation] = [annotation for path in hand_written_files() for annotation, _ in annotations_in(path)]
+    names: Set[Tuple[str, ...]] = {one.name for one in read}
+
+    assert len(read) > 5000
+    assert ("types", "Message") in names
+    assert ("raw", "base", "InputPeer") in names
+    assert any(one.path.name == "shipping_query.py" for one in read)
+
+
+def test_a_string_annotation_is_read_as_the_expression_it_holds() -> None:
+    def names(source: str) -> List[Tuple[str, ...]]:
+        return [name for name, _ in names_in(ast.parse(source, mode="eval").body, line=1)]
+
+    assert names('"types.Chat"') == [("types", "Chat")]
+    assert names('Optional[List["types.Chat"]]') == [("Optional",), ("List",), ("types", "Chat")]
+    assert names('Union["types.Chat", int]') == [("Union",), ("types", "Chat"), ("int",)]
+    assert names('"Optional[types.Chat]"') == [("Optional",), ("types", "Chat")]
+
+
+def test_a_subscript_is_read_through_the_wrapper_python_38_puts_around_it() -> None:
+    """The suite runs on 3.8, whose parser wraps `X[Y]` in a node 3.9 stopped emitting.
+
+    The wrapper cannot be produced by parsing here, so the node is built the way the 3.8
+    parser builds it. Without the unwrapping, every name inside a subscript is invisible
+    on 3.8 alone and the sweep passes there over nothing.
+    """
+    inner = ast.parse('"types.Chat"', mode="eval").body
+    wrapped = ast.Subscript(value=ast.Name(id="Optional", ctx=ast.Load()), slice=ast.Index(value=inner), ctx=ast.Load())
+    ast.fix_missing_locations(wrapped)
+
+    assert subscript_of(wrapped) is inner
+    assert [name for name, _ in names_in(wrapped, line=1)] == [("Optional",), ("types", "Chat")]
+
+
+def test_a_literal_holds_values_rather_than_names() -> None:
+    """Without this, every string a `Literal` lists would be read as a type that is missing."""
+    def names(source: str) -> List[Tuple[str, ...]]:
+        return [name for name, _ in names_in(ast.parse(source, mode="eval").body, line=1)]
+
+    assert names('Literal["socks4", "socks5"]') == [("Literal",)]
+    assert names('typing.Literal["a", "A"]') == [("typing", "Literal")]
+    assert names('Optional[Literal["a"]]') == [("Optional",), ("Literal",)]
+
+
+def test_a_name_resolves_against_the_namespace_it_was_written_in() -> None:
+    namespace: Dict[str, Any] = {"types": pyrogram.types}
+
+    assert resolves_where_written(("types", "Chat"), namespace=namespace)
+    assert resolves_where_written(("int",), namespace=namespace)
+
+    assert not resolves_where_written(("types", "NoSuchType"), namespace=namespace)
+    assert not resolves_where_written(("enums", "ParseMode"), namespace=namespace)

--- a/tests/unit/test_docstring_references.py
+++ b/tests/unit/test_docstring_references.py
@@ -23,17 +23,11 @@ and carries on, so a dead reference looks almost right and nothing reports it.
 """
 
 import ast
-import importlib
 import pathlib
 import re
 from typing import Final, Iterator, List, NamedTuple, Optional, Pattern, Set, Tuple
 
-_REPOSITORY_ROOT: Final[pathlib.Path] = pathlib.Path(__file__).resolve().parents[2]
-_PACKAGE_ROOT: Final[pathlib.Path] = _REPOSITORY_ROOT / "pyrogram"
-
-# The generated tree is rewritten wholesale by `make api` from the TL schema, so a repair
-#  there lives until the next schema update and no longer.
-_GENERATED_TREE: Final[pathlib.Path] = _PACKAGE_ROOT / "raw"
+from tests.unit.name_resolution import REPOSITORY_ROOT, hand_written_files, resolves
 
 # `:obj:`Message`` and `:py:obj:`Message`` are the same role, the second one naming the
 #  domain the first one inherits.
@@ -56,7 +50,7 @@ class Reference(NamedTuple):
     def __str__(self) -> str:
         body = self.target if self.label is None else "{} <{}>".format(self.label, self.target)
 
-        return "{}:{}: {}".format(self.path.relative_to(_REPOSITORY_ROOT), self.line, body)
+        return "{}:{}: {}".format(self.path.relative_to(REPOSITORY_ROOT), self.line, body)
 
 
 def components(dotted: str) -> List[str]:
@@ -112,37 +106,13 @@ def docstrings_of(path: pathlib.Path) -> Iterator[Tuple[str, int]]:
 def hand_written_references() -> List[Reference]:
     references: List[Reference] = []
 
-    for path in sorted(_PACKAGE_ROOT.rglob("*.py")):
-        if _GENERATED_TREE in path.parents:
-            continue
-
+    for path in hand_written_files():
         for docstring, first_line in docstrings_of(path):
             for offset, line in enumerate(docstring.splitlines()):
                 for label, target in references_in(line):
                     references.append(Reference(target, path, first_line + offset, label))
 
     return references
-
-
-def resolves(target: str) -> bool:
-    """Import the longest prefix of `target`, then walk the rest of it with `getattr`."""
-    parts = target.split(".")
-
-    for cut in range(len(parts), 0, -1):
-        try:
-            resolved = importlib.import_module(".".join(parts[:cut]))
-        except ImportError:
-            continue
-
-        for name in parts[cut:]:
-            if not hasattr(resolved, name):
-                return False
-
-            resolved = getattr(resolved, name)
-
-        return True
-
-    return False
 
 
 def test_every_cross_reference_in_a_docstring_resolves() -> None:


### PR DESCRIPTION
## What

Seven annotations across five files name types that do not exist. Each one is a
string, so nothing ever evaluates it: the interpreter does not look, and Sphinx
renders an unresolvable target as plain text rather than failing. They surface
only when somebody asks for the type — a type checker, an IDE, or
`typing.get_type_hints`:

    $ python -c 'import typing; from pyrogram import utils; typing.get_type_hints(utils.obj_to_jsonvalue)'
    AttributeError: module 'pyrogram.raw.base' has no attribute 'JsonValue'

The same question asked of all six affected callables, on `dev`:

    utils.obj_to_jsonvalue                 AttributeError: module 'pyrogram.raw.base' has no attribute 'JsonValue'
    Client.__init__                        AttributeError: module 'pyrogram.raw.base' has no attribute 'JsonValue'
    ShippingQuery.answer                   AttributeError: module 'pyrogram.types' has no attribute 'ShippingOptions'
    PrivacyRule.__init__                   AttributeError: module 'pyrogram.types' has no attribute 'PrivacyRuleType'
    MessageReactionCountUpdated.__init__   AttributeError: module 'pyrogram.types' has no attribute 'ReactionCount'
    ChatFolderInviteLinkInfo.__init__      AttributeError: module 'pyrogram.types' has no attribute 'ChatFolderInfo'

and here:

    utils.obj_to_jsonvalue                 ok
    Client.__init__                        ok
    ShippingQuery.answer                   ok
    PrivacyRule.__init__                   ok
    MessageReactionCountUpdated.__init__   ok
    ChatFolderInviteLinkInfo.__init__      ok

Every name is replaced with the type the code beside it actually builds:

- `raw.base.JsonValue` to `raw.base.JSONValue`, in `Client.__init__`,
  `utils.obj_to_jsonvalue()` and `utils.jsonvalue_to_obj()`. The generated base
  exports `JSONValue`, and the `init_connection_params` docstring said the wrong
  spelling too.
- `types.ReactionCount` to `types.Reaction`, in `MessageReactionCountUpdated`.
  `Reaction._parse_count()` is what fills that list.
- `types.ChatFolderInfo` to `types.Folder`, in `ChatFolderInviteLinkInfo`, whose
  `_parse()` builds a `types.Folder`.
- `types.PrivacyRuleType` to `enums.PrivacyRuleType`, in `PrivacyRule`. It is an
  enum, and `_parse()` assigns `enums.PrivacyRuleType(...)`.
- `types.ShippingOptions` to `List[types.ShippingOption]`, in
  `ShippingQuery.answer()`. That name never existed in either spelling, and the
  method forwards the value to `answer_shipping_query()`, which takes a list.

The last one is the only change of shape rather than of spelling: anyone
following the annotation was passing a single option where a list is required.
Its docstring is corrected to match.

## How to test

`make lint` and `make test-unit` (594 passed).

A new test walks every annotation in the hand-written tree and resolves each
name against the module it is written in, so a name that does not exist fails
the suite instead of waiting to be noticed. Against `dev` it reports exactly the
seven sites:

    AssertionError: 7 annotations name something that does not exist:
    pyrogram/client.py:342: raw.base.JsonValue
    pyrogram/types/bots_and_keyboards/message_reaction_count_updated.py:54: types.ReactionCount
    pyrogram/types/bots_and_keyboards/shipping_query.py:84: types.ShippingOptions
    pyrogram/types/user_and_chats/chat_folder_invite_link_info.py:45: types.ChatFolderInfo
    pyrogram/types/user_and_chats/privacy_rule.py:42: types.PrivacyRuleType
    pyrogram/utils.py:742: raw.base.JsonValue
    pyrogram/utils.py:759: raw.base.JsonValue

Resolution has to happen at runtime rather than statically: much of the tree
imports `types`, `raw` and `enums` only under `TYPE_CHECKING` to break an import
cycle, so the test imports those bindings for real before looking. The generated
`pyrogram/raw/` tree is skipped, because `make api` rewrites it wholesale and a
repair there would not survive the next schema update. The name-resolution half
is shared with the existing docstring-reference test rather than duplicated.
