### PR TITLE
chore(lint): enable PLW, drop dead loop-else and self-assignment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,6 +210,7 @@ select = [
     "LOG",    # flake8-logging: stdlib `logging` misuse, e.g. constructing a `Logger` directly.
     "PGH",    # pygrep-hooks: a blanket `# noqa`/`# type: ignore` with no code, or `eval()`.
     "PLE",    # Pylint Error: real bugs (bad `super()` call, `yield` outside a function, ...).
+    "PLW",    # Pylint warning — dead loop-else, shadowed loop vars, self-assignment, eq/hash.
     "RSE",    # flake8-raise: a parenthesized exception with no arguments, e.g. `raise Exc()`.
     "RUF013", # Implicit `Optional`, e.g. `def method(chat_id: int = None)`.
     "T10",    # flake8-debugger: a leftover `breakpoint()`/`pdb.set_trace()`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,7 +210,7 @@ select = [
     "LOG",    # flake8-logging: stdlib `logging` misuse, e.g. constructing a `Logger` directly.
     "PGH",    # pygrep-hooks: a blanket `# noqa`/`# type: ignore` with no code, or `eval()`.
     "PLE",    # Pylint Error: real bugs (bad `super()` call, `yield` outside a function, ...).
-    "PLW",    # Pylint warning — dead loop-else, shadowed loop vars, self-assignment, eq/hash.
+    "PLW",    # Pylint warning: dead loop-else, shadowed loop vars, self-assignment, eq/hash.
     "RSE",    # flake8-raise: a parenthesized exception with no arguments, e.g. `raise Exc()`.
     "RUF013", # Implicit `Optional`, e.g. `def method(chat_id: int = None)`.
     "T10",    # flake8-debugger: a leftover `breakpoint()`/`pdb.set_trace()`.

--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -1139,10 +1139,11 @@ class Client(Methods):
                         log.warning('[%s] [LOAD] Ignoring namespace "%s"', self.name, module_path)
                         continue
 
-                    handler_names = vars(module).keys() if handlers is None else handlers
-
                     if handlers is None:
+                        handler_names = vars(module).keys()
                         warn_non_existent_functions = False
+                    else:
+                        handler_names = handlers
 
                     for name in handler_names:
                         target_attr = getattr(module, name, None)
@@ -1201,10 +1202,11 @@ class Client(Methods):
                         log.warning('[%s] [UNLOAD] Ignoring namespace "%s"', self.name, module_path)
                         continue
 
-                    handler_names = vars(module).keys() if handlers is None else handlers
-
                     if handlers is None:
+                        handler_names = vars(module).keys()
                         warn_non_existent_functions = False
+                    else:
+                        handler_names = handlers
 
                     for name in handler_names:
                         target_attr = getattr(module, name, None)

--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -1132,11 +1132,12 @@ class Client(Methods):
                         log.warning('[%s] [LOAD] Ignoring namespace "%s"', self.name, module_path)
                         continue
 
+                    handler_names = vars(module).keys() if handlers is None else handlers
+
                     if handlers is None:
-                        handlers = vars(module).keys()
                         warn_non_existent_functions = False
 
-                    for name in handlers:
+                    for name in handler_names:
                         target_attr = getattr(module, name, None)
                         target_handlers = _plugin_handlers(target_attr)
 
@@ -1193,11 +1194,12 @@ class Client(Methods):
                         log.warning('[%s] [UNLOAD] Ignoring namespace "%s"', self.name, module_path)
                         continue
 
+                    handler_names = vars(module).keys() if handlers is None else handlers
+
                     if handlers is None:
-                        handlers = vars(module).keys()
                         warn_non_existent_functions = False
 
-                    for name in handlers:
+                    for name in handler_names:
                         target_attr = getattr(module, name, None)
                         target_handlers = _plugin_handlers(target_attr)
 

--- a/pyrogram/handlers/deleted_business_messages_handler.py
+++ b/pyrogram/handlers/deleted_business_messages_handler.py
@@ -68,5 +68,4 @@ class DeletedBusinessMessagesHandler(Handler):
         for message in messages:
             if await super().check(client, message):
                 return True
-        else:
-            return False
+        return False

--- a/pyrogram/handlers/deleted_messages_handler.py
+++ b/pyrogram/handlers/deleted_messages_handler.py
@@ -67,5 +67,4 @@ class DeletedMessagesHandler(Handler):
         for message in messages:
             if await super().check(client, message):
                 return True
-        else:
-            return False
+        return False

--- a/pyrogram/methods/chats/get_chat_member.py
+++ b/pyrogram/methods/chats/get_chat_member.py
@@ -59,8 +59,8 @@ class GetChatMember:
             members = getattr(r.full_chat.participants, "participants", [])
             users = {i.id: i for i in r.users}
 
-            for member in members:
-                member = await types.ChatMember._parse(self, member, users, {})
+            for raw_member in members:
+                member = await types.ChatMember._parse(self, raw_member, users, {})
 
                 if isinstance(user, raw.types.InputPeerSelf):
                     if member.user.is_self:
@@ -68,8 +68,7 @@ class GetChatMember:
                 else:
                     if member.user.id == user.user_id:
                         return member
-            else:
-                raise UserNotParticipant
+            raise UserNotParticipant
         elif isinstance(chat, raw.types.InputPeerChannel):
             r = await self.invoke(
                 raw.functions.channels.GetParticipant(channel=chat, participant=user)

--- a/pyrogram/parser/markdown.py
+++ b/pyrogram/parser/markdown.py
@@ -129,13 +129,14 @@ class Markdown:
                 continue
 
             elif line.endswith(BLOCKQUOTE_EXPANDABLE_END_DELIM) and inside_blockquote:
-                if line.startswith(BLOCKQUOTE_DELIM):
-                    line = line[
+                unwrapped_line = line
+                if unwrapped_line.startswith(BLOCKQUOTE_DELIM):
+                    unwrapped_line = unwrapped_line[
                         len(BLOCKQUOTE_DELIM)
-                        + (1 if line.startswith(f"{BLOCKQUOTE_DELIM} ") else 0) :
+                        + (1 if unwrapped_line.startswith(f"{BLOCKQUOTE_DELIM} ") else 0) :
                     ]
 
-                delim_stripped_line = line[: -len(BLOCKQUOTE_EXPANDABLE_END_DELIM)]
+                delim_stripped_line = unwrapped_line[: -len(BLOCKQUOTE_EXPANDABLE_END_DELIM)]
 
                 parsed_line = html.escape(delim_stripped_line) if strict else delim_stripped_line
 
@@ -170,8 +171,7 @@ class Markdown:
 
             elif len(to_quote_list) > 0:
                 create_blockquote()
-        else:
-            create_blockquote()
+        create_blockquote()
 
         if strict:
             for idx, line in enumerate(text_lines):

--- a/pyrogram/raw/core/tl_object.py
+++ b/pyrogram/raw/core/tl_object.py
@@ -87,6 +87,11 @@ class TLObject(Generic[ReturnType]):
 
         return True
 
+    # Equality is by mutable attribute value (see `__eq__` above), so a stable hash across
+    #  the object's lifetime cannot be guaranteed. Declared explicitly rather than relying on
+    #  the implicit `__hash__ = None` Python already applies when `__eq__` is defined alone.
+    __hash__ = None
+
     def __len__(self) -> int:
         return len(self.write())
 

--- a/pyrogram/types/bots_and_keyboards/callback_query.py
+++ b/pyrogram/types/bots_and_keyboards/callback_query.py
@@ -146,7 +146,7 @@ class CallbackQuery(Object, Update):
             try:
                 data = data.decode()
             except (UnicodeDecodeError, AttributeError):
-                data = data
+                pass
 
         return CallbackQuery(
             id=str(callback_query.query_id),

--- a/pyrogram/types/object.py
+++ b/pyrogram/types/object.py
@@ -105,6 +105,11 @@ class Object:
 
         return True
 
+    # Equality is by mutable attribute value (see `__eq__` above), so a stable hash across
+    #  the object's lifetime cannot be guaranteed. Declared explicitly rather than relying on
+    #  the implicit `__hash__ = None` Python already applies when `__eq__` is defined alone.
+    __hash__ = None
+
     def __setstate__(self, state):
         for attr in state:
             obj = state[attr]

--- a/pyrogram/utils.py
+++ b/pyrogram/utils.py
@@ -53,7 +53,7 @@ async def ainput(
 ):
     """Just like the built-in input, but async"""
     if isinstance(loop, asyncio.AbstractEventLoop):
-        loop = loop
+        pass
     else:
         loop = get_event_loop()
 
@@ -587,7 +587,7 @@ async def parse_text_entities(
         for entity in entities:
             entity._client = client
 
-        text, entities = text, [await entity.write() for entity in entities] or None
+        entities = [await entity.write() for entity in entities] or None
     else:
         text, entities = (await client.parser.parse(text, parse_mode)).values()
 

--- a/pyrogram/utils.py
+++ b/pyrogram/utils.py
@@ -52,9 +52,7 @@ async def ainput(
     prompt: str = "", *, hide: bool = False, loop: asyncio.AbstractEventLoop | None = None
 ):
     """Just like the built-in input, but async"""
-    if isinstance(loop, asyncio.AbstractEventLoop):
-        pass
-    else:
+    if not isinstance(loop, asyncio.AbstractEventLoop):
         loop = get_event_loop()
 
     with ThreadPoolExecutor(1) as executor:


### PR DESCRIPTION
## Summary
- `PLW0120`: dead `else` clause on a `for` loop that never `break`s (it always ran) — removed the `else`, dedented its body, on 4 loops.
- `PLW2901`: 3 spots reassigned their own `for`-loop variable inside the loop body, shadowing it — `client.py`'s plugin loader/unloader (`handlers`), `get_chat_member.py` (`member`), `markdown.py` (`line`) — each derived value now gets its own name instead.
- `PLW0127`: 3 self-assignments — 2 were true no-ops rewritten as `pass` (`callback_query.py`, `utils.py`'s `ainput`), 1 was a redundant tuple self-assignment (`utils.py`) simplified to assigning only the field that actually changes.
- `PLW1641`: `TLObject` and `pyrogram.types.Object` both define `__eq__` by mutable attribute value without `__hash__`. Their equality can't produce a hash stable across the object's lifetime, so both now declare `__hash__ = None` explicitly — same runtime behavior Python already gave them implicitly, just no longer implicit.
- Enables `"PLW"` as a group in `pyproject.toml`.

## How this was fixed
- `PLW0120` — autofix (`ruff check --select PLW0120 --fix`).
- `PLW2901` — manual: renaming a shadowed loop variable isn't something ruff can autofix (no safe replacement name to pick).
- `PLW0127` — manual: no autofix exists for this rule.
- `PLW1641` — manual: no autofix exists for this rule, and picking `__hash__ = None` over an actual `__hash__` implementation is a design call (see above), not something a linter can decide.

## Test plan
- [x] `make lint`
- [x] `make typecheck`
- [x] `make test-unit`