### PR TITLE
chore(lint): enable INP, add missing __init__.py under tests/unit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,6 +206,7 @@ select = [
     "EXE",    # flake8-executable: a shebang without the matching executable bit, or vice versa.
     "F",      # Pyflakes: unused imports and locals, wildcard imports, f-strings with no field.
     "ICN",    # flake8-import-conventions: an import that does not follow its usual alias.
+    "INP",    # flake8-no-pep420 — a `.py` file with no `__init__.py` anywhere above it.
     "INT",    # flake8-gettext: a gettext call built from an f-string/concatenation.
     "LOG",    # flake8-logging: stdlib `logging` misuse, e.g. constructing a `Logger` directly.
     "PGH",    # pygrep-hooks: a blanket `# noqa`/`# type: ignore` with no code, or `eval()`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,7 +206,7 @@ select = [
     "EXE",    # flake8-executable: a shebang without the matching executable bit, or vice versa.
     "F",      # Pyflakes: unused imports and locals, wildcard imports, f-strings with no field.
     "ICN",    # flake8-import-conventions: an import that does not follow its usual alias.
-    "INP",    # flake8-no-pep420 — a `.py` file with no `__init__.py` anywhere above it.
+    "INP",    # flake8-no-pep420: a `.py` file with no `__init__.py` anywhere above it.
     "INT",    # flake8-gettext: a gettext call built from an f-string/concatenation.
     "LOG",    # flake8-logging: stdlib `logging` misuse, e.g. constructing a `Logger` directly.
     "PGH",    # pygrep-hooks: a blanket `# noqa`/`# type: ignore` with no code, or `eval()`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,7 +207,7 @@ select = [
     "EXE",    # flake8-executable: a shebang without the matching executable bit, or vice versa.
     "F",      # Pyflakes: unused imports and locals, wildcard imports, f-strings with no field.
     "ICN",    # flake8-import-conventions: an import that does not follow its usual alias.
-    "INP",    # flake8-no-pep420: a `.py` file with no `__init__.py` anywhere above it.
+    "INP",    # flake8-no-pep420: a `.py` file whose own directory has no `__init__.py`.
     "INT",    # flake8-gettext: a gettext call built from an f-string/concatenation.
     "ISC",    # flake8-implicit-str-concat: a `+` between adjacent literals, or two on one line.
     "LOG",    # flake8-logging: stdlib `logging` misuse, e.g. constructing a `Logger` directly.

--- a/tests/unit/methods/messages/__init__.py
+++ b/tests/unit/methods/messages/__init__.py
@@ -1,0 +1,17 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.


### PR DESCRIPTION
## Summary
- `INP001`: `tests/unit/methods/messages/` was the one directory in the whole test tree without an `__init__.py` — every sibling package already has one, using the same LGPL header template (`tests/unit/methods/__init__.py`, `tests/unit/methods/chats/__init__.py`, etc.). Added the matching file.
- Enables `"INP"` as a group in `pyproject.toml` — this was the only finding in the family.

## How this was fixed
- `INP001` — manual: no autofix exists for this rule (ruff can detect a missing `__init__.py` but not author one).

## Test plan
- [x] `make lint`
- [x] `make typecheck`
- [x] `make test-unit`