### PR TITLE
fix(filters): escape the command name before matching it

### DIFF
--- a/pyrogram/filters.py
+++ b/pyrogram/filters.py
@@ -1217,7 +1217,7 @@ def command(
     command_re = re.compile(r"([\"'])(.*?)(?<!\\)\1|(\S+)")
 
     async def func(flt, client: pyrogram.Client, message: Message):
-        username = client.me.username or ""
+        escaped_username = re.escape(client.me.username or "")
         text = message.text or message.caption
         message.command = None
 
@@ -1231,15 +1231,17 @@ def command(
             without_prefix = text[len(prefix) :]
 
             for cmd in flt.commands:
+                escaped_command = re.escape(cmd)
+
                 if not re.match(
-                    rf"^(?:{cmd}(?:@?{username})?)(?:\s|$)",
+                    rf"^(?:{escaped_command}(?:@?{escaped_username})?)(?:\s|$)",
                     without_prefix,
                     flags=re.IGNORECASE if not flt.case_sensitive else 0,
                 ):
                     continue
 
                 without_command = re.sub(
-                    rf"{cmd}(?:@?{username})?\s?",
+                    rf"{escaped_command}(?:@?{escaped_username})?\s?",
                     "",
                     without_prefix,
                     count=1,

--- a/tests/unit/filters/test_command.py
+++ b/tests/unit/filters/test_command.py
@@ -16,6 +16,8 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations as _annotations
+
 import pytest
 
 from pyrogram import filters

--- a/tests/unit/filters/test_command.py
+++ b/tests/unit/filters/test_command.py
@@ -146,3 +146,41 @@ async def test_no_text():
 
     m = Message()
     assert not await f(c, m)
+
+
+@pytest.mark.asyncio
+async def test_metacharacter_matches_only_its_own_literal() -> None:
+    command_filter = filters.command("buy.now")
+
+    message = Message("/buy.now")
+    assert await command_filter(c, message)
+
+    message = Message("/buyXnow")
+    assert not await command_filter(c, message)
+
+
+@pytest.mark.asyncio
+async def test_repeated_metacharacter_matches_its_own_command() -> None:
+    command_filter = filters.command("c++")
+
+    message = Message("/c++ a b")
+    assert await command_filter(c, message)
+    assert message.command == ["c++"] + list("ab")
+
+    message = Message("/c++@username a b")
+    assert await command_filter(c, message)
+    assert message.command == ["c++"] + list("ab")
+
+
+@pytest.mark.asyncio
+async def test_command_that_is_nothing_but_a_metacharacter() -> None:
+    command_filter = filters.command("+")
+
+    message = Message("/+ a")
+    assert await command_filter(c, message)
+    assert message.command == ["+", "a"]
+
+    # The pattern was built for every message carrying the prefix, so an unrelated one
+    #  reached the same uncompilable regex and raised out of the dispatcher.
+    message = Message("/other")
+    assert not await command_filter(c, message)


### PR DESCRIPTION
Closes #363

## What

`command()` interpolated the command name and the bot username straight into two patterns with
no escaping: the `re.match` that decides the match, and the `re.sub` that builds
`message.command`. Every regex metacharacter in a command name therefore changed what the filter
matched, and some of them made the pattern uncompilable.

Both patterns are built inside the filter's `func`, which runs for every message carrying one of
the prefixes. An uncompilable command name therefore raised on unrelated messages, not only on
its own.

Before:

    command('buy.now') vs '/buyXnow'  ->  True, message.command = ['buy.now']
    command('c++')     vs '/c++ a b'  ->  False, message.command = None
    command('+')       vs '/other'    ->  PatternError: nothing to repeat at position 4

After:

    command('buy.now') vs '/buyXnow'  ->  False, message.command = None
    command('c++')     vs '/c++ a b'  ->  True, message.command = ['c++', 'a', 'b']
    command('+')       vs '/other'    ->  False, message.command = None

The username goes through `re.escape` as well, although nothing reaches it today: Telegram
restricts a username to letters, digits and underscores, and none of those mean anything in a
pattern.

Still not addressed, deliberately: the pattern is rebuilt and recompiled for every message and
every command in the filter. Compiling it once at construction is a separate change.

## How to test

`make test-unit`. Three cases were added to `tests/unit/filters/test_command.py`, covering
`buy.now`, `c++` and `+` as command names. With the `re.escape` calls removed, exactly those
three fail and the pre-existing nine pass.
