### PR TITLE
fix(types): make the three update types that reach a handler `Update`s

### DIFF
--- a/pyrogram/filters.py
+++ b/pyrogram/filters.py
@@ -23,6 +23,7 @@ from typing import Callable, Final, FrozenSet, List, Optional, Pattern, Tuple, T
 import pyrogram
 from pyrogram import enums
 from pyrogram.types import (
+    BusinessConnection,
     CallbackQuery,
     Chat,
     ChatBoostUpdated,
@@ -31,11 +32,13 @@ from pyrogram.types import (
     ChosenInlineResult,
     InlineKeyboardMarkup,
     InlineQuery,
+    ManagedBotUpdated,
     Message,
     MessageGenerationStopped,
     MessageReactionCountUpdated,
     MessageReactionUpdated,
     PreCheckoutQuery,
+    PurchasedPaidMedia,
     ReplyKeyboardMarkup,
     ShippingQuery,
     Story,
@@ -158,6 +161,7 @@ _WITH_A_SENDER: Final[Tuple[Type[Update], ...]] = (
     InlineQuery,
     Message,
     PreCheckoutQuery,
+    PurchasedPaidMedia,
     ShippingQuery,
     Story,
 )
@@ -178,18 +182,23 @@ _WITH_A_SENDER_CHAT: Final[Tuple[Type[Update], ...]] = (Message, Story)
 
 _CAN_BE_OUTGOING: Final[Tuple[Type[Update], ...]] = (Message, Story)
 
-# Three more shapes, one update type each, that the tuples above cannot express: the
-#  attribute is there, but not under the name the tuples read.
+# Three more shapes that the tuples above cannot express: the attribute is there, but not
+#  under the name the tuples read.
 #
 #  `UpdateUserStatus` is parsed into the `User` whose status changed and nothing else
-#  (`User._parse_user_status`), so that update *is* its own sender; `MessageReactionUpdated`
-#  spells the reacting user `user` and the anonymous one `actor_chat`; `ChatBoostUpdated`
-#  keeps the booster one level down, in `boost.from_user`.
+#  (`User._parse_user_status`), so that update *is* its own sender; `MessageReactionUpdated`,
+#  `BusinessConnection` and `ManagedBotUpdated` spell the sender `user`, and the first also
+#  spells the anonymous one `actor_chat`; `ChatBoostUpdated` keeps the booster one level
+#  down, in `boost.from_user`.
 #
 #  Reading them here rather than renaming the attributes leaves the public API untouched.
 _IS_ITS_OWN_SENDER: Final[Tuple[Type[Update], ...]] = (User,)
 
-_WITH_A_SENDER_NAMED_USER: Final[Tuple[Type[Update], ...]] = (MessageReactionUpdated,)
+_WITH_A_SENDER_NAMED_USER: Final[Tuple[Type[Update], ...]] = (
+    BusinessConnection,
+    ManagedBotUpdated,
+    MessageReactionUpdated,
+)
 
 _WITH_A_SENDER_CHAT_NAMED_ACTOR_CHAT: Final[Tuple[Type[Update], ...]] = (MessageReactionUpdated,)
 

--- a/pyrogram/handlers/business_connection_handler.py
+++ b/pyrogram/handlers/business_connection_handler.py
@@ -51,6 +51,6 @@ class BusinessConnectionHandler(Handler):
     """
 
     def __init__(
-        self, callback: Callable[["pyrogram.Client", "types.ManagedBotUpdated"], Any], filters=None
+        self, callback: Callable[["pyrogram.Client", "types.BusinessConnection"], Any], filters=None
     ):
         super().__init__(callback, filters)

--- a/pyrogram/handlers/chat_boost_handler.py
+++ b/pyrogram/handlers/chat_boost_handler.py
@@ -45,11 +45,11 @@ class ChatBoostHandler(Handler):
         client (:obj:`~pyrogram.Client`):
             The Client itself, useful when you want to call other API methods inside the handler.
 
-        boost (:obj:`~pyrogram.types.ChatBoost`):
+        boost (:obj:`~pyrogram.types.ChatBoostUpdated`):
             The applied chat boost.
     """
 
     def __init__(
-        self, callback: Callable[["pyrogram.Client", "types.ChatBoost"], Any], filters=None
+        self, callback: Callable[["pyrogram.Client", "types.ChatBoostUpdated"], Any], filters=None
     ):
         super().__init__(callback, filters)

--- a/pyrogram/types/bots_and_keyboards/managed_bot_updated.py
+++ b/pyrogram/types/bots_and_keyboards/managed_bot_updated.py
@@ -22,9 +22,10 @@ import pyrogram
 from pyrogram import raw, types
 
 from ..object import Object
+from ..update import Update
 
 
-class ManagedBotUpdated(Object):
+class ManagedBotUpdated(Object, Update):
     """This object contains information about the creation or token update of a bot that is managed by the current bot.
 
     Parameters:

--- a/pyrogram/types/bots_and_keyboards/purchased_paid_media.py
+++ b/pyrogram/types/bots_and_keyboards/purchased_paid_media.py
@@ -19,9 +19,10 @@
 from pyrogram import raw, types
 
 from ..object import Object
+from ..update import Update
 
 
-class PurchasedPaidMedia(Object):
+class PurchasedPaidMedia(Object, Update):
     """This object represents information about purchased paid media.
 
     Parameters:

--- a/pyrogram/types/user_and_chats/business_connection.py
+++ b/pyrogram/types/user_and_chats/business_connection.py
@@ -21,9 +21,10 @@ from typing import Optional, Union
 
 from pyrogram import types, raw, utils
 from ..object import Object
+from ..update import Update
 
 
-class BusinessConnection(Object):
+class BusinessConnection(Object, Update):
     """Business information of a user.
 
     Parameters:

--- a/tests/unit/handlers/__init__.py
+++ b/tests/unit/handlers/__init__.py
@@ -1,0 +1,18 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+

--- a/tests/unit/handlers/test_handler_update_types.py
+++ b/tests/unit/handlers/test_handler_update_types.py
@@ -1,0 +1,166 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Every handler names the type it is handed, and that type is an `Update`.
+
+A callback handed something that is not an `Update` can neither be filtered on its sender
+nor stop the chain, because both live on `Update`. Neither failure announces itself: the
+sender filters answer `False`, which reads as "no sender" rather than "never looked".
+"""
+
+import inspect
+import re
+import typing
+from typing import Any, Final, FrozenSet, Iterator, List, Optional, Pattern, Set, Tuple, Type
+
+from pyrogram import handlers, types
+from pyrogram.types import Update
+
+# The `Other parameters:` block of a handler docstring names the type the callback is
+#  handed, which is the same claim the annotation makes a few lines below it.
+_DOCUMENTED_TYPE: Final[Pattern[str]] = re.compile(r":obj:`~pyrogram\.types\.([A-Za-z]+)`")
+
+_OTHER_PARAMETERS: Final[str] = "Other parameters:"
+
+# The callbacks handed something other than a parsed update: `Handler` takes a bare
+#  `Callable`, `Start`/`Stop` the client, `Connect`/`Disconnect` the session it opened, and
+#  `Error`/`RawUpdate` the TL object before anything has parsed it.
+_TAKES_NO_PARSED_UPDATE: Final[FrozenSet[str]] = frozenset(
+    {
+        "ConnectHandler",
+        "DisconnectHandler",
+        "ErrorHandler",
+        "Handler",
+        "RawUpdateHandler",
+        "StartHandler",
+        "StopHandler",
+    }
+)
+
+
+def handler_classes() -> Iterator[Type[handlers.Handler]]:
+    """Every handler the package exports, the base class included."""
+    for name in sorted(vars(handlers)):
+        one = getattr(handlers, name)
+
+        if inspect.isclass(one) and issubclass(one, handlers.Handler):
+            yield one
+
+
+def name_of(annotation: Any) -> str:
+    """The last component of what an annotation names, whether or not it is still a string.
+
+    Handler modules import `types` under `TYPE_CHECKING` only, so their annotations survive
+    as `ForwardRef`s and `typing.get_type_hints` cannot evaluate them.
+    """
+    written = getattr(annotation, "__forward_arg__", None)
+
+    return (written or annotation.__name__).split(".")[-1]
+
+
+def handed_to(handler: Type[handlers.Handler]) -> Optional[str]:
+    """The type the callback of `handler` is handed, or `None` when it is handed no update.
+
+    `List[X]` reads as `X`: the two deleted-message handlers are given the whole batch at
+    once. The element is what a sender filter would read, and the list carries neither that
+    nor `stop_propagation()`: a separate shape, and a separate decision.
+    """
+    callback = inspect.signature(handler.__init__).parameters["callback"].annotation
+    arguments = typing.get_args(callback)
+
+    if not arguments or len(arguments[0]) < 2:
+        return None
+
+    update = arguments[0][1]
+
+    return name_of(typing.get_args(update)[0] if typing.get_origin(update) is list else update)
+
+
+def documented_by(handler: Type[handlers.Handler]) -> Set[str]:
+    """The `pyrogram.types` names the handler's `Other parameters:` block points at."""
+    documentation: str = handler.__doc__ or ""
+
+    if _OTHER_PARAMETERS not in documentation:
+        return set()
+
+    return set(_DOCUMENTED_TYPE.findall(documentation.split(_OTHER_PARAMETERS)[-1]))
+
+
+def handlers_with_an_update() -> List[Tuple[str, str]]:
+    return [
+        (handler.__name__, handed_to(handler))
+        for handler in handler_classes()
+        if handler.__name__ not in _TAKES_NO_PARSED_UPDATE
+    ]
+
+
+def test_every_handler_is_handed_an_update() -> None:
+    """A type that reaches a handler without being an `Update` is filtered against silently.
+
+    `PurchasedPaidMedia`, `ManagedBotUpdated` and `BusinessConnection` were `Object` alone,
+    so `filters.me` answered `False` for all three and their callbacks could not call
+    `stop_propagation()` at all.
+    """
+    not_updates = sorted(
+        "{}: {}".format(name, handed)
+        for name, handed in handlers_with_an_update()
+        if not issubclass(getattr(types, handed), Update)
+    )
+
+    assert not not_updates, "handlers handed something that is not an `Update` ({}):\n{}".format(
+        len(not_updates),
+        "\n".join(not_updates),
+    )
+
+
+def test_every_handler_documents_the_type_it_annotates() -> None:
+    """The docstring and the annotation are two copies of one claim, so they drift apart.
+
+    `BusinessConnectionHandler` documented `BusinessConnection` while annotating
+    `ManagedBotUpdated`, which is what an IDE showed the caller.
+    """
+    disagreeing = sorted(
+        "{}: documents {}, annotates {}".format(name, sorted(documented) or "nothing", handed)
+        for name, handed, documented in (
+            (name, handed, documented_by(getattr(handlers, name)))
+            for name, handed in handlers_with_an_update()
+        )
+        if documented != {handed}
+    )
+
+    assert not disagreeing, "handlers documenting a type they do not annotate ({}):\n{}".format(
+        len(disagreeing),
+        "\n".join(disagreeing),
+    )
+
+
+def test_the_sweep_reads_the_handlers_it_claims_to() -> None:
+    """A signature this stops being able to read would leave both rules passing over nothing."""
+    handed = dict(handlers_with_an_update())
+
+    assert len(handed) > 20
+    assert handed["PurchasedPaidMediaHandler"] == "PurchasedPaidMedia"
+    assert handed["DeletedMessagesHandler"] == "Message"
+    assert handed["UserStatusHandler"] == "User"
+
+
+def test_every_exemption_names_a_handler_that_exists() -> None:
+    """An exemption left behind by a rename exempts nothing and hides the next omission."""
+    exported = {handler.__name__ for handler in handler_classes()}
+
+    assert _TAKES_NO_PARSED_UPDATE <= exported, sorted(_TAKES_NO_PARSED_UPDATE - exported)


### PR DESCRIPTION
## What

`PurchasedPaidMedia`, `ManagedBotUpdated` and `BusinessConnection` reach a
handler like every other update, but they subclass `Object` alone. Two things
that live on `Update` are therefore missing from them: the sender filters read
nothing, and the callback cannot stop the chain.

Neither failure announces itself. `filters.me` answers `False`, which reads as
"this update is not from me" rather than "nothing was ever looked at", so a
handler guarded by it simply never runs and nothing is logged. On `dev`:

    PurchasedPaidMedia   isinstance(Update)=False  filters.me=False  filters.user(7)=False  stop_propagation=False
    ManagedBotUpdated    isinstance(Update)=False  filters.me=False  filters.user(7)=False  stop_propagation=False
    BusinessConnection   isinstance(Update)=False  filters.me=False  filters.user(7)=False  stop_propagation=False

and here, with each object built around the same `User(id=7, is_self=True)`:

    PurchasedPaidMedia   isinstance(Update)=True   filters.me=True   filters.user(7)=True   stop_propagation=True
    ManagedBotUpdated    isinstance(Update)=True   filters.me=True   filters.user(7)=True   stop_propagation=True
    BusinessConnection   isinstance(Update)=True   filters.me=True   filters.user(7)=True   stop_propagation=True

The three now inherit `Update` beside `Object`, exactly as the fifteen other
types a handler is handed already do, and `filters.py` names them in the tuples
it reads a sender from: `PurchasedPaidMedia` spells it `from_user`, the other
two spell it `user`.

Two handlers were also annotating a type they are never given, which is what an
IDE shows the caller:

- `BusinessConnectionHandler` annotated `types.ManagedBotUpdated` while its own
  docstring said `BusinessConnection`. It is handed a `BusinessConnection`.
- `ChatBoostHandler` annotated and documented `types.ChatBoost`, but the
  dispatcher builds a `ChatBoostUpdated` and passes that. `ChatBoost` is not an
  update at all; it is the boost sitting inside one.

## Why

`filters.me`, `filters.user()` and `filters.chat()` are how a bot decides whether
an update is its business. An update they cannot read is an update those filters
silently reject, and a payment notification is a poor place to discover that.

## How to test

`make lint` and `make test-unit` (592 passed).

A new test reads the callback annotation of every exported handler and asserts
the type it names is an `Update`, plus that the `Other parameters:` block of the
docstring names the same type the annotation does. Against `dev` it reports
exactly the sites this changes:

    AssertionError: handlers handed something that is not an `Update` (4):
      BusinessConnectionHandler: ManagedBotUpdated
      ChatBoostHandler: ChatBoost
      ManagedBotUpdatedHandler: ManagedBotUpdated
      PurchasedPaidMediaHandler: PurchasedPaidMedia

    AssertionError: handlers documenting a type they do not annotate (1):
      BusinessConnectionHandler: documents ['BusinessConnection'], annotates ManagedBotUpdated

`BusinessConnection` is hidden behind the copy-paste in that first list and
surfaces as a fourth defect once the annotation is corrected.

What this does not reach: `DeletedMessagesHandler` and
`DeletedBusinessMessagesHandler` are handed a `List[Message]` rather than an
update, so `stop_propagation()` is unavailable there and a sender filter has
nothing to read. That is a different shape and a separate decision, so the test
takes the element type for those two and leaves the question open.
