### PR TITLE
test(bots): guard the `restore` mapping in `edit_user_star_subscription()`

### DIFF
--- a/pyrogram/methods/bots/edit_user_star_subscription.py
+++ b/pyrogram/methods/bots/edit_user_star_subscription.py
@@ -47,10 +47,14 @@ class EditUserStarSubscription:
         Returns:
             ``bool``: On success, True is returned.
         """
+        # `restore` is the opposite of `is_canceled`: the request cancels the subscription when
+        #  the flag is absent and re-enables it when it is set. TDLib sends `!is_canceled` for the
+        #  same call, and passing `is_canceled` straight through left the subscription renewing.
+        #  https://github.com/tdlib/td/blob/d1085f9cebc5a62379991ae1652673954f229c1f/td/telegram/StarManager.cpp#L1100
         return await self.invoke(
             raw.functions.payments.BotCancelStarsSubscription(
                 user_id=await self.resolve_peer(user_id),
                 charge_id=telegram_payment_charge_id,
-                restore=is_canceled,
+                restore=not is_canceled,
             )
         )

--- a/tests/unit/methods/bots/__init__.py
+++ b/tests/unit/methods/bots/__init__.py
@@ -1,0 +1,17 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.

--- a/tests/unit/methods/bots/test_edit_user_star_subscription.py
+++ b/tests/unit/methods/bots/test_edit_user_star_subscription.py
@@ -1,0 +1,63 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations as _annotations
+
+import pytest
+
+from pyrogram import raw
+from pyrogram.methods.bots.edit_user_star_subscription import EditUserStarSubscription
+
+
+class _InvokeCalled(Exception):
+    """Raised by the fake `invoke` once reached, carrying the built query for inspection."""
+
+    def __init__(self, query: raw.functions.payments.BotCancelStarsSubscription) -> None:
+        self.query = query
+
+
+class FakeClient(EditUserStarSubscription):
+    async def resolve_peer(self, peer_id: int | str) -> raw.types.InputUser:
+        return raw.types.InputUser(
+            user_id=peer_id,
+            access_hash=0,
+        )
+
+    async def invoke(self, query: raw.functions.payments.BotCancelStarsSubscription) -> None:
+        raise _InvokeCalled(query)
+
+
+async def _restore_flag_for(*, is_canceled: bool) -> bool:
+    client = FakeClient()
+
+    with pytest.raises(_InvokeCalled) as exc_info:
+        await client.edit_user_star_subscription(7, "charge", is_canceled=is_canceled)
+
+    return exc_info.value.query.restore
+
+
+@pytest.mark.asyncio
+async def test_canceling_clears_the_restore_flag() -> None:
+    # `restore=is_canceled` sent `restore=True` for a cancellation, which the server reads as
+    #  "keep it renewing", so the subscription was never canceled and the call still returned True.
+    assert await _restore_flag_for(is_canceled=True) is False
+
+
+@pytest.mark.asyncio
+async def test_re_enabling_sets_the_restore_flag() -> None:
+    assert await _restore_flag_for(is_canceled=False) is True


### PR DESCRIPTION
Follow-up to 2f915c3a, which fixed the mapping but left nothing checking it.

## What

Two tests asserting the `restore` flag in both directions, plus a comment recording why the
negation is there.

```
is_canceled=True  -> restore flag on the wire = False
is_canceled=False -> restore flag on the wire = True
```

Both tests fail against `restore=is_canceled` and pass against `restore=not is_canceled`, so
they hold the line rather than restating it.

TDLib sends `!is_canceled` for the same call, which is what the comment cites:

```cpp
send_query(G()->net_query_creator().create(telegram_api::payments_botCancelStarsSubscription(
    0, !is_canceled, std::move(input_user), telegram_payment_charge_id)));
```

https://github.com/tdlib/td/blob/d1085f9cebc5a62379991ae1652673954f229c1f/td/telegram/StarManager.cpp#L1100

## How to test

`make test-unit`.
