### PR TITLE
docs(contributing): state the `__all__` rule the public exports guard enforces

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,6 +148,14 @@ A few conventions that have come up repeatedly in code review but aren't enforce
   The redundant alias silences `F401` by looking like a typing convention, and a reader has to
   know that convention to see it is deliberate at all. Where the module has an `__all__`,
   listing the name there is better still: nothing is suppressed and the export is declared.
+- **A module's `__all__` covers everything the module defines.** `ruff` holds one half of this:
+  `F401` fails on a name imported and neither used nor listed, `F822` on a listed name that
+  resolves to nothing. Neither looks at a class or function the module defines itself, so a
+  barrel that grows one beside its imports drops it from the public API and nothing says so.
+  `tests/guards/test_public_exports.py` fails on that, on a repeated entry, and on an `__all__`
+  built by concatenation or comprehension, which reads as a declaration while leaving the other
+  two checks nothing to read. Declaring one is not required: the aggregator `__init__.py` files
+  under `pyrogram/methods/` collect mixins for `Client` rather than exporting an API.
 - **Every `# ty: ignore[rule]` carries a reason** after a single `-`, as in
   `# ty: ignore[unresolved-import] - optional, not a project dependency`. Only the `[rule]`
   bracket is `ty`'s own syntax; the reason is ours, so nobody has to reconstruct why the


### PR DESCRIPTION
## What

The public exports guard landed without the rule it enforces being written down anywhere, so
`CONTRIBUTING.md` now carries it, next to the re-export rule it follows from.

## Why

The section it joins exists for conventions `ruff` and `ty` cannot express, and this one is
half expressible: `F401` fails on a name imported and neither used nor listed, `F822` on a
listed name that resolves to nothing. The half neither covers is a class or function the module
defines itself, which is how `pyrogram/__init__.py` lost `StopTransmission`,
`StopPropagation` and `ContinuePropagation` from its public API for the length of one review.

A check nobody can read about is a check people work around. The entry says what the guard
fails on, and also what it does not ask for: an `__all__` is not required, so the aggregator
`__init__.py` files under `pyrogram/methods/` are not in scope.

## How to test

Documentation only, no code changed. `make lint` and `make test-unit` pass.
