### PR TITLE
chore(lint): enable PIE, drop redundant range() start argument

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,7 +211,7 @@ select = [
     "ISC",    # flake8-implicit-str-concat: a `+` between adjacent literals, or two on one line.
     "LOG",    # flake8-logging: stdlib `logging` misuse, e.g. constructing a `Logger` directly.
     "PGH",    # pygrep-hooks: a blanket `# noqa`/`# type: ignore` with no code, or `eval()`.
-    "PIE",    # flake8-pie: misc simplifications, e.g. a redundant `range(0, ...)` start.
+    "PIE",    # flake8-pie: a `range(0, ...)` start, a stray `pass`, a duplicate class field.
     "PLC",    # Pylint convention: dict `.items()` misuse, deferred imports, `str.split` maxsplit.
     "PLE",    # Pylint Error: real bugs (bad `super()` call, `yield` outside a function, ...).
     "PLW",    # Pylint warning: dead loop-else, shadowed loop vars, self-assignment, eq/hash.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,7 +209,7 @@ select = [
     "INT",    # flake8-gettext: a gettext call built from an f-string/concatenation.
     "LOG",    # flake8-logging: stdlib `logging` misuse, e.g. constructing a `Logger` directly.
     "PGH",    # pygrep-hooks: a blanket `# noqa`/`# type: ignore` with no code, or `eval()`.
-    "PIE",    # flake8-pie — misc simplifications, e.g. a redundant `range(0, ...)` start.
+    "PIE",    # flake8-pie: misc simplifications, e.g. a redundant `range(0, ...)` start.
     "PLE",    # Pylint Error: real bugs (bad `super()` call, `yield` outside a function, ...).
     "RSE",    # flake8-raise: a parenthesized exception with no arguments, e.g. `raise Exc()`.
     "RUF013", # Implicit `Optional`, e.g. `def method(chat_id: int = None)`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,6 +209,7 @@ select = [
     "INT",    # flake8-gettext: a gettext call built from an f-string/concatenation.
     "LOG",    # flake8-logging: stdlib `logging` misuse, e.g. constructing a `Logger` directly.
     "PGH",    # pygrep-hooks: a blanket `# noqa`/`# type: ignore` with no code, or `eval()`.
+    "PIE",    # flake8-pie — misc simplifications, e.g. a redundant `range(0, ...)` start.
     "PLE",    # Pylint Error: real bugs (bad `super()` call, `yield` outside a function, ...).
     "RSE",    # flake8-raise: a parenthesized exception with no arguments, e.g. `raise Exc()`.
     "RUF013", # Implicit `Optional`, e.g. `def method(chat_id: int = None)`.

--- a/pyrogram/crypto/aes.py
+++ b/pyrogram/crypto/aes.py
@@ -107,7 +107,7 @@ except ImportError:
         chunk = cipher.encrypt(iv)
 
         for i in range(0, len(data), 16):
-            for j in range(0, min(len(data) - i, 16)):
+            for j in range(min(len(data) - i, 16)):
                 out[i + j] ^= chunk[state[0]]
 
                 state[0] += 1


### PR DESCRIPTION
## Summary
- `PIE808`: `aes.py`'s inner CTR-mode byte loop used `range(0, min(len(data) - i, 16))`; `0` is already `range`'s default start, so it's `range(min(len(data) - i, 16))` now — same sequence of values.
- Enables `"PIE"` as a group in `pyproject.toml` — this was the only finding in the family.

## How this was fixed
- `PIE808` — autofix (`ruff check --select PIE808 --fix`).

## Test plan
- [x] `make lint`
- [x] `make typecheck`
- [x] `make test-unit`