### PR TITLE
fix(client): name the `kurigram[qrcode]` extra when QR login cannot import it

### DIFF
--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -695,7 +695,12 @@ class Client(Methods):
     async def authorize_qr(self, except_ids: list[int] = []) -> User:
         # `qrcode` is an optional extra, so importing it at module level would break
         #  `import pyrogram` for everyone who did not install it.
-        from qrcode import QRCode  # noqa: PLC0415 # ty: ignore[unresolved-import]
+        try:
+            from qrcode import QRCode  # noqa: PLC0415 # ty: ignore[unresolved-import]
+        except ImportError as er:
+            raise ImportError(
+                "`qrcode` is not installed, run `pip install 'kurigram[qrcode]'`"
+            ) from er
 
         qr_login = QRLogin(self, except_ids)
         await qr_login.recreate()

--- a/pyrogram/methods/utilities/run.py
+++ b/pyrogram/methods/utilities/run.py
@@ -50,6 +50,7 @@ class Run:
 
         Raises:
             ConnectionError: In case you try to run an already started client.
+            ImportError: In case ``use_qr`` is True and the ``qrcode`` extra is not installed.
 
         Example:
             .. code-block:: python

--- a/pyrogram/methods/utilities/start.py
+++ b/pyrogram/methods/utilities/start.py
@@ -18,7 +18,6 @@
 
 from __future__ import annotations as _annotations
 
-import importlib.util
 import logging
 
 import pyrogram
@@ -42,7 +41,7 @@ class Start:
 
         .. note::
 
-            You should install ``qrcode`` package if you want to use QR code authorization.
+            QR code authorization needs the ``qrcode`` extra: ``pip install "kurigram[qrcode]"``.
 
         Parameters:
             use_qr (``bool``, *optional*):
@@ -58,6 +57,7 @@ class Start:
 
         Raises:
             ConnectionError: In case you try to start an already started client.
+            ImportError: In case ``use_qr`` is True and the ``qrcode`` extra is not installed.
 
         Example:
             .. code-block:: python
@@ -83,15 +83,7 @@ class Start:
         try:
             if not is_authorized:
                 if use_qr:
-                    # `qrcode` is an optional extra, not a dependency.
-                    #  https://docs.kurigram.icu/start/auth
-                    if importlib.util.find_spec("qrcode") is not None:
-                        await self.authorize_qr(except_ids=except_ids)
-                    else:
-                        log.warning(
-                            "qrcode package not found, falling back to authorization prompt"
-                        )
-                        await self.authorize()
+                    await self.authorize_qr(except_ids=except_ids)
                 else:
                     await self.authorize()
 


### PR DESCRIPTION
## What

A missing `qrcode` extra is now reported, instead of being worked around.

`Client.authorize_qr` imports `qrcode` lazily, and until now a missing extra surfaced as
the raw import error, which names neither the extra nor the command that installs it:

```
$ python qr_probe.py         # calls `await app.authorize_qr()`
ModuleNotFoundError: No module named 'qrcode'
```

It now names both:

```
$ python qr_probe.py
ImportError: `qrcode` is not installed, run `pip install 'kurigram[qrcode]'`
```

`start(use_qr=True)` probed for the module with `importlib.util.find_spec` and, when it
was absent, logged a warning and ran the interactive phone-number prompt instead:

```
$ python qr_probe.py         # calls `await app.start(use_qr=True)`
WARNING qrcode package not found, falling back to authorization prompt
-> fell back to the interactive phone-number prompt
```

`use_qr=True` is an explicit request for one authorization method, so it now fails with
the message above rather than silently performing the other one:

```
$ python qr_probe.py
ImportError: `qrcode` is not installed, run `pip install 'kurigram[qrcode]'`
```

That also removes the second place that knew about the extra. `find_spec` only proves a
module is importable in principle: a half-installed package passes it and then fails at
the import anyway, which the fallback could not have caught.

## Why

`pip3 install qrcode` was what the docs told people to run, and it installs the package
without the floor `pyproject.toml` pins for it (`qrcode>=5.2.2`): on 5.2 and 5.2.1
`print_ascii(tty=True)` raises `TypeError`, so QR login is broken in a way that looks
like a library bug. `pip install 'kurigram[qrcode]'` is the only form that carries the
floor, and it is now what both the error and the documentation say.

## How to test

```python
import asyncio

from pyrogram import Client

app = Client("probe", api_id=1, api_hash="0" * 32, in_memory=True)
asyncio.run(app.authorize_qr())
```

In an environment without the extra this raises the `ImportError` above; with
`pip install 'kurigram[qrcode]'` it reaches the QR flow as before.

`make lint`, `make typecheck` and `make test-unit` are green: 979 files formatted, 748
passed.

## Note for a follow-up

The documentation change belongs with this one and is not in the diff: `docs/` is listed
in `.gitignore` and no file under it is tracked, so `docs/source/start/auth.rst`, which
still says `pip3 install qrcode`, cannot be committed. The whole `docs/source` tree is
absent from the repository and exists only in local checkouts.
