### PR TITLE
refactor(tests): name every client double `FakeClient`

### DIFF
--- a/tests/unit/filters/__init__.py
+++ b/tests/unit/filters/__init__.py
@@ -19,7 +19,7 @@
 from typing import Optional
 
 
-class Client:
+class FakeClient:
     def __init__(self):
         self.me = User("username")
 

--- a/tests/unit/filters/test_command.py
+++ b/tests/unit/filters/test_command.py
@@ -19,9 +19,9 @@
 import pytest
 
 from pyrogram import filters
-from tests.unit.filters import Client, Message
+from tests.unit.filters import FakeClient, Message
 
-c = Client()
+c = FakeClient()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/session/test_invoke_flood_wait.py
+++ b/tests/unit/session/test_invoke_flood_wait.py
@@ -24,7 +24,7 @@ from pyrogram.errors import FloodWait
 from pyrogram.session.session import Session
 
 
-class _Client:
+class FakeClient:
     name = "test"
 
 
@@ -34,7 +34,7 @@ class _Session(Session):
     def __init__(self, seconds) -> None:
         self.is_started = asyncio.Event()
         self.is_started.set()
-        self.client = _Client()
+        self.client = FakeClient()
         self.seconds = seconds
         self.send_calls = 0
 

--- a/tests/unit/types/messages_and_media/test_message_reply_game.py
+++ b/tests/unit/types/messages_and_media/test_message_reply_game.py
@@ -25,7 +25,7 @@ class _Chat:
     id = 42
 
 
-class _Client:
+class FakeClient:
     def __init__(self) -> None:
         self.captured = "not-called"
 
@@ -39,7 +39,7 @@ class _Message:
     id = 1
     message_thread_id = None
 
-    def __init__(self, client: _Client) -> None:
+    def __init__(self, client: FakeClient) -> None:
         self._client = client
 
 
@@ -48,7 +48,7 @@ async def test_reply_game_default_effect_id_is_none() -> None:
     # `effect_id: int = Optional[None]` evaluated at runtime to the NoneType class
     #  itself, not to None (Optional[None] collapses to NoneType): every call that
     #  omitted effect_id silently forwarded that class object to send_game().
-    client = _Client()
+    client = FakeClient()
 
     await Message.reply_game(_Message(client), "lumberjack")
 
@@ -57,7 +57,7 @@ async def test_reply_game_default_effect_id_is_none() -> None:
 
 @pytest.mark.asyncio
 async def test_answer_game_default_effect_id_is_none() -> None:
-    client = _Client()
+    client = FakeClient()
 
     await Message.answer_game(_Message(client), "lumberjack")
 


### PR DESCRIPTION
## What

Eleven test modules already call their client double `FakeClient`. Three did not:

```
# before
tests/unit/filters/__init__.py:22:class Client:
tests/unit/session/test_invoke_flood_wait.py:27:class _Client:
tests/unit/types/messages_and_media/test_message_reply_game.py:28:class _Client:

# after
tests/unit/filters/__init__.py:22:class FakeClient:
tests/unit/session/test_invoke_flood_wait.py:27:class FakeClient:
tests/unit/types/messages_and_media/test_message_reply_game.py:28:class FakeClient:
```

Seven call sites follow the rename. Nothing else changes.

## Why

`class Client` in `tests/unit/filters/__init__.py` shadows the real `pyrogram.Client` for anyone
reading that file, and a leading underscore claims "private to this module" about a name that is
the module's whole point. `CONTRIBUTING.md` already states `FakeClient` as the convention; this
makes the tree match it.

## How to test

```
make test-unit       # 738 passed, 7 deselected
```
