### PR TITLE
chore(lint): enable ISC, join two explicitly-concatenated strings

### DIFF
--- a/compiler/api/compiler.py
+++ b/compiler/api/compiler.py
@@ -482,13 +482,13 @@ def start(format: bool = False):
                 if function_docs.get("can_use_without_auth"):
                     docstring += (
                         "\n\n    .. note::\n\n        "
-                        + "This method can be used by not yet logged in connections."
+                        "This method can be used by not yet logged in connections."
                     )
 
                 if function_docs.get("can_use_business_connection"):
                     docstring += (
                         "\n\n    .. note::\n\n        "
-                        + "This method can be invoked over a `business connection » <https://corefork.telegram.org/api/bots/connected-business-bots>`__"
+                        "This method can be invoked over a `business connection » <https://corefork.telegram.org/api/bots/connected-business-bots>`__"
                     )
             else:
                 docstring += "Telegram API function."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,7 +208,7 @@ select = [
     "F",      # Pyflakes: unused imports and locals, wildcard imports, f-strings with no field.
     "ICN",    # flake8-import-conventions: an import that does not follow its usual alias.
     "INT",    # flake8-gettext: a gettext call built from an f-string/concatenation.
-    "ISC",    # flake8-implicit-str-concat: explicit `+` between adjacent string literals.
+    "ISC",    # flake8-implicit-str-concat: a `+` between adjacent literals, or two on one line.
     "LOG",    # flake8-logging: stdlib `logging` misuse, e.g. constructing a `Logger` directly.
     "PGH",    # pygrep-hooks: a blanket `# noqa`/`# type: ignore` with no code, or `eval()`.
     "PLC",    # Pylint convention: dict `.items()` misuse, deferred imports, `str.split` maxsplit.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,6 +207,7 @@ select = [
     "F",      # Pyflakes: unused imports and locals, wildcard imports, f-strings with no field.
     "ICN",    # flake8-import-conventions: an import that does not follow its usual alias.
     "INT",    # flake8-gettext: a gettext call built from an f-string/concatenation.
+    "ISC",    # flake8-implicit-str-concat — explicit `+` between adjacent string literals.
     "LOG",    # flake8-logging: stdlib `logging` misuse, e.g. constructing a `Logger` directly.
     "PGH",    # pygrep-hooks: a blanket `# noqa`/`# type: ignore` with no code, or `eval()`.
     "PLE",    # Pylint Error: real bugs (bad `super()` call, `yield` outside a function, ...).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,7 +207,7 @@ select = [
     "F",      # Pyflakes: unused imports and locals, wildcard imports, f-strings with no field.
     "ICN",    # flake8-import-conventions: an import that does not follow its usual alias.
     "INT",    # flake8-gettext: a gettext call built from an f-string/concatenation.
-    "ISC",    # flake8-implicit-str-concat — explicit `+` between adjacent string literals.
+    "ISC",    # flake8-implicit-str-concat: explicit `+` between adjacent string literals.
     "LOG",    # flake8-logging: stdlib `logging` misuse, e.g. constructing a `Logger` directly.
     "PGH",    # pygrep-hooks: a blanket `# noqa`/`# type: ignore` with no code, or `eval()`.
     "PLE",    # Pylint Error: real bugs (bad `super()` call, `yield` outside a function, ...).


### PR DESCRIPTION
## Summary
- `ISC003`: two docstring fragments in the API compiler used explicit `+` between two adjacent string literals on consecutive lines; joined into implicit concatenation, same resulting string.
- Enables `"ISC"` as a group in `pyproject.toml` — these were the only two findings in the family.

## How this was fixed
- `ISC003` — autofix (`ruff check --select ISC003 --fix`), followed by `ruff format` to fix indentation of the now-implicitly-concatenated literal.

## Test plan
- [x] `make lint`
- [x] `make typecheck`
- [x] `make test-unit`