### PR TITLE
ci(deps): run the suite at both ends of every dependency range

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,6 +1,14 @@
 name: Pyrogram
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  # Every job above installs from `uv.lock`, so a dependency release published after the last
+  #  `uv lock` is exercised by nothing until somebody happens to relock. `test-ceil` resolves
+  #  fresh and is what catches it, which only helps if something runs it without a push.
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
 
 jobs:
   build:
@@ -65,3 +73,34 @@ jobs:
       - name: Run ty
         run: |
           make typecheck
+
+  # The recipe names the interpreter and `uv` provisions it, so neither of these jobs pins one:
+  #  `setup-uv`'s `python-version` would export `UV_PYTHON` over the whole workflow.
+  test-floor:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v10.0.1
+
+      # Builds `.venv-floor` and generates the API in it, so no `make sync` or `make api` here.
+      - name: Run the suite at the dependency floor
+        run: |
+          make test-floor
+
+  test-ceil:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v10.0.1
+
+      - name: Run the suite at the dependency ceiling
+        run: |
+          make test-ceil

--- a/.gitignore
+++ b/.gitignore
@@ -110,7 +110,9 @@ celerybeat-schedule
 # Environments
 .env
 .env.test
-.venv
+# `.venv*` rather than `.venv`: `make test-floor` and `make test-ceil` build `.venv-floor`
+#  and `.venv-ceil` beside it, and an exact match leaves those untracked and committable.
+.venv*
 env/
 venv/
 ENV/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,22 @@ ERROR: test_example.py is outside tests/guards, tests/integrations, tests/unit -
 `make test-guards` runs the guard layer on its own, for working on it; `make test-unit` already
 includes it.
 
+### Dependency ranges
+
+Everything above installs from `uv.lock`, so it only ever exercises one point inside each
+declared range. Two more recipes cover the ends of it, each in an environment of its own
+(`.venv-floor`, `.venv-ceil`) built from `pyproject.toml` rather than the lock file:
+
+```bash
+make test-floor    # oldest allowed version of every dependency, on the oldest supported Python
+make test-ceil     # newest released version of every dependency, on the newest supported Python
+```
+
+CI runs both on every push and again weekly, which is what catches a release published after the
+last `uv lock`. Neither recipe writes `uv.lock`. Run `make test-floor` after raising a floor in
+`pyproject.toml`, and note that the interpreter versions live at the top of the `Makefile` and
+have to move with `requires-python` and the CI matrix.
+
 ### Optional: pre-commit hook
 
 The repository ships a `pre-commit` config that runs `make lint` and `make typecheck` on commit,

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,14 @@
 UV := uv
 PYTHON := $(UV) run python
 
+# The two ends of the supported range: the oldest interpreter `requires-python` claims and the
+#  newest the matrix runs. Keep both in sync with `pyproject.toml`.
+PYTHON_FLOOR := 3.8
+PYTHON_CEIL := 3.14
+# Absolute, because `api` runs its compilers from inside `compiler/`.
+VENV_FLOOR := $(CURDIR)/.venv-floor
+VENV_CEIL := $(CURDIR)/.venv-ceil
+
 # The live tests take every parameter from the environment. `.env.test` is the
 #  git-ignored file that carries them locally; the runner loads it so nothing
 #  under `tests/` has to read a file of its own. Absent, the tests skip by name.
@@ -24,7 +32,7 @@ BLUE   := \033[0;34m
 BOLD   := \033[1m
 RESET  := \033[0m
 
-.PHONY: sync version clean-venv clean-build clean-api clean-docs clean api docs docs-archive build tag dtag lint typecheck test test-unit test-guards test-integration
+.PHONY: sync version clean-venv clean-build clean-api clean-docs clean api docs docs-archive build tag dtag lint typecheck test test-unit test-guards test-integration test-floor test-ceil
 
 # No other recipe needs this: they all sync on their own. It exists so CI can install in
 #  a step of its own, which is what makes a resolution failure read as one in the log
@@ -34,8 +42,8 @@ sync:
 	@printf "$(YELLOW)Synced .venv with %s$(RESET)\n" "$$($(PYTHON) --version)"
 
 clean-venv:
-	$(RM) .venv
-	@printf "$(YELLOW)Cleaned venv directory$(RESET)\n"
+	$(RM) .venv $(VENV_FLOOR) $(VENV_CEIL)
+	@printf "$(YELLOW)Cleaned venv directories$(RESET)\n"
 
 clean-build:
 	$(RM) *.egg-info build dist
@@ -86,6 +94,26 @@ test-guards:
 
 test-integration:
 	@$(LOAD_ENV_TEST) $(PYTHON) -m pytest -m integration
+
+# Both recipes build a throwaway environment from `pyproject.toml`, never from `uv.lock`.
+#  `uv run` and `uv sync` are not usable here: asked for a resolution other than the locked
+#  one they rewrite `uv.lock` to match, and `--frozen` installs the locked versions instead.
+
+# The oldest version of every dependency the declarations allow, on the oldest interpreter.
+test-floor:
+	$(UV) venv --clear --python $(PYTHON_FLOOR) $(VENV_FLOOR)
+	VIRTUAL_ENV=$(VENV_FLOOR) $(UV) pip install --resolution lowest-direct --all-extras --group test -r pyproject.toml
+	$(MAKE) api PYTHON=$(VENV_FLOOR)/bin/python
+	$(MAKE) test-unit PYTHON=$(VENV_FLOOR)/bin/python
+
+# The newest, which the matrix never sees: it installs from `uv.lock`, so a release published
+#  after the last `uv lock` is exercised by nothing until this runs. A fresh environment
+#  resolves to the newest compatible release on its own, so there is no flag to pass.
+test-ceil:
+	$(UV) venv --clear --python $(PYTHON_CEIL) $(VENV_CEIL)
+	VIRTUAL_ENV=$(VENV_CEIL) $(UV) pip install --all-extras --group test -r pyproject.toml
+	$(MAKE) api PYTHON=$(VENV_CEIL)/bin/python
+	$(MAKE) test-unit PYTHON=$(VENV_CEIL)/bin/python
 
 build:
 	$(UV) build


### PR DESCRIPTION
## What

Two `make` recipes and two CI jobs that install from `pyproject.toml` instead of `uv.lock`:

- `make test-floor` builds `.venv-floor` on Python `3.8` with `--resolution lowest-direct`, the
  oldest version every declaration allows.
- `make test-ceil` builds `.venv-ceil` on Python `3.14` with a fresh resolve, the newest released
  version of each.

Both generate the API and run the offline suite in that environment, and neither writes
`uv.lock`. `.gitignore` widens `.venv` to `.venv*` so the two directories stay untracked.

Neither resolution is one CI sees today:

```
$ make test-floor
Python 3.8.20   pyaes 1.2.0  python-socks 2.4.0  qrcode 5.2.2  tgcrypto 1.2.2  uvloop 0.21.0
738 passed, 7 deselected in 9.80s

$ make test-ceil
Python 3.14.3   pyaes 1.6.1  python-socks 3.0.0  qrcode 8.2    tgcrypto 1.2.5  uvloop 0.22.1
738 passed, 7 deselected in 7.70s
```

`qrcode 8.2` is not in the lock file at all. And because every existing job installs through
`make sync`, which takes no extras, the `fast` and `qrcode` code paths are currently exercised by
nothing:

```
$ .venv/bin/python -c "import pyrogram.crypto.aes as a; print('tgcrypto' if getattr(a, 'tgcrypto', None) else 'pure-python pyaes fallback')"
TgCrypto is missing! Pyrogram will work the same, but at a much slower speed. More info: https://docs.pyrogram.org/topics/speedups
pure-python pyaes fallback

$ .venv-floor/bin/python -c "import pyrogram.crypto.aes as a; print('tgcrypto' if getattr(a, 'tgcrypto', None) else 'pure-python pyaes fallback')"
tgcrypto
```

The recipes use `uv pip install -r pyproject.toml` rather than `uv sync` or `uv run`. Asked for a
resolution other than the locked one, both of those rewrite `uv.lock` to match (measured: 210
insertions, 927 deletions) and neither has a flag to leave it alone; `--frozen` keeps the file but
then installs the locked versions, so the floor job would pass on `pyaes 1.6.1` and prove nothing.

## Why

Every dependency is declared as a floor with no ceiling, and the lock file pins one point inside
each of those ranges. Nothing checks either end. A floor that is too low fails only for a user
who resolves differently from us, and a release published after the last `uv lock` reaches CI
only when somebody happens to relock.

The workflow also gains a weekly `schedule` and `workflow_dispatch`, because the ceiling job is
only useful when it runs without a push: our own pushes are exactly when nothing upstream has
changed. A failure is a red job and nothing else.

This does not remove the duplication it depends on: the two interpreter versions sit at the top
of the `Makefile` and have to be moved together with `requires-python` and the matrix. Nothing
enforces that yet.

## How to test

```bash
make test-floor
make test-ceil
git diff --stat uv.lock   # empty; neither recipe writes the lock
```
