### PR TITLE
chore(metadata): list a second maintainer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,10 @@ description = "Elegant, modern and asynchronous Telegram MTProto API framework i
 readme = "README.md"
 requires-python = ">=3.8"
 authors = [{ name = "Dan", email = "dan@pyrogram.org" }]
-maintainers = [{ name = "KurimuzonAkuma" }]
+maintainers = [
+    { name = "KurimuzonAkuma" },
+    { name = "Danipulok", email = "danipulok@gmail.com" },
+]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",


### PR DESCRIPTION
## What

Adds a second entry to `maintainers` in `pyproject.toml`. The list held one name; it now
holds two, and the new one carries a contact address.

The field feeds core metadata, so the change is visible in what the build emits. Before:

    $ uv build --sdist && tar -xOf dist/*.tar.gz --wildcards '*/PKG-INFO' | grep -i '^Maintainer'
    Maintainer: KurimuzonAkuma

After:

    Maintainer: KurimuzonAkuma
    Maintainer-email: Danipulok <danipulok@gmail.com>

The two lines are one field. Core metadata splits `maintainers` by whether an entry has an
address: names without one go to `Maintainer`, the rest to `Maintainer-email`. That is why
the existing entry does not move.

https://packaging.python.org/en/latest/specifications/pyproject-toml/#authors-maintainers

## How to test

    make lint
    uv build --sdist
