### PR TITLE
test(guards): sweep the suite and the compilers for the future import, not only the package

### DIFF
--- a/tests/guards/name_resolution.py
+++ b/tests/guards/name_resolution.py
@@ -16,7 +16,7 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-"""What the sweeps over the package share: which files they read, and how they read a name.
+"""What the sweeps share: which files they read, and how they read a name.
 
 The name sweeps ask the same question of a different kind of text: does this name exist.
 Neither can answer it statically, because the tree is one import cycle wide and half the
@@ -46,6 +46,14 @@ GENERATED: Final[tuple[pathlib.Path, ...]] = (
 )
 
 
+# Everything a person maintains that is not the package. Nothing here is generated, and
+#  nothing here ships: `[tool.hatch.build.targets.wheel]` packages `pyrogram` alone.
+TOOLING_ROOTS: Final[tuple[pathlib.Path, ...]] = (
+    REPOSITORY_ROOT / "tests",
+    REPOSITORY_ROOT / "compiler",
+)
+
+
 def is_generated(path: pathlib.Path) -> bool:
     return path in GENERATED or any(tree in path.parents for tree in GENERATED)
 
@@ -55,6 +63,12 @@ def hand_written_files() -> Iterator[pathlib.Path]:
     for path in sorted(PACKAGE_ROOT.rglob("*.py")):
         if not is_generated(path):
             yield path
+
+
+def tooling_files() -> Iterator[pathlib.Path]:
+    """Every module beside the package: the suite and the code generators."""
+    for root in TOOLING_ROOTS:
+        yield from sorted(root.rglob("*.py"))
 
 
 def attribute_chain(root: Any, *, names: Sequence[str]) -> bool:

--- a/tests/guards/test_future_annotations.py
+++ b/tests/guards/test_future_annotations.py
@@ -16,22 +16,25 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Every module of the package that writes an annotation defers it.
+"""Every module that writes an annotation defers it.
 
 Without `from __future__ import annotations` a name used in an annotation has to exist at
 import time, and the tree is one import cycle wide: the way round it was to quote the
 annotation, which hides it from `ruff`'s `UP037` and from anything else that reads one. With
 the import, the quotes are unnecessary everywhere and their absence is checkable.
 
-The sweep reads the package. `tests/` and `compiler/` carry the import too, and nothing here
-asserts that they keep it.
+The sweep reads the package, the suite and the compilers, which is every module a person here
+maintains. One rule over all three is what makes it checkable at all: whether a given module
+needs the import depends on what its own annotations name and in what order, so "where it is
+needed" is not a question this or any other sweep can answer.
 """
 
 from __future__ import annotations as _annotations
 
 import ast
+from itertools import chain
 
-from tests.guards.name_resolution import REPOSITORY_ROOT, hand_written_files
+from tests.guards.name_resolution import REPOSITORY_ROOT, hand_written_files, tooling_files
 
 
 def writes_an_annotation(tree: ast.Module) -> bool:
@@ -61,7 +64,7 @@ def defers_its_annotations(tree: ast.Module) -> bool:
 def modules_that_do_not_defer() -> list[str]:
     found: list[str] = []
 
-    for path in hand_written_files():
+    for path in chain(hand_written_files(), tooling_files()):
         tree = ast.parse(path.read_text(), filename=path.name)
 
         if writes_an_annotation(tree) and not defers_its_annotations(tree):
@@ -77,12 +80,16 @@ def test_every_annotated_module_defers_its_annotations() -> None:
 def test_the_sweep_reads_the_modules_it_claims_to() -> None:
     annotated = [
         path.relative_to(REPOSITORY_ROOT).as_posix()
-        for path in hand_written_files()
+        for path in chain(hand_written_files(), tooling_files())
         if writes_an_annotation(ast.parse(path.read_text(), filename=path.name))
     ]
 
     assert len(annotated) > 700
+
+    # One from each root, so dropping a root fails here rather than passing quietly.
     assert "pyrogram/client.py" in annotated
+    assert "tests/guards/test_future_annotations.py" in annotated
+    assert "compiler/api/compiler.py" in annotated
 
 
 def test_the_sweep_reads_both_halves_of_what_it_asks() -> None:


### PR DESCRIPTION
## What

The future-import sweep read `pyrogram/` only, so a module under `tests/` or `compiler/` could drop
`from __future__ import annotations` and nothing noticed. With the import deleted from
`tests/unit/test_client.py`, whose nested annotation needs it:

    $ uv run pytest tests/guards/test_future_annotations.py -q
    3 passed in 1.10s

The sweep now reads the package, the suite and the compilers, which is every module maintained by
hand here:

    $ uv run pytest tests/guards/test_future_annotations.py -q
    >       assert modules_that_do_not_defer() == []
    E       AssertionError: assert ['tests/unit/test_client.py'] == []
    1 failed, 2 passed in 1.27s

`tests/guards/name_resolution.py` gains `TOOLING_ROOTS` and `tooling_files()` for the two extra
roots. `hand_written_files()` is unchanged, so the annotation-reference sweep still reads the
package alone. The coverage assertion now names one file per root, so dropping a root fails the
test instead of passing quietly.

## Why

One rule over all three roots is what makes this checkable at all: whether a given module needs the
import depends on what its own annotations name and in what order, so "where is it needed" is not a
question this or any other sweep can answer.

## How to test

    make test-guards
