### PR TITLE
chore(deps): replace every `<=` ceiling with a tested `>=` floor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,9 @@ A few conventions that have come up repeatedly in code review but aren't enforce
   `list[str]` and `int | None` in a signature pass on a modern interpreter and fail the matrix
   with `TypeError: 'type' object is not subscriptable` and `TypeError: unsupported operand
   type(s) for |: 'type' and 'NoneType'`. Use `List[str]` and `Optional[int]` from `typing`.
+- **A dependency is declared with a floor, never a ceiling.** `pyproject.toml` carries the
+  reasoning beside the declarations. Where a major version genuinely breaks us, add the upper
+  bound and name the breakage in a comment next to it.
 - **No `assert` for runtime guards in library code.** `assert` statements are stripped when
   Python runs with `-O`, and raise a bare `AssertionError` with no context for library consumers.
   Raise `RuntimeError` (or a more specific exception) instead.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
 [build-system]
-requires = ["hatchling"]
+# PEP 639 metadata (`license` as an expression, `license-files` as a list) needs 1.26.3.
+#  Below it the build fails with `TypeError: Field project.license-files must be a table`.
+requires = ["hatchling>=1.26.3"]
 build-backend = "hatchling.build"
 
 [project]
@@ -35,10 +37,17 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
-# Every constraint is a floor, at the oldest version the lock resolves to, which is what CI
-#  installs on the lowest interpreter in the matrix. No ceilings: an upper bound on a
-#  library's dependency propagates into every downstream resolve and ages by hand.
-dependencies = ["pyaes>=1.6.1", "python-socks[asyncio]>=2.8.1"]
+# Every constraint is a floor, measured rather than guessed: the oldest version this code
+#  works with, and the start of an unbroken range up to the newest. No ceilings, because an
+#  upper bound propagates into every downstream resolve and ages by hand.
+dependencies = [
+    # 1.1.0 and below are Python 2 only: the import fails with a `SyntaxError` on a `print`
+    #  statement, and 1.0.0 with a `NameError` on `xrange`.
+    "pyaes>=1.2.0",
+    # `tcp.py` builds the proxy as `Proxy(proxy_type=..., host=..., port=...)`, and 2.3.0
+    #  and below have no such constructor: `TypeError: Proxy() takes no arguments`.
+    "python-socks[asyncio]>=2.4.0",
+]
 license = "LGPL-3.0-or-later"
 license-files = ["COPYING", "COPYING.lesser"]
 keywords = [
@@ -61,17 +70,27 @@ Community = "https://t.me/kurigram_chat"
 
 [project.optional-dependencies]
 fast = [
-    "tgcrypto>=1.2.5",
+    # 1.2.1 shipped no sdist and no wheel past `cp38`, so it cannot be installed on a
+    #  current interpreter at all, while 1.2.0 below it and 1.2.2 above it both can. The
+    #  floor sits above that hole rather than at the oldest working release.
+    "tgcrypto>=1.2.2",
     "uvloop>=0.21.0; sys_platform == 'darwin' or sys_platform == 'linux'",
 ]
 
 qrcode = [
-    "qrcode>=7.4.2",
+    # `Client.authorize_qr` calls `print_ascii(tty=True)`, and on 5.2 and 5.2.1 that raises
+    #  a `TypeError`: it writes bytes into a text buffer. 5.1 below the hole and 5.2.2 above
+    #  it both work, so the floor sits above the hole.
+    "qrcode>=5.2.2",
 ]
 
 # `dev` and `docs` are tooling, not something a user of the library installs, so they are
 #  dependency groups rather than extras: `uv sync` takes them from the lock file and `pip
 #  install kurigram[dev]` stops being a thing anyone can type by accident.
+#
+# Their floors are deliberately above the oldest version that runs. A linter or a
+#  documentation theme resolved a year back gives a different verdict and a different site
+#  from the one CI gives, which is worse than a version conflict.
 [dependency-groups]
 # `dev` is the aggregate one `uv sync` installs by default. It lists groups, never packages,
 #  so every package below sits in a group that says what it is for and a leaner install can

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,10 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
-dependencies = ["pyaes<=1.6.1", "python-socks[asyncio]<=2.8.1"]
+# Every constraint is a floor, at the oldest version the lock resolves to, which is what CI
+#  installs on the lowest interpreter in the matrix. No ceilings: an upper bound on a
+#  library's dependency propagates into every downstream resolve and ages by hand.
+dependencies = ["pyaes>=1.6.1", "python-socks[asyncio]>=2.8.1"]
 license = "LGPL-3.0-or-later"
 license-files = ["COPYING", "COPYING.lesser"]
 keywords = [
@@ -58,12 +61,12 @@ Community = "https://t.me/kurigram_chat"
 
 [project.optional-dependencies]
 fast = [
-    "tgcrypto<=1.2.5",
-    "uvloop<=0.22.1; sys_platform == 'darwin' or sys_platform == 'linux'",
+    "tgcrypto>=1.2.5",
+    "uvloop>=0.21.0; sys_platform == 'darwin' or sys_platform == 'linux'",
 ]
 
 qrcode = [
-    "qrcode<=8.2",
+    "qrcode>=7.4.2",
 ]
 
 # `dev` and `docs` are tooling, not something a user of the library installs, so they are
@@ -83,33 +86,33 @@ lint = [
     # The build backend, already named in `[build-system]`. It is here because
     #  `hatch_build.py` imports `hatchling.builders.hooks.plugin.interface` and `ty` checks
     #  that file like any other: without it, `make typecheck` fails on an unresolved import.
-    "hatchling<=1.32.0",
-    "pre-commit<=4.6.2",
-    "ruff<=0.16.3",
-    "ty<=0.0.78",
+    "hatchling>=1.27.0",
+    "pre-commit>=3.5.0",
+    "ruff>=0.16.3",
+    "ty>=0.0.78",
 ]
 
 release = [
     # `twine` stores the upload token through `keyring`.
-    "keyring<=25.7.0",
-    "twine<=6.2.0",
+    "keyring>=25.5.0",
+    "twine>=6.1.0",
 ]
 
 test = [
-    "pytest<=9.1.1",
-    "pytest-asyncio<=1.4.0",
-    "pytest-cov<=7.1.0",
-    "pytest-timeout<=2.4.0",
+    "pytest>=8.3.5",
+    "pytest-asyncio>=0.24.0",
+    "pytest-cov>=5.0.0",
+    "pytest-timeout>=2.4.0",
 ]
 
 docs = [
-    "Sphinx<=9.1.0",
-    "shibuya<=2026.5.19",
-    "sphinx-autobuild<=2025.8.25",
-    "sphinx-copybutton<=0.5.2",
-    "sphinx-iconify<=0.3.0",
-    "sphinx-design<=0.7.0",
-    "pygments<=2.20.0",
+    "Sphinx>=7.4.7",
+    "shibuya>=2025.10.21",
+    "sphinx-autobuild>=2024.10.3",
+    "sphinx-copybutton>=0.5.2",
+    "sphinx-iconify>=0.3.0",
+    "sphinx-design>=0.6.1",
+    "pygments>=2.19.2",
 ]
 
 # No `sphinx-iconify` release supports 3.8, so resolving `docs` against the library's own

--- a/pyrogram/connection/transport/tcp/tcp.py
+++ b/pyrogram/connection/transport/tcp/tcp.py
@@ -272,7 +272,7 @@ class TCP:
         # Stays `async` because `SocksProxy.__init__` calls
         #  `asyncio.get_event_loop()`, which raises "There is no current event
         #  loop" outside a running one.
-        #  https://github.com/romis2012/python-socks/blob/8794dfc734cc6fb98c61099905a9f8de186719b9/python_socks/async_/asyncio/_proxy.py#L38
+        #  https://github.com/romis2012/python-socks/blob/bc543bb8449bb9b3db372bd28116548d40d73915/python_socks/async_/asyncio/_proxy.py#L43
         proxy = self.proxy
 
         if not isinstance(proxy, (SOCKS4Proxy, SOCKS5Proxy, HTTPProxy)):
@@ -282,7 +282,7 @@ class TCP:
         # Passing the fields rather than a URL: `parse_proxy_url` drops a
         #  username that comes without a password, and `unquote()`s both, so a
         #  credential holding `@`, `:` or `%` does not survive the round trip.
-        #  https://github.com/romis2012/python-socks/blob/8794dfc734cc6fb98c61099905a9f8de186719b9/python_socks/_helpers.py#L76-L79
+        #  https://github.com/romis2012/python-socks/blob/bc543bb8449bb9b3db372bd28116548d40d73915/python_socks/_helpers.py#L79-L82
         return SocksProxy(
             proxy_type=_PYTHON_SOCKS_TYPES[proxy.scheme],
             host=proxy.hostname,

--- a/uv.lock
+++ b/uv.lock
@@ -1675,10 +1675,10 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "pyaes", specifier = ">=1.6.1" },
-    { name = "python-socks", extras = ["asyncio"], specifier = ">=2.8.1" },
-    { name = "qrcode", marker = "extra == 'qrcode'", specifier = ">=7.4.2" },
-    { name = "tgcrypto", marker = "extra == 'fast'", specifier = ">=1.2.5" },
+    { name = "pyaes", specifier = ">=1.2.0" },
+    { name = "python-socks", extras = ["asyncio"], specifier = ">=2.4.0" },
+    { name = "qrcode", marker = "extra == 'qrcode'", specifier = ">=5.2.2" },
+    { name = "tgcrypto", marker = "extra == 'fast'", specifier = ">=1.2.2" },
     { name = "uvloop", marker = "(sys_platform == 'darwin' and extra == 'fast') or (sys_platform == 'linux' and extra == 'fast')", specifier = ">=0.21.0" },
 ]
 provides-extras = ["fast", "qrcode"]

--- a/uv.lock
+++ b/uv.lock
@@ -1593,7 +1593,8 @@ name = "kurigram"
 source = { editable = "." }
 dependencies = [
     { name = "pyaes" },
-    { name = "python-socks", extra = ["asyncio"] },
+    { name = "python-socks", version = "2.8.2", source = { registry = "https://pypi.org/simple" }, extra = ["asyncio"], marker = "python_full_version < '3.9'" },
+    { name = "python-socks", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, extra = ["asyncio"], marker = "python_full_version >= '3.9'" },
 ]
 
 [package.optional-dependencies]
@@ -1674,51 +1675,51 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "pyaes", specifier = "<=1.6.1" },
-    { name = "python-socks", extras = ["asyncio"], specifier = "<=2.8.1" },
-    { name = "qrcode", marker = "extra == 'qrcode'", specifier = "<=8.2" },
-    { name = "tgcrypto", marker = "extra == 'fast'", specifier = "<=1.2.5" },
-    { name = "uvloop", marker = "(sys_platform == 'darwin' and extra == 'fast') or (sys_platform == 'linux' and extra == 'fast')", specifier = "<=0.22.1" },
+    { name = "pyaes", specifier = ">=1.6.1" },
+    { name = "python-socks", extras = ["asyncio"], specifier = ">=2.8.1" },
+    { name = "qrcode", marker = "extra == 'qrcode'", specifier = ">=7.4.2" },
+    { name = "tgcrypto", marker = "extra == 'fast'", specifier = ">=1.2.5" },
+    { name = "uvloop", marker = "(sys_platform == 'darwin' and extra == 'fast') or (sys_platform == 'linux' and extra == 'fast')", specifier = ">=0.21.0" },
 ]
 provides-extras = ["fast", "qrcode"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "hatchling", specifier = "<=1.32.0" },
-    { name = "keyring", specifier = "<=25.7.0" },
-    { name = "pre-commit", specifier = "<=4.6.2" },
-    { name = "pytest", specifier = "<=9.1.1" },
-    { name = "pytest-asyncio", specifier = "<=1.4.0" },
-    { name = "pytest-cov", specifier = "<=7.1.0" },
-    { name = "pytest-timeout", specifier = "<=2.4.0" },
-    { name = "ruff", specifier = "<=0.16.3" },
-    { name = "twine", specifier = "<=6.2.0" },
-    { name = "ty", specifier = "<=0.0.78" },
+    { name = "hatchling", specifier = ">=1.27.0" },
+    { name = "keyring", specifier = ">=25.5.0" },
+    { name = "pre-commit", specifier = ">=3.5.0" },
+    { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pytest-asyncio", specifier = ">=0.24.0" },
+    { name = "pytest-cov", specifier = ">=5.0.0" },
+    { name = "pytest-timeout", specifier = ">=2.4.0" },
+    { name = "ruff", specifier = ">=0.16.3" },
+    { name = "twine", specifier = ">=6.1.0" },
+    { name = "ty", specifier = ">=0.0.78" },
 ]
 docs = [
-    { name = "pygments", marker = "python_full_version >= '3.9'", specifier = "<=2.20.0" },
-    { name = "shibuya", marker = "python_full_version >= '3.9'", specifier = "<=2026.5.19" },
-    { name = "sphinx", marker = "python_full_version >= '3.9'", specifier = "<=9.1.0" },
-    { name = "sphinx-autobuild", marker = "python_full_version >= '3.9'", specifier = "<=2025.8.25" },
-    { name = "sphinx-copybutton", marker = "python_full_version >= '3.9'", specifier = "<=0.5.2" },
-    { name = "sphinx-design", marker = "python_full_version >= '3.9'", specifier = "<=0.7.0" },
-    { name = "sphinx-iconify", marker = "python_full_version >= '3.9'", specifier = "<=0.3.0" },
+    { name = "pygments", marker = "python_full_version >= '3.9'", specifier = ">=2.19.2" },
+    { name = "shibuya", marker = "python_full_version >= '3.9'", specifier = ">=2025.10.21" },
+    { name = "sphinx", marker = "python_full_version >= '3.9'", specifier = ">=7.4.7" },
+    { name = "sphinx-autobuild", marker = "python_full_version >= '3.9'", specifier = ">=2024.10.3" },
+    { name = "sphinx-copybutton", marker = "python_full_version >= '3.9'", specifier = ">=0.5.2" },
+    { name = "sphinx-design", marker = "python_full_version >= '3.9'", specifier = ">=0.6.1" },
+    { name = "sphinx-iconify", marker = "python_full_version >= '3.9'", specifier = ">=0.3.0" },
 ]
 lint = [
-    { name = "hatchling", specifier = "<=1.32.0" },
-    { name = "pre-commit", specifier = "<=4.6.2" },
-    { name = "ruff", specifier = "<=0.16.3" },
-    { name = "ty", specifier = "<=0.0.78" },
+    { name = "hatchling", specifier = ">=1.27.0" },
+    { name = "pre-commit", specifier = ">=3.5.0" },
+    { name = "ruff", specifier = ">=0.16.3" },
+    { name = "ty", specifier = ">=0.0.78" },
 ]
 release = [
-    { name = "keyring", specifier = "<=25.7.0" },
-    { name = "twine", specifier = "<=6.2.0" },
+    { name = "keyring", specifier = ">=25.5.0" },
+    { name = "twine", specifier = ">=6.1.0" },
 ]
 test = [
-    { name = "pytest", specifier = "<=9.1.1" },
-    { name = "pytest-asyncio", specifier = "<=1.4.0" },
-    { name = "pytest-cov", specifier = "<=7.1.0" },
-    { name = "pytest-timeout", specifier = "<=2.4.0" },
+    { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pytest-asyncio", specifier = ">=0.24.0" },
+    { name = "pytest-cov", specifier = ">=5.0.0" },
+    { name = "pytest-timeout", specifier = ">=2.4.0" },
 ]
 
 [[package]]
@@ -2406,11 +2407,36 @@ wheels = [
 
 [[package]]
 name = "python-socks"
-version = "2.8.1"
+version = "2.8.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/36/0b/cd77011c1bc01b76404f7aba07fca18aca02a19c7626e329b40201217624/python_socks-2.8.1.tar.gz", hash = "sha256:698daa9616d46dddaffe65b87db222f2902177a2d2b2c0b9a9361df607ab3687", size = 38909, upload-time = "2026-02-16T05:24:00.745Z" }
+resolution-markers = [
+    "python_full_version >= '3.8.1' and python_full_version < '3.9'",
+    "python_full_version < '3.8.1'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/ad/5bbfab3d3a266963cca0c09e23a725bbf5f0535d21c8bd1d5272e4430771/python_socks-2.8.2.tar.gz", hash = "sha256:ffc493951854fa3fc0551e0434a09a7b9f9047f9ad666dce42cb94a52e8a34b6", size = 39656, upload-time = "2026-06-23T05:22:01.994Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/fe/9a58cb6eec633ff6afae150ca53c16f8cc8b65862ccb3d088051efdfceb7/python_socks-2.8.1-py3-none-any.whl", hash = "sha256:28232739c4988064e725cdbcd15be194743dd23f1c910f784163365b9d7be035", size = 55087, upload-time = "2026-02-16T05:23:59.147Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/18/23b981b1cf58c1e7b7e36fa1392daf12878b6a3c26c5e4248601647a6d09/python_socks-2.8.2-py3-none-any.whl", hash = "sha256:7cf785d0631e0659384a773b3c402bc22cccdc23894ba1d65f8524748ace1193", size = 55501, upload-time = "2026-06-23T05:22:00.658Z" },
+]
+
+[package.optional-dependencies]
+asyncio = [
+    { name = "async-timeout" },
+]
+
+[[package]]
+name = "python-socks"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+    "python_full_version == '3.10.*'",
+    "python_full_version > '3.9' and python_full_version < '3.10'",
+    "python_full_version == '3.9'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/6b/bd9e15e67cf42b318970028a572750924adbe28776e8420fcdfe60838c61/python_socks-3.0.0.tar.gz", hash = "sha256:c20ddf978b5c90467bf242757a11dcd00d7c8bd339901de1839b492d5571ab7f", size = 232731, upload-time = "2026-08-11T11:17:09.464Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/e7/af080d0d2d5bbc3dbdf58a805812ee45175c5c32c6673f23a5480f9785c2/python_socks-3.0.0-py3-none-any.whl", hash = "sha256:e06a421d4d7f3fc17ef2740ab6c291640364f6a362b94a1ae87a136c29bd0067", size = 49519, upload-time = "2026-08-11T11:17:07.118Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## What

Every dependency in `pyproject.toml` was pinned with a `<=` ceiling and no floor. All 22 are
now `>=` floors, and each runtime floor is the oldest version the code was actually tested
against rather than whatever the lock happened to resolve to.

A ceiling on a library's dependency is not a local decision: it propagates into the resolve
of every application that installs us, so `kurigram` was capping `python-socks` for anything
that depended on both. It also has to be raised by hand for every upgrade, which is why most
of the tooling ones named a version from months ago.

The one runtime dependency the conversion by itself moves is `python-socks`, which has a
newer major:

```console
$ uv run --no-project --with 'python-socks[asyncio]<=2.8.1' python -c 'import python_socks; print(python_socks.__version__)'
2.8.1
$ uv run --no-project --with 'python-socks[asyncio]>=2.8.1' python -c 'import python_socks; print(python_socks.__version__)'
3.0.0
```

`3.0.0` has three breaking changes and all three miss us: it drops Python 3.8, removes the
`curio` backend (we install the `[asyncio]` extra), and changes the anyio `Proxy.connect`
return type (we import `python_socks.async_.asyncio`). The lock splits it accordingly,
`2.8.2` below 3.9 and `3.0.0` from 3.9 up, so the 3.8 job keeps a release that supports it.

The two upstream behaviours `TCP._build_proxy` works around were re-checked against `3.0.0`
rather than assumed, since both permalinks in the comments pointed at a 2.x commit:

```console
$ python -c 'from python_socks.async_.asyncio import Proxy; Proxy.create(proxy_type=ProxyType.SOCKS5, host="127.0.0.1", port=1080)'
RuntimeError: There is no current event loop in thread 'MainThread'.

$ python -c 'from python_socks._helpers import parse_proxy_url; print(parse_proxy_url("socks5://someone@127.0.0.1:1080"))'
(<ProxyType.SOCKS5: 2>, '127.0.0.1', 1080, '', '')
```

Still true, so the deferred construction and the field-by-field call both stay. Both
permalinks are repointed at the `v3.0.0` tag with corrected line numbers.

`make test-unit` passes on both splits: 738 tests on 3.8.20 with `python-socks` 2.8.2, and on
3.14 with 3.0.0. The 129 proxy and transport tests pass on both.

The floors themselves were then measured rather than guessed. Each candidate version was
installed on its own and put through the code that uses it, oldest first, so the declared
number is a tested claim and not an observation about one lock file:

| | declared before | tested floor | what fails below it |
|---|---|---|---|
| `pyaes` | `1.6.1` | `1.2.0` | Python 2 syntax: `SyntaxError` on a `print` statement |
| `python-socks[asyncio]` | `2.8.1` | `2.4.0` | `TypeError: Proxy() takes no arguments` |
| `tgcrypto` | `1.2.5` | `1.2.2` | 1.2.1 has no sdist and no wheel past `cp38` |
| `qrcode` | `7.4.2` | `5.2.2` | `print_ascii()` raises `TypeError` on 5.2 and 5.2.1 |
| `hatchling` | none at all | `1.26.3` | ``TypeError: Field `project.license-files` must be a table`` |

Two of those are the reason a floor is not simply the oldest release that works. `qrcode` 5.1
works, 5.2 and 5.2.1 are broken, 5.2.2 works again; `tgcrypto` 1.2.0 installs, 1.2.1 cannot be
installed on a current interpreter at all, 1.2.2 onwards can. A floor at the absolute oldest
would let a resolver land inside either hole, so both sit above it.

`[build-system] requires` carried no floor, which is the one that builds the artifact people
download:

```console
$ uv run --no-project --with 'hatchling==1.25.0' python -m hatchling build -t sdist
TypeError: Field `project.license-files` must be a table
$ uv run --no-project --with 'hatchling==1.26.3' python -m hatchling build -t sdist
dist/kurigram-2.2.25.tar.gz
```

The floors are now checkable in one command:

```console
$ uv pip install --resolution lowest-direct -e '.[fast,qrcode]' --group test
$ uv pip list | grep -E '^(pyaes|python-socks|qrcode|tgcrypto) '
pyaes          1.2.0
python-socks   2.4.0
qrcode         5.2.2
tgcrypto       1.2.2
$ python -m pytest -m 'not integration' -q
738 passed, 7 deselected
```

The tooling groups keep their higher floors on purpose, and `pyproject.toml` says why: a
linter or a documentation theme resolved a year back gives a different verdict and a
different site from the one CI gives, which is worse than a version conflict.

## Why

An upper bound promises that the next release of a dependency will break us, before anybody
has looked at whether it does. Where one genuinely does, the bound belongs there with a
comment naming the breakage - `CONTRIBUTING.md` now says so, and `pyproject.toml` carries the
reasoning next to the declarations.

## How to test

```bash
make sync
make test-unit
```

To check the 3.8 end of the matrix specifically:

```bash
uv sync --python 3.8
uv run --python 3.8 python -m pytest -m 'not integration'
```
