### PR TITLE
fix(messages): catch `StopIteration` when `click()` looks a button up by label

### DIFF
--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -9453,8 +9453,8 @@ class Message(Object, Update):
 
             try:
                 button = next(button for row in keyboard for button in row if label == button.text)
-            except IndexError as e:
-                raise ValueError(f"The button with label '{x}' doesn't exists") from e
+            except StopIteration as e:
+                raise ValueError(f"The button with label '{x}' doesn't exist") from e
         else:
             raise ValueError("Invalid arguments")
 

--- a/tests/unit/types/messages_and_media/test_message.py
+++ b/tests/unit/types/messages_and_media/test_message.py
@@ -16,6 +16,10 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import annotations as _annotations
+
+from typing import Final
+
 import pytest
 
 import pyrogram
@@ -24,6 +28,7 @@ from pyrogram import enums, raw, types
 CHANNEL_ID = 1000000000
 USER_ID = 777000
 DATE = 1755100000
+_BUTTON_URL: Final[str] = "https://example.com"
 
 
 def client():
@@ -78,3 +83,37 @@ async def test_a_direct_message_with_a_topic_keeps_its_id():
     )
 
     assert parsed.direct_messages_topic_id == USER_ID
+
+
+def message_with_url_button(label: str) -> types.Message:
+    keyboard = types.InlineKeyboardMarkup(
+        [[types.InlineKeyboardButton(label, url=_BUTTON_URL)]],
+    )
+
+    return types.Message(
+        id=1,
+        reply_markup=keyboard,
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_button_is_found_by_its_label() -> None:
+    keyboard_message = message_with_url_button("Open")
+
+    assert await keyboard_message.click("Open") == _BUTTON_URL
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_button_label_names_the_label() -> None:
+    keyboard_message = message_with_url_button("Open")
+
+    with pytest.raises(ValueError, match="The button with label 'Close' doesn't exist"):
+        await keyboard_message.click("Close")
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_button_index_names_the_index() -> None:
+    keyboard_message = message_with_url_button("Open")
+
+    with pytest.raises(ValueError, match="The button at index 9 doesn't exist"):
+        await keyboard_message.click(9)


### PR DESCRIPTION
## What

`click()` resolves a button by label with `next()`, inside a `try` that catches `IndexError`.
`next()` raises `StopIteration`, so that handler never ran, and inside a coroutine an escaping
`StopIteration` is converted: the caller got the name of a coroutine instead of the name of the
button they got wrong.

Run against a message carrying one inline button labelled `Open`:

    before:  click('no such button')  ->  RuntimeError: coroutine raised StopIteration
             click(99)                ->  ValueError: The button at index 99 doesn't exist

    after:   click('no such button')  ->  ValueError: The button with label 'no such button' doesn't exist
             click(99)                ->  ValueError: The button at index 99 doesn't exist

The two index branches are unchanged: they subscript, which really does raise `IndexError`. The
label branch also said "doesn't exists" where both index branches say "doesn't exist", so the three
messages now agree.

## How to test

`make test-unit`. Three cases were added to `tests/unit/types/messages_and_media/test_message.py`:
a label resolving to its button, an unknown label, and an unknown index. The first uses a URL
button because that branch returns `button.url` without reaching the client, so the lookup is
covered with no network and no fake. With `StopIteration` put back to `IndexError`, exactly the
unknown-label case fails, with the `RuntimeError` above.
