### PR TITLE
chore(lint): enable SLOT, add __slots__ to the str subclasses

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,7 +212,7 @@ select = [
     "PLE",    # Pylint Error: real bugs (bad `super()` call, `yield` outside a function, ...).
     "RSE",    # flake8-raise: a parenthesized exception with no arguments, e.g. `raise Exc()`.
     "RUF013", # Implicit `Optional`, e.g. `def method(chat_id: int = None)`.
-    "SLOT",   # flake8-slots — an immutable-builtin subclass missing `__slots__`.
+    "SLOT",   # flake8-slots: an immutable-builtin subclass missing `__slots__`.
     "T10",    # flake8-debugger: a leftover `breakpoint()`/`pdb.set_trace()`.
     "UP",     # pyupgrade: outdated typing syntax, and `.format()` calls an f-string replaces.
     "W",      # pycodestyle warnings: an invalid escape sequence, and whitespace the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,6 +212,7 @@ select = [
     "PLE",    # Pylint Error: real bugs (bad `super()` call, `yield` outside a function, ...).
     "RSE",    # flake8-raise: a parenthesized exception with no arguments, e.g. `raise Exc()`.
     "RUF013", # Implicit `Optional`, e.g. `def method(chat_id: int = None)`.
+    "SLOT",   # flake8-slots — an immutable-builtin subclass missing `__slots__`.
     "T10",    # flake8-debugger: a leftover `breakpoint()`/`pdb.set_trace()`.
     "UP",     # pyupgrade: outdated typing syntax, and `.format()` calls an f-string replaces.
     "W",      # pycodestyle warnings: an invalid escape sequence, and whitespace the

--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -46,6 +46,8 @@ log = logging.getLogger(__name__)
 
 
 class Str(str):
+    __slots__ = ("entities",)
+
     def __init__(self, *args):
         super().__init__()
 

--- a/pyrogram/types/user_and_chats/user.py
+++ b/pyrogram/types/user_and_chats/user.py
@@ -32,6 +32,8 @@ log = logging.getLogger(__name__)
 
 
 class Link(str):
+    __slots__ = ("url", "text", "style")
+
     HTML = "<a href={url}>{text}</a>"
     MARKDOWN = "[{text}]({url})"
 


### PR DESCRIPTION
## Summary
- `SLOT000`: `message.py`'s `Str` and `user.py`'s `Link` both subclass `str` and set instance attributes in `__init__` without declaring `__slots__`, so every instance also carries an unneeded `__dict__`. Each class now declares `__slots__` listing exactly the attributes it already sets (`Str`: `entities`; `Link`: `url`, `text`, `style`) — no new attributes, no behavior change, verified with a runtime smoke test that both classes still construct and read back correctly.
- Enables `"SLOT"` as a group in `pyproject.toml` — these were the only two findings in the family.

## How this was fixed
- `SLOT000` — manual, no autofix exists for this rule (ruff can flag a missing `__slots__` but can't know which attribute names belong in it).

## Test plan
- [x] `make lint`
- [x] `make typecheck`
- [x] `make test-unit`