### PR TITLE
chore(lint): enable C4, drop unnecessary comprehension and map()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,7 +202,7 @@ quote-style = "double"
 #  --statistics` reports nearly 19000 findings, the bulk of them line length, missing
 #  trailing commas and docstring section formatting.
 select = [
-    "C4",     # Comprehension/generator simplification, e.g. `list()` over a list comprehension.
+    "C4",     # flake8-comprehensions: a comprehension a plain builtin call already expresses.
     "E9",     # Syntax errors and files that cannot be read.
     "EXE",    # flake8-executable: a shebang without the matching executable bit, or vice versa.
     "F",      # Pyflakes: unused imports and locals, wildcard imports, f-strings with no field.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,6 +202,7 @@ quote-style = "double"
 #  --statistics` reports nearly 19000 findings, the bulk of them line length, missing
 #  trailing commas and docstring section formatting.
 select = [
+    "C4",     # Comprehension/generator simplification, e.g. `list()` over a list comprehension.
     "E9",     # Syntax errors and files that cannot be read.
     "EXE",    # flake8-executable: a shebang without the matching executable bit, or vice versa.
     "F",      # Pyflakes: unused imports and locals, wildcard imports, f-strings with no field.

--- a/pyrogram/methods/messages/get_media_group.py
+++ b/pyrogram/methods/messages/get_media_group.py
@@ -58,7 +58,7 @@ class GetMediaGroup:
         # Get messages with id from `id - 9` to `id + 10` to get all possible media group messages.
         messages = await self.get_messages(
             chat_id=chat_id,
-            message_ids=[msg_id for msg_id in range(message_id - 9, message_id + 10)],
+            message_ids=list(range(message_id - 9, message_id + 10)),
             replies=0,
         )
 

--- a/pyrogram/parser/markdown.py
+++ b/pyrogram/parser/markdown.py
@@ -348,9 +348,11 @@ class Markdown:
                 )
             )
 
-        entities_offsets = map(
-            lambda x: x[1],
-            sorted(enumerate(entities_offsets), key=lambda x: (x[1][1], x[0]), reverse=True),
+        entities_offsets = (
+            x[1]
+            for x in sorted(
+                enumerate(entities_offsets), key=lambda x: (x[1][1], x[0]), reverse=True
+            )
         )
 
         for entity, offset in entities_offsets:

--- a/pyrogram/parser/markdown.py
+++ b/pyrogram/parser/markdown.py
@@ -349,9 +349,11 @@ class Markdown:
             )
 
         entities_offsets = (
-            x[1]
-            for x in sorted(
-                enumerate(entities_offsets), key=lambda x: (x[1][1], x[0]), reverse=True
+            entity_and_offset
+            for _, entity_and_offset in sorted(
+                enumerate(entities_offsets),
+                key=lambda indexed: (indexed[1][1], indexed[0]),
+                reverse=True,
             )
         )
 


### PR DESCRIPTION
## Summary
- `C416`: `get_media_group()` builds `message_ids` with `list(range(...))` instead of wrapping `range()` in a list comprehension that does nothing extra.
- `C417`: `markdown.py`'s `entities_offsets` sort replaces `map(lambda x: x[1], ...)` with an equivalent generator expression.
- Enables `"C4"` as a group in `pyproject.toml` — these were the only two findings in the family.

## Test plan
- [x] `make lint`
- [x] `make typecheck`
- [x] `make test-unit`