### PR TITLE
chore(lint): enable PLC, fix dict-items and split-maxsplit findings

### DIFF
--- a/compiler/api/compiler.py
+++ b/compiler/api/compiler.py
@@ -352,7 +352,7 @@ def start(format: bool = False):
     # import json
     # print(json.dumps(namespaces_to_types, indent=2))
 
-    for qualtype in types_to_constructors:
+    for qualtype, qualtype_constructors in types_to_constructors.items():
         typespace, type = qualtype.split(".") if "." in qualtype else ("", qualtype)
         dir_path = DESTINATION_PATH / "base" / typespace
 
@@ -363,7 +363,7 @@ def start(format: bool = False):
 
         os.makedirs(dir_path, exist_ok=True)
 
-        constructors = sorted(types_to_constructors[qualtype])
+        constructors = sorted(qualtype_constructors)
         constr_count = len(constructors)
         items = "\n            ".join([f"{c}" for c in constructors])
 

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -28,8 +28,8 @@ class CustomHook(BuildHookInterface):
         if self.target_name not in ["wheel", "install"]:
             return
 
-        # Deferred: `compiler` only becomes importable once `sys.path` is patched above,
-        #  and only wheel/install builds need it at all.
+        # `hatch_build.py` is imported for every build target, and only wheel and install
+        #  builds reach this line, so the compilers are imported here rather than at the top.
         from compiler.api.compiler import start as compile_api  # noqa: PLC0415
         from compiler.errors.compiler import start as compile_errors  # noqa: PLC0415
 

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -28,8 +28,10 @@ class CustomHook(BuildHookInterface):
         if self.target_name not in ["wheel", "install"]:
             return
 
-        from compiler.api.compiler import start as compile_api
-        from compiler.errors.compiler import start as compile_errors
+        # Deferred: `compiler` only becomes importable once `sys.path` is patched above,
+        #  and only wheel/install builds need it at all.
+        from compiler.api.compiler import start as compile_api  # noqa: PLC0415
+        from compiler.errors.compiler import start as compile_errors  # noqa: PLC0415
 
         compile_api(format=False)
         compile_errors()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,6 +209,7 @@ select = [
     "INT",    # flake8-gettext: a gettext call built from an f-string/concatenation.
     "LOG",    # flake8-logging: stdlib `logging` misuse, e.g. constructing a `Logger` directly.
     "PGH",    # pygrep-hooks: a blanket `# noqa`/`# type: ignore` with no code, or `eval()`.
+    "PLC",    # Pylint convention — dict `.items()` misuse, deferred imports, `str.split` maxsplit.
     "PLE",    # Pylint Error: real bugs (bad `super()` call, `yield` outside a function, ...).
     "RSE",    # flake8-raise: a parenthesized exception with no arguments, e.g. `raise Exc()`.
     "RUF013", # Implicit `Optional`, e.g. `def method(chat_id: int = None)`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,7 +209,7 @@ select = [
     "INT",    # flake8-gettext: a gettext call built from an f-string/concatenation.
     "LOG",    # flake8-logging: stdlib `logging` misuse, e.g. constructing a `Logger` directly.
     "PGH",    # pygrep-hooks: a blanket `# noqa`/`# type: ignore` with no code, or `eval()`.
-    "PLC",    # Pylint convention — dict `.items()` misuse, deferred imports, `str.split` maxsplit.
+    "PLC",    # Pylint convention: dict `.items()` misuse, deferred imports, `str.split` maxsplit.
     "PLE",    # Pylint Error: real bugs (bad `super()` call, `yield` outside a function, ...).
     "RSE",    # flake8-raise: a parenthesized exception with no arguments, e.g. `raise Exc()`.
     "RUF013", # Implicit `Optional`, e.g. `def method(chat_id: int = None)`.

--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -693,7 +693,8 @@ class Client(Methods):
         return signed_up
 
     async def authorize_qr(self, except_ids: list[int] = []) -> User:
-        # Deferred: qrcode is an optional dependency, not importable at module load time.
+        # `qrcode` is an optional extra, so importing it at module level would break
+        #  `import pyrogram` for everyone who did not install it.
         from qrcode import QRCode  # noqa: PLC0415 # ty: ignore[unresolved-import]
 
         qr_login = QRLogin(self, except_ids)

--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -693,7 +693,8 @@ class Client(Methods):
         return signed_up
 
     async def authorize_qr(self, except_ids: list[int] = []) -> User:
-        from qrcode import QRCode  # ty: ignore[unresolved-import] - optional, not a project dependency
+        # Deferred: qrcode is an optional dependency, not importable at module load time.
+        from qrcode import QRCode  # noqa: PLC0415 # ty: ignore[unresolved-import]
 
         qr_login = QRLogin(self, except_ids)
         await qr_login.recreate()

--- a/tests/unit/handlers/test_handler_update_types.py
+++ b/tests/unit/handlers/test_handler_update_types.py
@@ -108,7 +108,7 @@ def documented_by(handler: type[handlers.Handler]) -> set[str]:
     if _OTHER_PARAMETERS not in documentation:
         return set()
 
-    return set(_DOCUMENTED_TYPE.findall(documentation.split(_OTHER_PARAMETERS)[-1]))
+    return set(_DOCUMENTED_TYPE.findall(documentation.rsplit(_OTHER_PARAMETERS, maxsplit=1)[-1]))
 
 
 def handlers_with_an_update() -> list[tuple[str, str]]:


### PR DESCRIPTION
## Summary
- `PLC0206`: `compiler/api/compiler.py` iterates `types_to_constructors.items()` instead of re-indexing the dict by key inside the loop.
- `PLC0207` (autofix): the update-type documentation lookup in the test suite uses `str.rsplit(_OTHER_PARAMETERS, maxsplit=1)` instead of an unbounded `str.split`.
- `PLC0415` (3 findings): the remaining ones are deliberate deferred imports — `hatch_build.py` only imports the `compiler` package for wheel/install builds, and `pyrogram/client.py`/`pyrogram/methods/utilities/start.py` import `qrcode`, an optional dependency not importable at module load time. Marked with `# noqa: PLC0415` and a short comment.
- Enables `"PLC"` as a group in `pyproject.toml`.

## Test plan
- [x] `make lint`
- [x] `make typecheck`
- [x] `make test-unit`