### PR TITLE
test(errors): count the expected rows off the table instead of hardcoding 936

### DIFF
--- a/tests/unit/errors/test_error_codes.py
+++ b/tests/unit/errors/test_error_codes.py
@@ -128,6 +128,7 @@ def test_every_error_in_the_table_reports_the_code_it_came_from() -> None:
     errors: ModuleType = import_module("pyrogram.errors")
     categories = {code: getattr(errors, table["_"]) for code, table in exceptions.items()}
     checked: int = 0
+    skipped: int = 0
 
     for code, table in exceptions.items():
         for error_id, class_name in table.items():
@@ -139,6 +140,7 @@ def test_every_error_in_the_table_reports_the_code_it_came_from() -> None:
             # `FILE_PART_0_MISSING` normalises to `FILE_PART_X_MISSING`, so nothing ever resolves
             # to it. It is a row of the table no answer can reach, not a class to check.
             if normalised != error_id and normalised in table:
+                skipped += 1
                 continue
 
             with pytest.raises(getattr(errors, class_name)) as raised:
@@ -153,4 +155,10 @@ def test_every_error_in_the_table_reports_the_code_it_came_from() -> None:
 
             checked += 1
 
-    assert checked == 936
+    # Every row is either checked or deliberately skipped, so a row that stops being reached
+    #  fails here. Counted off the table rather than written down: a literal total had to be
+    #  raised by hand for each new error, and the build went red on the row that added one.
+    rows = sum(len(table) - 1 for table in exceptions.values())
+
+    assert checked > 0
+    assert checked + skipped == rows


### PR DESCRIPTION
`dev` is red: `36a0322e` added `SUBSCRIPTION_NOT_MODIFIED` to the 400 table and the literal
total in `test_every_error_in_the_table_reports_the_code_it_came_from` was not raised with it.

```
$ make api && uv run pytest tests/unit/errors/test_error_codes.py -q
E       assert 937 == 936
tests/unit/errors/test_error_codes.py:156: AssertionError
1 failed, 11 passed
```

## What

The total is now counted off the table instead of written down, and the rows the loop skips on
purpose are counted too, so every row is either checked or deliberately skipped:

```python
rows = sum(len(table) - 1 for table in exceptions.values())

assert checked > 0
assert checked + skipped == rows
```

After the change, on a freshly generated tree:

```
$ make api && uv run pytest tests/unit/errors/test_error_codes.py -q
12 passed
```

The guard is the same one, not a weaker one. Making a row silently unreachable still fails it:

```python
if error_id == "_" or error_id.startswith("CHAT_"):   # temporary, to check the assertion bites
    continue
```

```
FAILED tests/unit/errors/test_error_codes.py::test_every_error_in_the_table_reports_the_code_it_came_from
1 failed, 11 passed
```

## Why

The error tables are generated from Telegram's own error list and grow, so a literal total made
every added row a red build rather than a finding. This is the second commit it has caught out.

## How to test

`make api`, then `make test-unit`. Note that a checkout whose generated tree predates the new
row passes either way: the table has to be regenerated first, which is why this went unnoticed
locally.
