### PR TITLE
fix(upload): annotate `self` on the `save_file()` overloads as the implementation does

### DIFF
--- a/pyrogram/methods/advanced/save_file.py
+++ b/pyrogram/methods/advanced/save_file.py
@@ -36,13 +36,15 @@ log = logging.getLogger(__name__)
 
 
 class SaveFile:
-    # The three shapes below are what the body already does. They are spelled out so a caller
-    #  storing the result into a required `InputFile` field is not asked to handle a `None`
-    #  the arguments it passed cannot produce. They leave `self` bare because `Client`
-    #  inherits this mixin, so the binding is the same without the annotation below.
+    # The three shapes below are what the body already does, so a caller storing the result
+    #  into a required `InputFile` field is not asked to handle a `None` the arguments it
+    #  passed cannot produce.
+    #
+    # Each repeats the implementation's `self`: a bare one reads as `SaveFile`, which is
+    #  wider than `Client`, and an overload the implementation does not accept is an error.
     @overload
     async def save_file(
-        self,
+        self: "pyrogram.Client",
         path: None,
         file_id: Optional[int] = None,
         file_part: int = 0,
@@ -52,7 +54,7 @@ class SaveFile:
 
     @overload
     async def save_file(
-        self,
+        self: "pyrogram.Client",
         path: Union[str, BinaryIO],
         file_id: int,
         file_part: int = 0,
@@ -62,7 +64,7 @@ class SaveFile:
 
     @overload
     async def save_file(
-        self,
+        self: "pyrogram.Client",
         path: Union[str, BinaryIO],
         file_id: None = None,
         file_part: int = 0,

--- a/tests/unit/test_annotation_references.py
+++ b/tests/unit/test_annotation_references.py
@@ -257,7 +257,11 @@ def test_a_subscript_is_read_through_the_wrapper_python_38_puts_around_it() -> N
     on 3.8 alone and the sweep passes there over nothing.
     """
     inner = ast.parse('"types.Chat"', mode="eval").body
-    wrapped = ast.Subscript(value=ast.Name(id="Optional", ctx=ast.Load()), slice=ast.Index(value=inner), ctx=ast.Load())
+
+    # TODO: Delete this test and the unwrapping in `subscript_of()` when the floor moves
+    #       off 3.8. Nothing else reads `ast.Index`, and 3.9 stopped emitting it.
+    index = ast.Index(value=inner)  # ty: ignore[deprecated] - the 3.8 node is what this test is for
+    wrapped = ast.Subscript(value=ast.Name(id="Optional", ctx=ast.Load()), slice=index, ctx=ast.Load())
     ast.fix_missing_locations(wrapped)
 
     assert subscript_of(wrapped) is inner


### PR DESCRIPTION
## What

Two things on `dev` fail `ty`. Neither is visible here, because nothing on `dev`
runs a type checker yet: they surface in the open pull request that wires `ty`
in, whose ignore list was frozen before either landed.

**The three `save_file()` overloads leave `self` bare while the implementation
annotates it.** An overload taking `self: SaveFile` is wider than an
implementation requiring `self: pyrogram.Client`, so a call the overload accepts
is one the implementation would reject. This is not a quirk of one checker;
`pyright` reports the same shape, reduced to a minimal example:

    error: Overloaded implementation is not consistent with signature of overload 1
      Parameter 1: type "Self@Mixin" is incompatible with type "Client"
        "Mixin*" is not assignable to "Client" (reportInconsistentOverload)

Each overload now repeats the implementation's annotation, and the comment above
them says why rather than claiming the bare `self` is equivalent.

**`test_a_subscript_is_read_through_the_wrapper_python_38_puts_around_it` builds
an `ast.Index` on purpose**, and that class is deprecated. The deprecation is the
point: 3.9 stopped emitting the node, so it cannot be produced by parsing and has
to be constructed by hand for the 3.8 unwrapping in `subscript_of()` to be
covered on any other version. Silenced at the line, with a `TODO` to delete both
the test and the unwrapping once the floor moves off 3.8.

Together, against the branch that turns the checker on:

    $ make typecheck
    Found 4 diagnostics
    make: *** [Makefile:92: typecheck] Error 1

    $ make typecheck
    All checks passed!

## Why

`ty check` exits 1 on any diagnostic, warnings included, so the deprecation alone
is enough to fail a lint job. Verified: with the three overload errors fixed and
only that warning left, the exit code is still 1.

The overload half is worth fixing regardless of tooling. Anyone reading those
signatures is told the method is callable on any `SaveFile`, which the
implementation does not honour.

## How to test

`make lint` and `make test-unit` (688 passed).

`make typecheck` does not exist on `dev` yet, so the before and after above were
produced by merging this branch into the type-checking branch and running its own
recipe there.
