### PR TITLE
fix(async): route local file I/O through aiofiles, enable ruff's ASYNC rule

### DIFF
--- a/compiler/api/compiler.py
+++ b/compiler/api/compiler.py
@@ -19,7 +19,6 @@
 from __future__ import annotations as _annotations
 
 import json
-import os
 import re
 import shutil
 from functools import partial
@@ -361,7 +360,7 @@ def start(format: bool = False):
         if module == "Updates":
             module = "UpdatesT"
 
-        os.makedirs(dir_path, exist_ok=True)
+        dir_path.mkdir(parents=True, exist_ok=True)
 
         constructors = sorted(qualtype_constructors)
         constr_count = len(constructors)
@@ -643,7 +642,7 @@ def start(format: bool = False):
 
         dir_path = DESTINATION_PATH / directory / c.namespace
 
-        os.makedirs(dir_path, exist_ok=True)
+        dir_path.mkdir(parents=True, exist_ok=True)
 
         module = c.name
 
@@ -730,7 +729,7 @@ def start(format: bool = False):
 
 
 if "__main__" == __name__:
-    HOME_PATH = Path(".")
+    HOME_PATH = Path()
     DESTINATION_PATH = Path("../../pyrogram/raw")
     NOTICE_PATH = Path("../../NOTICE")
 

--- a/compiler/errors/sort.py
+++ b/compiler/errors/sort.py
@@ -20,12 +20,12 @@ import csv
 from pathlib import Path
 
 for p in Path("source").glob("*.tsv"):
-    with open(p) as f:
+    with p.open() as f:
         reader = csv.reader(f, delimiter="\t")
         dct = {k: v for k, v in reader if k != "id"}
         keys = sorted(dct)
 
-    with open(p, "w") as f:
+    with p.open("w") as f:
         f.write("id\tmessage\n")
 
         for i, item in enumerate(keys, start=1):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,6 +214,8 @@ quote-style = "double"
 #  --statistics` reports nearly 19000 findings, the bulk of them line length, missing
 #  trailing commas and docstring section formatting.
 select = [
+    "ASYNC",  # flake8-async: a blocking call (`open`, `time.sleep`, pathlib I/O, ...) inside
+              #  an `async def`, which stalls the event loop instead of yielding to it.
     "B",      # flake8-bugbear: mutable/call-based argument defaults, bare `except: raise`,
               #  unused loop variables, `zip()` without `strict=`.
     "C4",     # flake8-comprehensions: a comprehension a plain builtin call already expresses.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,8 @@ classifiers = [
 #  works with, and the start of an unbroken range up to the newest. No ceilings, because an
 #  upper bound propagates into every downstream resolve and ages by hand.
 dependencies = [
+    # Async-native replacement for local file I/O, so it does not block the event loop.
+    "aiofiles>=25.1.0",
     # 1.1.0 and below are Python 2 only: the import fails with a `SyntaxError` on a `print`
     #  statement, and 1.0.0 with a `NameError` on `xrange`.
     "pyaes>=1.2.0",

--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -19,6 +19,7 @@
 from __future__ import annotations as _annotations
 
 import asyncio
+import contextlib
 import functools
 import inspect
 import logging
@@ -38,6 +39,10 @@ from mimetypes import MimeTypes
 from pathlib import Path
 from typing import Any
 from collections.abc import AsyncGenerator, Callable, Sequence
+
+import aiofiles
+import aiofiles.os
+from aiofiles.threadpool import wrap
 
 import pyrogram
 from pyrogram import __license__, __version__, enums, raw, utils
@@ -1258,33 +1263,41 @@ class Client(Methods):
     async def handle_download(self, packet):
         file_id, directory, file_name, in_memory, file_size, progress, progress_args = packet
 
-        os.makedirs(directory, exist_ok=True) if not in_memory else None
-        temp_file_path = (
-            os.path.abspath(re.sub("\\\\", "/", os.path.join(directory, file_name))) + ".temp"
-        )
-        file = BytesIO() if in_memory else open(temp_file_path, "wb")
+        if in_memory:
+            memory_file = BytesIO()
+            file = wrap(memory_file)
+            temp_file_path = None
+        else:
+            memory_file = None
+            await aiofiles.os.makedirs(directory, exist_ok=True)
+            temp_file_path = (
+                await aiofiles.os.path.abspath(Path(directory, file_name).as_posix()) + ".temp"
+            )
+            file = await aiofiles.open(temp_file_path, "wb")
 
         try:
             async for chunk in self.get_file(file_id, file_size, 0, 0, progress, progress_args):
-                file.write(chunk)
+                await file.write(chunk)
         except BaseException as e:
-            if not in_memory:
-                file.close()
-                os.remove(temp_file_path)
+            await file.close()
+
+            if temp_file_path is not None:
+                with contextlib.suppress(OSError):
+                    await aiofiles.os.remove(temp_file_path)
 
             if isinstance(e, pyrogram.StopTransmission):
                 return None
 
-            raise e
-        else:
-            if in_memory:
-                file.name = file_name
-                return file
-            else:
-                file.close()
-                file_path = str(Path(temp_file_path).with_suffix(""))
-                shutil.move(temp_file_path, file_path)
-                return file_path
+            raise
+
+        if memory_file is not None:
+            memory_file.name = file_name
+            return memory_file
+
+        await file.close()
+        file_path = str(Path(temp_file_path).with_suffix(""))
+        shutil.move(temp_file_path, file_path)
+        return file_path
 
     async def get_file(
         self,

--- a/pyrogram/client.py
+++ b/pyrogram/client.py
@@ -1282,7 +1282,7 @@ class Client(Methods):
                 return file
             else:
                 file.close()
-                file_path = os.path.splitext(temp_file_path)[0]
+                file_path = str(Path(temp_file_path).with_suffix(""))
                 shutil.move(temp_file_path, file_path)
                 return file_path
 
@@ -1704,7 +1704,7 @@ class Client(Methods):
             self.message_split_ranges = await self.invoke(raw.functions.messages.GetSplitRanges())
         return self.message_split_ranges
 
-    def guess_mime_type(self, filename: str | BytesIO) -> str | None:
+    def guess_mime_type(self, filename: str | Path | BytesIO) -> str | None:
         if isinstance(filename, BytesIO):
             return self.mimetypes.guess_type(filename.name)[0]
 

--- a/pyrogram/errors/rpc_error.py
+++ b/pyrogram/errors/rpc_error.py
@@ -22,6 +22,7 @@ import re
 from dataclasses import dataclass
 from datetime import datetime
 from importlib import import_module
+from pathlib import Path
 from typing import Final
 from re import Pattern
 
@@ -114,7 +115,7 @@ class RPCError(Exception):
             self.value = value
 
         if is_unknown:
-            with open("unknown_errors.txt", "a", encoding="utf-8") as f:
+            with Path("unknown_errors.txt").open("a", encoding="utf-8") as f:
                 f.write(f"{datetime.now()}\t{value}\t{rpc_name}\n")
 
     @staticmethod

--- a/pyrogram/methods/account/add_profile_audio.py
+++ b/pyrogram/methods/account/add_profile_audio.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations as _annotations
 
+import os
 from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
@@ -80,7 +81,7 @@ class AddProfileAudio:
         file = None
 
         try:
-            if isinstance(audio, (str, Path)):
+            if isinstance(audio, (str, os.PathLike)):
                 if await aiofiles.os.path.isfile(audio):
                     mime_type = self.guess_mime_type(audio) or "audio/mpeg"
                     if mime_type == "audio/ogg":

--- a/pyrogram/methods/account/add_profile_audio.py
+++ b/pyrogram/methods/account/add_profile_audio.py
@@ -18,10 +18,11 @@
 
 from __future__ import annotations as _annotations
 
-import os
 from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
+
+import aiofiles.os
 
 import pyrogram
 from pyrogram import StopTransmission, raw, utils
@@ -80,7 +81,7 @@ class AddProfileAudio:
 
         try:
             if isinstance(audio, (str, Path)):
-                if os.path.isfile(audio):
+                if await aiofiles.os.path.isfile(audio):
                     mime_type = self.guess_mime_type(audio) or "audio/mpeg"
                     if mime_type == "audio/ogg":
                         mime_type = "audio/opus"

--- a/pyrogram/methods/account/add_profile_audio.py
+++ b/pyrogram/methods/account/add_profile_audio.py
@@ -19,6 +19,7 @@
 from __future__ import annotations as _annotations
 
 import os
+from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
 
@@ -31,11 +32,11 @@ from pyrogram.file_id import FileType
 class AddProfileAudio:
     async def add_profile_audio(
         self: pyrogram.Client,
-        audio: str | BinaryIO,
+        audio: str | Path | BinaryIO,
         duration: int = 0,
         performer: str | None = None,
         title: str | None = None,
-        thumb: str | BinaryIO | None = None,
+        thumb: str | Path | BinaryIO | None = None,
         file_name: str | None = None,
         progress: Callable | None = None,
         progress_args: tuple = (),
@@ -45,7 +46,7 @@ class AddProfileAudio:
         .. include:: /_includes/usable-by/users.rst
 
         Parameters:
-            audio (``str`` | ``BinaryIO``):
+            audio (``str`` | ``pathlib.Path`` | ``BinaryIO``):
                 Audio file to add.
                 Pass a file_id as string to add an audio file that exists on the Telegram servers,
                 pass a file path as string to upload a new audio file that exists on your local machine, or
@@ -54,6 +55,9 @@ class AddProfileAudio:
         Returns:
             ``bool`` | ``None``: On success, True is returned, otherwise, in
             case the upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned.
+
+        Raises:
+            FileNotFoundError: In case a local ``pathlib.Path`` doesn't point to an existing file.
 
         Example:
             .. code-block:: python
@@ -75,7 +79,7 @@ class AddProfileAudio:
         file = None
 
         try:
-            if isinstance(audio, str):
+            if isinstance(audio, (str, Path)):
                 if os.path.isfile(audio):
                     mime_type = self.guess_mime_type(audio) or "audio/mpeg"
                     if mime_type == "audio/ogg":
@@ -97,7 +101,7 @@ class AddProfileAudio:
                                         duration=duration, performer=performer, title=title
                                     ),
                                     raw.types.DocumentAttributeFilename(
-                                        file_name=file_name or os.path.basename(audio)
+                                        file_name=file_name or Path(audio).name
                                     ),
                                 ],
                             ),
@@ -109,8 +113,10 @@ class AddProfileAudio:
                         access_hash=uploaded_media.document.access_hash,
                         file_reference=uploaded_media.document.file_reference,
                     )
-                else:
+                elif isinstance(audio, str):
                     media = (utils.get_input_media_from_file_id(audio, FileType.AUDIO)).id
+                else:
+                    raise FileNotFoundError(f"No such file or directory: {audio}")
             else:
                 mime_type = self.guess_mime_type(file_name or audio.name) or "audio/mpeg"
                 if mime_type == "audio/ogg":

--- a/pyrogram/methods/advanced/save_file.py
+++ b/pyrogram/methods/advanced/save_file.py
@@ -161,7 +161,7 @@ class SaveFile:
 
             part_size = 512 * 1024
 
-            if isinstance(path, (str, PurePath)):
+            if isinstance(path, (str, os.PathLike)):
                 fp = await aiofiles.open(path, "rb")
             elif isinstance(path, io.IOBase):
                 # `aiofiles.threadpool.wrap()` only recognizes stdlib file types — a `SpooledTemporaryFile`
@@ -260,7 +260,7 @@ class SaveFile:
 
                 # Only what this method opened: a file the caller handed over stays open,
                 #  the same way it did before the upload.
-                if isinstance(path, (str, PurePath)):
+                if isinstance(path, (str, os.PathLike)):
                     await fp.close()
 
             # Outside the `finally` on purpose: a worker only reports a failed part once it has been

--- a/pyrogram/methods/advanced/save_file.py
+++ b/pyrogram/methods/advanced/save_file.py
@@ -26,6 +26,7 @@ import logging
 import math
 import os
 from hashlib import md5
+from tempfile import SpooledTemporaryFile
 from typing import BinaryIO, overload
 from collections.abc import Callable
 
@@ -162,9 +163,12 @@ class SaveFile:
 
             if isinstance(path, (str, os.PathLike)):
                 fp = await aiofiles.open(path, "rb")
-            elif isinstance(path, io.IOBase):
-                # `aiofiles.threadpool.wrap()` only recognizes stdlib file types — a `SpooledTemporaryFile`
-                #  or custom `io.IOBase` raises there, though both are accepted here.
+            elif isinstance(path, (io.IOBase, SpooledTemporaryFile)):
+                # `SpooledTemporaryFile` only became an `io.IOBase` in Python 3.11 (the floor
+                #  here is 3.10), so it needs naming on its own to keep accepting it below that.
+                # `aiofiles.threadpool.wrap()` only recognizes stdlib file types (a
+                #  `SpooledTemporaryFile` or custom `io.IOBase` raises there), though both are
+                #  accepted here.
                 fp = AsyncBufferedIOBase(path, loop=None, executor=None)
             else:
                 raise ValueError(

--- a/pyrogram/methods/advanced/save_file.py
+++ b/pyrogram/methods/advanced/save_file.py
@@ -30,6 +30,9 @@ from pathlib import PurePath
 from typing import BinaryIO, overload
 from collections.abc import Callable
 
+import aiofiles
+from aiofiles.threadpool.binary import AsyncBufferedIOBase
+
 import pyrogram
 from pyrogram import StopTransmission
 from pyrogram import raw
@@ -159,9 +162,11 @@ class SaveFile:
             part_size = 512 * 1024
 
             if isinstance(path, (str, PurePath)):
-                fp = open(path, "rb")
+                fp = await aiofiles.open(path, "rb")
             elif isinstance(path, io.IOBase):
-                fp = path
+                # `aiofiles.threadpool.wrap()` only recognizes stdlib file types — a `SpooledTemporaryFile`
+                #  or custom `io.IOBase` raises there, though both are accepted here.
+                fp = AsyncBufferedIOBase(path, loop=None, executor=None)
             else:
                 raise ValueError(
                     "Invalid file. Expected a file path as string or a binary (not text) file pointer"
@@ -169,9 +174,9 @@ class SaveFile:
 
             file_name = getattr(fp, "name", "file.jpg")
 
-            fp.seek(0, os.SEEK_END)
-            file_size = fp.tell()
-            fp.seek(0)
+            await fp.seek(0, os.SEEK_END)
+            file_size = await fp.tell()
+            await fp.seek(0)
 
             if file_size == 0:
                 raise ValueError("File size equals to 0 B")
@@ -198,10 +203,10 @@ class SaveFile:
             queue = asyncio.Queue(1)
 
             try:
-                fp.seek(part_size * file_part)
+                await fp.seek(part_size * file_part)
 
                 while True:
-                    chunk = fp.read(part_size)
+                    chunk = await fp.read(part_size)
 
                     if not chunk:
                         if not is_big and not is_missing_part:
@@ -253,8 +258,10 @@ class SaveFile:
 
                 await asyncio.gather(*workers)
 
+                # Only what this method opened: a file the caller handed over stays open,
+                #  the same way it did before the upload.
                 if isinstance(path, (str, PurePath)):
-                    fp.close()
+                    await fp.close()
 
             # Outside the `finally` on purpose: a worker only reports a failed part once it has been
             #  woken up and drained above, so a check any earlier can miss it.

--- a/pyrogram/methods/advanced/save_file.py
+++ b/pyrogram/methods/advanced/save_file.py
@@ -26,7 +26,6 @@ import logging
 import math
 import os
 from hashlib import md5
-from pathlib import PurePath
 from typing import BinaryIO, overload
 from collections.abc import Callable
 
@@ -60,7 +59,7 @@ class SaveFile:
     @overload
     async def save_file(
         self: pyrogram.Client,
-        path: str | PurePath | BinaryIO,
+        path: str | os.PathLike[str] | BinaryIO,
         file_id: int,
         file_part: int = 0,
         progress: Callable | None = None,
@@ -70,7 +69,7 @@ class SaveFile:
     @overload
     async def save_file(
         self: pyrogram.Client,
-        path: str | PurePath | BinaryIO,
+        path: str | os.PathLike[str] | BinaryIO,
         file_id: None = None,
         file_part: int = 0,
         progress: Callable | None = None,
@@ -79,7 +78,7 @@ class SaveFile:
 
     async def save_file(
         self: pyrogram.Client,
-        path: str | PurePath | BinaryIO | None,
+        path: str | os.PathLike[str] | BinaryIO | None,
         file_id: int | None = None,
         file_part: int = 0,
         progress: Callable | None = None,
@@ -97,7 +96,7 @@ class SaveFile:
         .. include:: /_includes/usable-by/users-bots.rst
 
         Parameters:
-            path (``str`` | ``pathlib.PurePath`` | ``BinaryIO``):
+            path (``str`` | ``os.PathLike`` | ``BinaryIO``):
                 The path of the file you want to upload that exists on your local machine or a binary file-like object
                 with its attribute ".name" set for in-memory uploads.
 

--- a/pyrogram/methods/advanced/save_file.py
+++ b/pyrogram/methods/advanced/save_file.py
@@ -57,7 +57,7 @@ class SaveFile:
     @overload
     async def save_file(
         self: pyrogram.Client,
-        path: str | BinaryIO,
+        path: str | PurePath | BinaryIO,
         file_id: int,
         file_part: int = 0,
         progress: Callable | None = None,
@@ -67,7 +67,7 @@ class SaveFile:
     @overload
     async def save_file(
         self: pyrogram.Client,
-        path: str | BinaryIO,
+        path: str | PurePath | BinaryIO,
         file_id: None = None,
         file_part: int = 0,
         progress: Callable | None = None,
@@ -76,7 +76,7 @@ class SaveFile:
 
     async def save_file(
         self: pyrogram.Client,
-        path: str | BinaryIO | None,
+        path: str | PurePath | BinaryIO | None,
         file_id: int | None = None,
         file_part: int = 0,
         progress: Callable | None = None,
@@ -94,7 +94,7 @@ class SaveFile:
         .. include:: /_includes/usable-by/users-bots.rst
 
         Parameters:
-            path (``str`` | ``BinaryIO``):
+            path (``str`` | ``pathlib.PurePath`` | ``BinaryIO``):
                 The path of the file you want to upload that exists on your local machine or a binary file-like object
                 with its attribute ".name" set for in-memory uploads.
 

--- a/pyrogram/methods/chats/set_chat_photo.py
+++ b/pyrogram/methods/chats/set_chat_photo.py
@@ -19,6 +19,7 @@
 from __future__ import annotations as _annotations
 
 import os
+from pathlib import Path
 from typing import BinaryIO
 
 import pyrogram
@@ -33,8 +34,8 @@ class SetChatPhoto:
         self: pyrogram.Client,
         chat_id: int | str,
         *,
-        photo: str | BinaryIO | None = None,
-        video: str | BinaryIO | None = None,
+        photo: str | Path | BinaryIO | None = None,
+        video: str | Path | BinaryIO | None = None,
         video_start_ts: float | None = None,
     ) -> types.Message | None:
         """Set a new chat photo or video (H.264/MPEG-4 AVC video, max 5 seconds).
@@ -50,12 +51,12 @@ class SetChatPhoto:
             chat_id (``int`` | ``str``):
                 Unique identifier (int) or username (str) of the target chat.
 
-            photo (``str`` | ``BinaryIO``, *optional*):
+            photo (``str`` | ``pathlib.Path`` | ``BinaryIO``, *optional*):
                 New chat photo. You can pass a :obj:`~pyrogram.types.Photo` file_id, a file path to upload a new photo
                 from your local machine or a binary file-like object with its attribute
                 ".name" set for in-memory uploads.
 
-            video (``str`` | ``BinaryIO``, *optional*):
+            video (``str`` | ``pathlib.Path`` | ``BinaryIO``, *optional*):
                 New chat video. You can pass a :obj:`~pyrogram.types.Video` file_id, a file path to upload a new video
                 from your local machine or a binary file-like object with its attribute
                 ".name" set for in-memory uploads.
@@ -69,6 +70,7 @@ class SetChatPhoto:
 
         Raises:
             ValueError: if a chat_id belongs to user.
+            FileNotFoundError: In case a local ``pathlib.Path`` doesn't point to an existing file.
 
         Example:
             .. code-block:: python
@@ -88,16 +90,18 @@ class SetChatPhoto:
         """
         peer = await self.resolve_peer(chat_id)
 
-        if isinstance(photo, str):
+        if isinstance(photo, (str, Path)):
             if os.path.isfile(photo):
                 photo = raw.types.InputChatUploadedPhoto(
                     file=await self.save_file(photo),
                     video=await self.save_file(video),
                     video_start_ts=video_start_ts,
                 )
-            else:
+            elif isinstance(photo, str):
                 photo = utils.get_input_media_from_file_id(photo, FileType.PHOTO)
                 photo = raw.types.InputChatPhoto(id=photo.id)
+            else:
+                raise FileNotFoundError(f"No such file or directory: {photo}")
         else:
             photo = raw.types.InputChatUploadedPhoto(
                 file=await self.save_file(photo),

--- a/pyrogram/methods/chats/set_chat_photo.py
+++ b/pyrogram/methods/chats/set_chat_photo.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations as _annotations
 
+import os
 from pathlib import Path
 from typing import BinaryIO
 
@@ -91,7 +92,7 @@ class SetChatPhoto:
         """
         peer = await self.resolve_peer(chat_id)
 
-        if isinstance(photo, (str, Path)):
+        if isinstance(photo, (str, os.PathLike)):
             if await aiofiles.os.path.isfile(photo):
                 photo = raw.types.InputChatUploadedPhoto(
                     file=await self.save_file(photo),

--- a/pyrogram/methods/chats/set_chat_photo.py
+++ b/pyrogram/methods/chats/set_chat_photo.py
@@ -18,9 +18,10 @@
 
 from __future__ import annotations as _annotations
 
-import os
 from pathlib import Path
 from typing import BinaryIO
+
+import aiofiles.os
 
 import pyrogram
 from pyrogram import raw
@@ -91,7 +92,7 @@ class SetChatPhoto:
         peer = await self.resolve_peer(chat_id)
 
         if isinstance(photo, (str, Path)):
-            if os.path.isfile(photo):
+            if await aiofiles.os.path.isfile(photo):
                 photo = raw.types.InputChatUploadedPhoto(
                     file=await self.save_file(photo),
                     video=await self.save_file(video),

--- a/pyrogram/methods/messages/download_media.py
+++ b/pyrogram/methods/messages/download_media.py
@@ -23,6 +23,9 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, BinaryIO, Literal, overload
 
+import aiofiles
+import aiofiles.os
+
 import pyrogram
 from pyrogram import types, utils
 from pyrogram.file_id import PHOTO_TYPES, FileId, FileType
@@ -351,10 +354,10 @@ class DownloadMedia:
                 directory = self.workdir / (directory or DEFAULT_DOWNLOAD_DIR)
 
             if not in_memory:
-                Path(directory).mkdir(parents=True, exist_ok=True)
+                await aiofiles.os.makedirs(directory, exist_ok=True)
 
-            with (Path(directory) / file_name).open("wb") as file:
-                file.write(thumb.getbuffer())
+            async with aiofiles.open(Path(directory) / file_name, "wb") as file:
+                await file.write(thumb.getbuffer())
 
             return str(Path(directory) / file_name)
         elif isinstance(message, types.ChatPhoto):

--- a/pyrogram/methods/messages/edit_inline_media.py
+++ b/pyrogram/methods/messages/edit_inline_media.py
@@ -20,10 +20,10 @@ from __future__ import annotations as _annotations
 
 import asyncio
 import io
-import os
 import re
 from pathlib import Path
 
+import aiofiles.os
 
 import pyrogram
 from pyrogram import raw
@@ -87,7 +87,7 @@ class EditInlineMedia:
         caption_entities = media.caption_entities
 
         is_bytes_io = isinstance(media.media, io.BytesIO)
-        is_uploaded_file = is_bytes_io or os.path.isfile(media.media)
+        is_uploaded_file = is_bytes_io or await aiofiles.os.path.isfile(media.media)
 
         if isinstance(media.media, Path) and not is_uploaded_file:
             raise FileNotFoundError(f"No such file or directory: {media.media}")

--- a/pyrogram/methods/messages/edit_inline_media.py
+++ b/pyrogram/methods/messages/edit_inline_media.py
@@ -20,6 +20,7 @@ from __future__ import annotations as _annotations
 
 import asyncio
 import io
+import os
 import re
 from pathlib import Path
 
@@ -89,7 +90,7 @@ class EditInlineMedia:
         is_bytes_io = isinstance(media.media, io.BytesIO)
         is_uploaded_file = is_bytes_io or await aiofiles.os.path.isfile(media.media)
 
-        if isinstance(media.media, Path) and not is_uploaded_file:
+        if isinstance(media.media, os.PathLike) and not is_uploaded_file:
             raise FileNotFoundError(f"No such file or directory: {media.media}")
 
         is_external_url = not is_uploaded_file and re.match("^https?://", media.media)

--- a/pyrogram/methods/messages/edit_inline_media.py
+++ b/pyrogram/methods/messages/edit_inline_media.py
@@ -22,6 +22,7 @@ import asyncio
 import io
 import os
 import re
+from pathlib import Path
 
 
 import pyrogram
@@ -62,6 +63,9 @@ class EditInlineMedia:
         Returns:
             ``bool``: On success, True is returned.
 
+        Raises:
+            FileNotFoundError: In case a local ``pathlib.Path`` doesn't point to an existing file.
+
         Example:
             .. code-block:: python
 
@@ -85,6 +89,9 @@ class EditInlineMedia:
         is_bytes_io = isinstance(media.media, io.BytesIO)
         is_uploaded_file = is_bytes_io or os.path.isfile(media.media)
 
+        if isinstance(media.media, Path) and not is_uploaded_file:
+            raise FileNotFoundError(f"No such file or directory: {media.media}")
+
         is_external_url = not is_uploaded_file and re.match("^https?://", media.media)
 
         if is_bytes_io and not hasattr(media.media, "name"):
@@ -93,7 +100,7 @@ class EditInlineMedia:
         if is_uploaded_file:
             filename_attribute = [
                 raw.types.DocumentAttributeFilename(
-                    file_name=media.media.name if is_bytes_io else os.path.basename(media.media)
+                    file_name=media.media.name if is_bytes_io else Path(media.media).name
                 )
             ]
         else:

--- a/pyrogram/methods/messages/send_animation.py
+++ b/pyrogram/methods/messages/send_animation.py
@@ -19,6 +19,7 @@
 from __future__ import annotations as _annotations
 
 import logging
+import os
 import re
 from datetime import datetime
 from pathlib import Path
@@ -287,7 +288,7 @@ class SendAnimation:
         file = None
 
         try:
-            if isinstance(animation, (str, Path)):
+            if isinstance(animation, (str, os.PathLike)):
                 if await aiofiles.os.path.isfile(animation):
                     thumb = await self.save_file(thumb)
                     file = await self.save_file(

--- a/pyrogram/methods/messages/send_animation.py
+++ b/pyrogram/methods/messages/send_animation.py
@@ -22,6 +22,7 @@ import logging
 import os
 import re
 from datetime import datetime
+from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
 
@@ -37,7 +38,7 @@ class SendAnimation:
     async def send_animation(
         self: pyrogram.Client,
         chat_id: int | str,
-        animation: str | BinaryIO,
+        animation: str | Path | BinaryIO,
         caption: str = "",
         unsave: bool = False,
         parse_mode: enums.ParseMode | None = None,
@@ -46,7 +47,7 @@ class SendAnimation:
         duration: int = 0,
         width: int = 0,
         height: int = 0,
-        thumb: str | BinaryIO | None = None,
+        thumb: str | Path | BinaryIO | None = None,
         file_name: str | None = None,
         disable_notification: bool | None = None,
         message_thread_id: int | None = None,
@@ -88,7 +89,7 @@ class SendAnimation:
                 For your personal cloud (Saved Messages) you can simply use "me" or "self".
                 For a contact that exists in your Telegram address book you can use his phone number (str).
 
-            animation (``str`` | ``BinaryIO``):
+            animation (``str`` | ``pathlib.Path`` | ``BinaryIO``):
                 Animation to send.
                 Pass a file_id as string to send an animation that exists on the Telegram servers,
                 pass an HTTP URL as a string for Telegram to get an animation from the Internet,
@@ -121,7 +122,7 @@ class SendAnimation:
             height (``int``, *optional*):
                 Animation height.
 
-            thumb (``str`` | ``BinaryIO``, *optional*):
+            thumb (``str`` | ``pathlib.Path`` | ``BinaryIO``, *optional*):
                 Thumbnail of the animation file sent.
                 The thumbnail should be in JPEG format and less than 200 KB in size.
                 A thumbnail's width and height should not exceed 320 pixels.
@@ -211,6 +212,9 @@ class SendAnimation:
             in case the upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is
             returned.
 
+        Raises:
+            FileNotFoundError: In case a local ``pathlib.Path`` doesn't point to an existing file.
+
         Example:
             .. code-block:: python
 
@@ -282,7 +286,7 @@ class SendAnimation:
         file = None
 
         try:
-            if isinstance(animation, str):
+            if isinstance(animation, (str, Path)):
                 if os.path.isfile(animation):
                     thumb = await self.save_file(thumb)
                     file = await self.save_file(
@@ -298,17 +302,19 @@ class SendAnimation:
                                 supports_streaming=True, duration=duration, w=width, h=height
                             ),
                             raw.types.DocumentAttributeFilename(
-                                file_name=file_name or os.path.basename(animation)
+                                file_name=file_name or Path(animation).name
                             ),
                             raw.types.DocumentAttributeAnimated(),
                         ],
                     )
-                elif re.match("^https?://", animation):
+                elif isinstance(animation, str) and re.match("^https?://", animation):
                     media = raw.types.InputMediaDocumentExternal(url=animation, spoiler=has_spoiler)
-                else:
+                elif isinstance(animation, str):
                     media = utils.get_input_media_from_file_id(
                         animation, FileType.ANIMATION, has_spoiler=has_spoiler
                     )
+                else:
+                    raise FileNotFoundError(f"No such file or directory: {animation}")
             else:
                 thumb = await self.save_file(thumb)
                 file = await self.save_file(

--- a/pyrogram/methods/messages/send_animation.py
+++ b/pyrogram/methods/messages/send_animation.py
@@ -19,12 +19,13 @@
 from __future__ import annotations as _annotations
 
 import logging
-import os
 import re
 from datetime import datetime
 from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
+
+import aiofiles.os
 
 import pyrogram
 from pyrogram import StopTransmission, enums, raw, types, utils
@@ -287,7 +288,7 @@ class SendAnimation:
 
         try:
             if isinstance(animation, (str, Path)):
-                if os.path.isfile(animation):
+                if await aiofiles.os.path.isfile(animation):
                     thumb = await self.save_file(thumb)
                     file = await self.save_file(
                         animation, progress=progress, progress_args=progress_args

--- a/pyrogram/methods/messages/send_audio.py
+++ b/pyrogram/methods/messages/send_audio.py
@@ -19,6 +19,7 @@
 from __future__ import annotations as _annotations
 
 import logging
+import os
 import re
 from datetime import datetime
 from pathlib import Path
@@ -277,7 +278,7 @@ class SendAudio:
         file = None
 
         try:
-            if isinstance(audio, (str, Path)):
+            if isinstance(audio, (str, os.PathLike)):
                 if await aiofiles.os.path.isfile(audio):
                     mime_type = self.guess_mime_type(audio) or "audio/mpeg"
                     if mime_type == "audio/ogg":

--- a/pyrogram/methods/messages/send_audio.py
+++ b/pyrogram/methods/messages/send_audio.py
@@ -19,12 +19,13 @@
 from __future__ import annotations as _annotations
 
 import logging
-import os
 import re
 from datetime import datetime
 from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
+
+import aiofiles.os
 
 import pyrogram
 from pyrogram import StopTransmission, enums, raw, types, utils
@@ -277,7 +278,7 @@ class SendAudio:
 
         try:
             if isinstance(audio, (str, Path)):
-                if os.path.isfile(audio):
+                if await aiofiles.os.path.isfile(audio):
                     mime_type = self.guess_mime_type(audio) or "audio/mpeg"
                     if mime_type == "audio/ogg":
                         mime_type = "audio/opus"

--- a/pyrogram/methods/messages/send_audio.py
+++ b/pyrogram/methods/messages/send_audio.py
@@ -22,6 +22,7 @@ import logging
 import os
 import re
 from datetime import datetime
+from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
 
@@ -37,14 +38,14 @@ class SendAudio:
     async def send_audio(
         self: pyrogram.Client,
         chat_id: int | str,
-        audio: str | BinaryIO,
+        audio: str | Path | BinaryIO,
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
         duration: int = 0,
         performer: str | None = None,
         title: str | None = None,
-        thumb: str | BinaryIO | None = None,
+        thumb: str | Path | BinaryIO | None = None,
         file_name: str | None = None,
         disable_notification: bool | None = None,
         message_thread_id: int | None = None,
@@ -87,7 +88,7 @@ class SendAudio:
                 For your personal cloud (Saved Messages) you can simply use "me" or "self".
                 For a contact that exists in your Telegram address book you can use his phone number (str).
 
-            audio (``str`` | ``BinaryIO``):
+            audio (``str`` | ``pathlib.Path`` | ``BinaryIO``):
                 Audio file to send.
                 Pass a file_id as string to send an audio file that exists on the Telegram servers,
                 pass an HTTP URL as a string for Telegram to get an audio file from the Internet,
@@ -113,7 +114,7 @@ class SendAudio:
             title (``str``, *optional*):
                 Track name.
 
-            thumb (``str`` | ``BinaryIO``, *optional*):
+            thumb (``str`` | ``pathlib.Path`` | ``BinaryIO``, *optional*):
                 Thumbnail of the music file album cover.
                 The thumbnail should be in JPEG format and less than 200 KB in size.
                 A thumbnail's width and height should not exceed 320 pixels.
@@ -199,6 +200,9 @@ class SendAudio:
             :obj:`~pyrogram.types.Message` | ``None``: On success, the sent audio message is returned, otherwise, in
             case the upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned.
 
+        Raises:
+            FileNotFoundError: In case a local ``pathlib.Path`` doesn't point to an existing file.
+
         Example:
             .. code-block:: python
 
@@ -272,7 +276,7 @@ class SendAudio:
         file = None
 
         try:
-            if isinstance(audio, str):
+            if isinstance(audio, (str, Path)):
                 if os.path.isfile(audio):
                     mime_type = self.guess_mime_type(audio) or "audio/mpeg"
                     if mime_type == "audio/ogg":
@@ -290,14 +294,16 @@ class SendAudio:
                                 duration=duration, performer=performer, title=title
                             ),
                             raw.types.DocumentAttributeFilename(
-                                file_name=file_name or os.path.basename(audio)
+                                file_name=file_name or Path(audio).name
                             ),
                         ],
                     )
-                elif re.match("^https?://", audio):
+                elif isinstance(audio, str) and re.match("^https?://", audio):
                     media = raw.types.InputMediaDocumentExternal(url=audio)
-                else:
+                elif isinstance(audio, str):
                     media = utils.get_input_media_from_file_id(audio, FileType.AUDIO)
+                else:
+                    raise FileNotFoundError(f"No such file or directory: {audio}")
             else:
                 mime_type = self.guess_mime_type(file_name or audio.name) or "audio/mpeg"
                 if mime_type == "audio/ogg":

--- a/pyrogram/methods/messages/send_document.py
+++ b/pyrogram/methods/messages/send_document.py
@@ -19,12 +19,13 @@
 from __future__ import annotations as _annotations
 
 import logging
-import os
 import re
 from datetime import datetime
 from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
+
+import aiofiles.os
 
 import pyrogram
 from pyrogram import StopTransmission, enums, raw, types, utils
@@ -264,7 +265,7 @@ class SendDocument:
 
         try:
             if isinstance(document, (str, Path)):
-                if os.path.isfile(document):
+                if await aiofiles.os.path.isfile(document):
                     thumb = await self.save_file(thumb)
                     file = await self.save_file(
                         document, progress=progress, progress_args=progress_args

--- a/pyrogram/methods/messages/send_document.py
+++ b/pyrogram/methods/messages/send_document.py
@@ -22,6 +22,7 @@ import logging
 import os
 import re
 from datetime import datetime
+from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
 
@@ -37,8 +38,8 @@ class SendDocument:
     async def send_document(
         self: pyrogram.Client,
         chat_id: int | str,
-        document: str | BinaryIO,
-        thumb: str | BinaryIO | None = None,
+        document: str | Path | BinaryIO,
+        thumb: str | Path | BinaryIO | None = None,
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
@@ -83,14 +84,14 @@ class SendDocument:
                 For your personal cloud (Saved Messages) you can simply use "me" or "self".
                 For a contact that exists in your Telegram address book you can use his phone number (str).
 
-            document (``str`` | ``BinaryIO``):
+            document (``str`` | ``pathlib.Path`` | ``BinaryIO``):
                 File to send.
                 Pass a file_id as string to send a file that exists on the Telegram servers,
                 pass an HTTP URL as a string for Telegram to get a file from the Internet,
                 pass a file path as string to upload a new file that exists on your local machine, or
                 pass a binary file-like object with its attribute ".name" set for in-memory uploads.
 
-            thumb (``str`` | ``BinaryIO``, *optional*):
+            thumb (``str`` | ``pathlib.Path`` | ``BinaryIO``, *optional*):
                 Thumbnail of the file sent.
                 The thumbnail should be in JPEG format and less than 200 KB in size.
                 A thumbnail's width and height should not exceed 320 pixels.
@@ -191,6 +192,9 @@ class SendDocument:
             :obj:`~pyrogram.types.Message` | ``None``: On success, the sent document message is returned, otherwise, in
             case the upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned.
 
+        Raises:
+            FileNotFoundError: In case a local ``pathlib.Path`` doesn't point to an existing file.
+
         Example:
             .. code-block:: python
 
@@ -259,7 +263,7 @@ class SendDocument:
         file = None
 
         try:
-            if isinstance(document, str):
+            if isinstance(document, (str, Path)):
                 if os.path.isfile(document):
                     thumb = await self.save_file(thumb)
                     file = await self.save_file(
@@ -272,14 +276,16 @@ class SendDocument:
                         thumb=thumb,
                         attributes=[
                             raw.types.DocumentAttributeFilename(
-                                file_name=file_name or os.path.basename(document)
+                                file_name=file_name or Path(document).name
                             )
                         ],
                     )
-                elif re.match("^https?://", document):
+                elif isinstance(document, str) and re.match("^https?://", document):
                     media = raw.types.InputMediaDocumentExternal(url=document)
-                else:
+                elif isinstance(document, str):
                     media = utils.get_input_media_from_file_id(document, FileType.DOCUMENT)
+                else:
+                    raise FileNotFoundError(f"No such file or directory: {document}")
             else:
                 thumb = await self.save_file(thumb)
                 file = await self.save_file(

--- a/pyrogram/methods/messages/send_document.py
+++ b/pyrogram/methods/messages/send_document.py
@@ -19,6 +19,7 @@
 from __future__ import annotations as _annotations
 
 import logging
+import os
 import re
 from datetime import datetime
 from pathlib import Path
@@ -264,7 +265,7 @@ class SendDocument:
         file = None
 
         try:
-            if isinstance(document, (str, Path)):
+            if isinstance(document, (str, os.PathLike)):
                 if await aiofiles.os.path.isfile(document):
                     thumb = await self.save_file(thumb)
                     file = await self.save_file(

--- a/pyrogram/methods/messages/send_live_photo.py
+++ b/pyrogram/methods/messages/send_live_photo.py
@@ -20,6 +20,7 @@ from __future__ import annotations as _annotations
 
 import logging
 from datetime import datetime
+from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
 
@@ -34,8 +35,8 @@ class SendLivePhoto:
     async def send_live_photo(
         self: pyrogram.Client,
         chat_id: int | str,
-        live_photo: str | BinaryIO,
-        photo: str | BinaryIO,
+        live_photo: str | Path | BinaryIO,
+        photo: str | Path | BinaryIO,
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
@@ -76,7 +77,7 @@ class SendLivePhoto:
                 For your personal cloud (Saved Messages) you can simply use "me" or "self".
                 For a contact that exists in your Telegram address book you can use his phone number (str).
 
-            live_photo (``str`` | ``BinaryIO``):
+            live_photo (``str`` | ``pathlib.Path`` | ``BinaryIO``):
                 Live photo video to send.
                 The video must be no longer than 10 seconds and must not exceed 10 MB in size.
                 Pass a file_id as string to send a video that exists on the Telegram servers,
@@ -84,7 +85,7 @@ class SendLivePhoto:
                 pass a file path as string to upload a new video that exists on your local machine, or
                 pass a binary file-like object with its attribute ".name" set for in-memory uploads.
 
-            photo (``str`` | ``BinaryIO``):
+            photo (``str`` | ``pathlib.Path`` | ``BinaryIO``):
                 The static photo to send.
                 The video must be no longer than 10 seconds and must not exceed 10 MB in size.
                 Pass a file_id as string to send a video that exists on the Telegram servers,

--- a/pyrogram/methods/messages/send_media_group.py
+++ b/pyrogram/methods/messages/send_media_group.py
@@ -19,10 +19,11 @@
 from __future__ import annotations as _annotations
 
 import logging
-import os
 import re
 from datetime import datetime
 from pathlib import Path
+
+import aiofiles.os
 
 import pyrogram
 from pyrogram import enums, raw, types, utils
@@ -195,7 +196,7 @@ class SendMediaGroup:
         for i in media:
             if isinstance(i, types.InputMediaPhoto):
                 if isinstance(i.media, (str, Path)):
-                    if os.path.isfile(i.media):
+                    if await aiofiles.os.path.isfile(i.media):
                         media = await self.invoke(
                             raw.functions.messages.UploadMedia(
                                 peer=await self.resolve_peer(chat_id),
@@ -260,7 +261,7 @@ class SendMediaGroup:
                     )
             elif isinstance(i, types.InputMediaVideo):
                 if isinstance(i.media, (str, Path)):
-                    if os.path.isfile(i.media):
+                    if await aiofiles.os.path.isfile(i.media):
                         media = await self.invoke(
                             raw.functions.messages.UploadMedia(
                                 peer=await self.resolve_peer(chat_id),
@@ -359,7 +360,7 @@ class SendMediaGroup:
                     )
             elif isinstance(i, types.InputMediaAudio):
                 if isinstance(i.media, (str, Path)):
-                    if os.path.isfile(i.media):
+                    if await aiofiles.os.path.isfile(i.media):
                         media = await self.invoke(
                             raw.functions.messages.UploadMedia(
                                 peer=await self.resolve_peer(chat_id),
@@ -443,7 +444,7 @@ class SendMediaGroup:
                     )
             elif isinstance(i, types.InputMediaDocument):
                 if isinstance(i.media, (str, Path)):
-                    if os.path.isfile(i.media):
+                    if await aiofiles.os.path.isfile(i.media):
                         media = await self.invoke(
                             raw.functions.messages.UploadMedia(
                                 peer=await self.resolve_peer(chat_id),

--- a/pyrogram/methods/messages/send_media_group.py
+++ b/pyrogram/methods/messages/send_media_group.py
@@ -22,6 +22,7 @@ import logging
 import os
 import re
 from datetime import datetime
+from pathlib import Path
 
 import pyrogram
 from pyrogram import enums, raw, types, utils
@@ -116,6 +117,9 @@ class SendMediaGroup:
         Returns:
             List of :obj:`~pyrogram.types.Message`: On success, a list of the sent messages is returned.
 
+        Raises:
+            FileNotFoundError: In case a local ``pathlib.Path`` doesn't point to an existing file.
+
         Example:
             .. code-block:: python
 
@@ -190,7 +194,7 @@ class SendMediaGroup:
 
         for i in media:
             if isinstance(i, types.InputMediaPhoto):
-                if isinstance(i.media, str):
+                if isinstance(i.media, (str, Path)):
                     if os.path.isfile(i.media):
                         media = await self.invoke(
                             raw.functions.messages.UploadMedia(
@@ -210,7 +214,7 @@ class SendMediaGroup:
                             ),
                             spoiler=i.has_spoiler,
                         )
-                    elif re.match("^https?://", i.media):
+                    elif isinstance(i.media, str) and re.match("^https?://", i.media):
                         media = await self.invoke(
                             raw.functions.messages.UploadMedia(
                                 peer=await self.resolve_peer(chat_id),
@@ -229,10 +233,12 @@ class SendMediaGroup:
                             ),
                             spoiler=i.has_spoiler,
                         )
-                    else:
+                    elif isinstance(i.media, str):
                         media = utils.get_input_media_from_file_id(
                             i.media, FileType.PHOTO, has_spoiler=i.has_spoiler
                         )
+                    else:
+                        raise FileNotFoundError(f"No such file or directory: {i.media}")
                 else:
                     media = await self.invoke(
                         raw.functions.messages.UploadMedia(
@@ -253,7 +259,7 @@ class SendMediaGroup:
                         spoiler=i.has_spoiler,
                     )
             elif isinstance(i, types.InputMediaVideo):
-                if isinstance(i.media, str):
+                if isinstance(i.media, (str, Path)):
                     if os.path.isfile(i.media):
                         media = await self.invoke(
                             raw.functions.messages.UploadMedia(
@@ -272,7 +278,7 @@ class SendMediaGroup:
                                             h=i.height,
                                         ),
                                         raw.types.DocumentAttributeFilename(
-                                            file_name=i.file_name or os.path.basename(i.media)
+                                            file_name=i.file_name or Path(i.media).name
                                         ),
                                     ],
                                 ),
@@ -288,7 +294,7 @@ class SendMediaGroup:
                             ),
                             spoiler=i.has_spoiler,
                         )
-                    elif re.match("^https?://", i.media):
+                    elif isinstance(i.media, str) and re.match("^https?://", i.media):
                         media = await self.invoke(
                             raw.functions.messages.UploadMedia(
                                 peer=await self.resolve_peer(chat_id),
@@ -307,10 +313,12 @@ class SendMediaGroup:
                             ),
                             spoiler=i.has_spoiler,
                         )
-                    else:
+                    elif isinstance(i.media, str):
                         media = utils.get_input_media_from_file_id(
                             i.media, FileType.VIDEO, has_spoiler=i.has_spoiler
                         )
+                    else:
+                        raise FileNotFoundError(f"No such file or directory: {i.media}")
                 else:
                     media = await self.invoke(
                         raw.functions.messages.UploadMedia(
@@ -350,7 +358,7 @@ class SendMediaGroup:
                         spoiler=i.has_spoiler,
                     )
             elif isinstance(i, types.InputMediaAudio):
-                if isinstance(i.media, str):
+                if isinstance(i.media, (str, Path)):
                     if os.path.isfile(i.media):
                         media = await self.invoke(
                             raw.functions.messages.UploadMedia(
@@ -366,7 +374,7 @@ class SendMediaGroup:
                                             title=i.title,
                                         ),
                                         raw.types.DocumentAttributeFilename(
-                                            file_name=i.file_name or os.path.basename(i.media)
+                                            file_name=i.file_name or Path(i.media).name
                                         ),
                                     ],
                                 ),
@@ -381,7 +389,7 @@ class SendMediaGroup:
                                 file_reference=media.document.file_reference,
                             )
                         )
-                    elif re.match("^https?://", i.media):
+                    elif isinstance(i.media, str) and re.match("^https?://", i.media):
                         media = await self.invoke(
                             raw.functions.messages.UploadMedia(
                                 peer=await self.resolve_peer(chat_id),
@@ -397,8 +405,10 @@ class SendMediaGroup:
                                 file_reference=media.document.file_reference,
                             )
                         )
-                    else:
+                    elif isinstance(i.media, str):
                         media = utils.get_input_media_from_file_id(i.media, FileType.AUDIO)
+                    else:
+                        raise FileNotFoundError(f"No such file or directory: {i.media}")
                 else:
                     media = await self.invoke(
                         raw.functions.messages.UploadMedia(
@@ -432,7 +442,7 @@ class SendMediaGroup:
                         )
                     )
             elif isinstance(i, types.InputMediaDocument):
-                if isinstance(i.media, str):
+                if isinstance(i.media, (str, Path)):
                     if os.path.isfile(i.media):
                         media = await self.invoke(
                             raw.functions.messages.UploadMedia(
@@ -443,7 +453,7 @@ class SendMediaGroup:
                                     thumb=await self.save_file(i.thumb),
                                     attributes=[
                                         raw.types.DocumentAttributeFilename(
-                                            file_name=i.file_name or os.path.basename(i.media)
+                                            file_name=i.file_name or Path(i.media).name
                                         )
                                     ],
                                 ),
@@ -458,7 +468,7 @@ class SendMediaGroup:
                                 file_reference=media.document.file_reference,
                             )
                         )
-                    elif re.match("^https?://", i.media):
+                    elif isinstance(i.media, str) and re.match("^https?://", i.media):
                         media = await self.invoke(
                             raw.functions.messages.UploadMedia(
                                 peer=await self.resolve_peer(chat_id),
@@ -474,8 +484,10 @@ class SendMediaGroup:
                                 file_reference=media.document.file_reference,
                             )
                         )
-                    else:
+                    elif isinstance(i.media, str):
                         media = utils.get_input_media_from_file_id(i.media, FileType.DOCUMENT)
+                    else:
+                        raise FileNotFoundError(f"No such file or directory: {i.media}")
                 else:
                     media = await self.invoke(
                         raw.functions.messages.UploadMedia(

--- a/pyrogram/methods/messages/send_media_group.py
+++ b/pyrogram/methods/messages/send_media_group.py
@@ -19,6 +19,7 @@
 from __future__ import annotations as _annotations
 
 import logging
+import os
 import re
 from datetime import datetime
 from pathlib import Path
@@ -195,7 +196,7 @@ class SendMediaGroup:
 
         for i in media:
             if isinstance(i, types.InputMediaPhoto):
-                if isinstance(i.media, (str, Path)):
+                if isinstance(i.media, (str, os.PathLike)):
                     if await aiofiles.os.path.isfile(i.media):
                         media = await self.invoke(
                             raw.functions.messages.UploadMedia(
@@ -260,7 +261,7 @@ class SendMediaGroup:
                         spoiler=i.has_spoiler,
                     )
             elif isinstance(i, types.InputMediaVideo):
-                if isinstance(i.media, (str, Path)):
+                if isinstance(i.media, (str, os.PathLike)):
                     if await aiofiles.os.path.isfile(i.media):
                         media = await self.invoke(
                             raw.functions.messages.UploadMedia(
@@ -359,7 +360,7 @@ class SendMediaGroup:
                         spoiler=i.has_spoiler,
                     )
             elif isinstance(i, types.InputMediaAudio):
-                if isinstance(i.media, (str, Path)):
+                if isinstance(i.media, (str, os.PathLike)):
                     if await aiofiles.os.path.isfile(i.media):
                         media = await self.invoke(
                             raw.functions.messages.UploadMedia(
@@ -443,7 +444,7 @@ class SendMediaGroup:
                         )
                     )
             elif isinstance(i, types.InputMediaDocument):
-                if isinstance(i.media, (str, Path)):
+                if isinstance(i.media, (str, os.PathLike)):
                     if await aiofiles.os.path.isfile(i.media):
                         media = await self.invoke(
                             raw.functions.messages.UploadMedia(

--- a/pyrogram/methods/messages/send_paid_media.py
+++ b/pyrogram/methods/messages/send_paid_media.py
@@ -22,6 +22,7 @@ import logging
 import os
 import re
 from datetime import datetime
+from pathlib import Path
 
 import pyrogram
 from pyrogram import enums, raw, types, utils
@@ -109,6 +110,9 @@ class SendPaidMedia:
         Returns:
             List of :obj:`~pyrogram.types.Message`: On success, a list of messages is returned.
 
+        Raises:
+            FileNotFoundError: In case a local ``pathlib.Path`` doesn't point to an existing file.
+
         Example:
             .. code-block:: python
 
@@ -166,7 +170,7 @@ class SendPaidMedia:
 
         for i in media:
             if isinstance(i, types.InputMediaPhoto):
-                if isinstance(i.media, str):
+                if isinstance(i.media, (str, Path)):
                     if os.path.isfile(i.media):
                         media = await self.invoke(
                             raw.functions.messages.UploadMedia(
@@ -185,17 +189,19 @@ class SendPaidMedia:
                             ),
                             spoiler=i.has_spoiler,
                         )
-                    elif re.match("^https?://", i.media):
+                    elif isinstance(i.media, str) and re.match("^https?://", i.media):
                         media = await self.invoke(
                             raw.functions.messages.UploadMedia(
                                 peer=await self.resolve_peer(chat_id),
                                 media=raw.types.InputMediaPhotoExternal(url=i.media),
                             )
                         )
-                    else:
+                    elif isinstance(i.media, str):
                         media = utils.get_input_media_from_file_id(
                             i.media, FileType.PHOTO, has_spoiler=i.has_spoiler
                         )
+                    else:
+                        raise FileNotFoundError(f"No such file or directory: {i.media}")
                 else:
                     media = await self.invoke(
                         raw.functions.messages.UploadMedia(
@@ -219,7 +225,7 @@ class SendPaidMedia:
                 vcover_media = None
 
                 if i.video_cover is not None:
-                    if isinstance(i.video_cover, str):
+                    if isinstance(i.video_cover, (str, Path)):
                         if os.path.isfile(i.video_cover):
                             vcover_media = await self.invoke(
                                 raw.functions.messages.UploadMedia(
@@ -229,17 +235,21 @@ class SendPaidMedia:
                                     ),
                                 )
                             )
-                        elif re.match("^https?://", i.video_cover):
+                        elif isinstance(i.video_cover, str) and re.match(
+                            "^https?://", i.video_cover
+                        ):
                             vcover_media = await self.invoke(
                                 raw.functions.messages.UploadMedia(
                                     peer=peer,
                                     media=raw.types.InputMediaPhotoExternal(url=i.video_cover),
                                 )
                             )
-                        else:
+                        elif isinstance(i.video_cover, str):
                             vcover_file = utils.get_input_media_from_file_id(
                                 i.video_cover, FileType.PHOTO
                             ).id
+                        else:
+                            raise FileNotFoundError(f"No such file or directory: {i.video_cover}")
                     else:
                         vcover_media = await self.invoke(
                             raw.functions.messages.UploadMedia(
@@ -257,7 +267,7 @@ class SendPaidMedia:
                             file_reference=vcover_media.photo.file_reference,
                         )
 
-                if isinstance(i.media, str):
+                if isinstance(i.media, (str, Path)):
                     if os.path.isfile(i.media):
                         media = await self.invoke(
                             raw.functions.messages.UploadMedia(
@@ -278,7 +288,7 @@ class SendPaidMedia:
                                             h=i.height,
                                         ),
                                         raw.types.DocumentAttributeFilename(
-                                            file_name=os.path.basename(i.media)
+                                            file_name=Path(i.media).name
                                         ),
                                     ],
                                 ),
@@ -295,7 +305,7 @@ class SendPaidMedia:
                             video_cover=vcover_file,
                             video_timestamp=i.video_start_timestamp,
                         )
-                    elif re.match("^https?://", i.media):
+                    elif isinstance(i.media, str) and re.match("^https?://", i.media):
                         media = await self.invoke(
                             raw.functions.messages.UploadMedia(
                                 peer=await self.resolve_peer(chat_id),
@@ -306,7 +316,7 @@ class SendPaidMedia:
                                 ),
                             )
                         )
-                    else:
+                    elif isinstance(i.media, str):
                         media = utils.get_input_media_from_file_id(
                             i.media,
                             FileType.VIDEO,
@@ -314,6 +324,8 @@ class SendPaidMedia:
                             video_cover=vcover_file,
                             video_start_timestamp=i.video_start_timestamp,
                         )
+                    else:
+                        raise FileNotFoundError(f"No such file or directory: {i.media}")
                 else:
                     media = await self.invoke(
                         raw.functions.messages.UploadMedia(

--- a/pyrogram/methods/messages/send_paid_media.py
+++ b/pyrogram/methods/messages/send_paid_media.py
@@ -19,10 +19,11 @@
 from __future__ import annotations as _annotations
 
 import logging
-import os
 import re
 from datetime import datetime
 from pathlib import Path
+
+import aiofiles.os
 
 import pyrogram
 from pyrogram import enums, raw, types, utils
@@ -171,7 +172,7 @@ class SendPaidMedia:
         for i in media:
             if isinstance(i, types.InputMediaPhoto):
                 if isinstance(i.media, (str, Path)):
-                    if os.path.isfile(i.media):
+                    if await aiofiles.os.path.isfile(i.media):
                         media = await self.invoke(
                             raw.functions.messages.UploadMedia(
                                 peer=peer,
@@ -226,7 +227,7 @@ class SendPaidMedia:
 
                 if i.video_cover is not None:
                     if isinstance(i.video_cover, (str, Path)):
-                        if os.path.isfile(i.video_cover):
+                        if await aiofiles.os.path.isfile(i.video_cover):
                             vcover_media = await self.invoke(
                                 raw.functions.messages.UploadMedia(
                                     peer=peer,
@@ -268,7 +269,7 @@ class SendPaidMedia:
                         )
 
                 if isinstance(i.media, (str, Path)):
-                    if os.path.isfile(i.media):
+                    if await aiofiles.os.path.isfile(i.media):
                         media = await self.invoke(
                             raw.functions.messages.UploadMedia(
                                 peer=peer,

--- a/pyrogram/methods/messages/send_paid_media.py
+++ b/pyrogram/methods/messages/send_paid_media.py
@@ -19,6 +19,7 @@
 from __future__ import annotations as _annotations
 
 import logging
+import os
 import re
 from datetime import datetime
 from pathlib import Path
@@ -171,7 +172,7 @@ class SendPaidMedia:
 
         for i in media:
             if isinstance(i, types.InputMediaPhoto):
-                if isinstance(i.media, (str, Path)):
+                if isinstance(i.media, (str, os.PathLike)):
                     if await aiofiles.os.path.isfile(i.media):
                         media = await self.invoke(
                             raw.functions.messages.UploadMedia(
@@ -226,7 +227,7 @@ class SendPaidMedia:
                 vcover_media = None
 
                 if i.video_cover is not None:
-                    if isinstance(i.video_cover, (str, Path)):
+                    if isinstance(i.video_cover, (str, os.PathLike)):
                         if await aiofiles.os.path.isfile(i.video_cover):
                             vcover_media = await self.invoke(
                                 raw.functions.messages.UploadMedia(
@@ -268,7 +269,7 @@ class SendPaidMedia:
                             file_reference=vcover_media.photo.file_reference,
                         )
 
-                if isinstance(i.media, (str, Path)):
+                if isinstance(i.media, (str, os.PathLike)):
                     if await aiofiles.os.path.isfile(i.media):
                         media = await self.invoke(
                             raw.functions.messages.UploadMedia(

--- a/pyrogram/methods/messages/send_photo.py
+++ b/pyrogram/methods/messages/send_photo.py
@@ -22,6 +22,7 @@ import logging
 import os
 import re
 from datetime import datetime
+from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
 
@@ -37,7 +38,7 @@ class SendPhoto:
     async def send_photo(
         self: pyrogram.Client,
         chat_id: int | str,
-        photo: str | BinaryIO,
+        photo: str | Path | BinaryIO,
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
@@ -84,7 +85,7 @@ class SendPhoto:
                 For your personal cloud (Saved Messages) you can simply use "me" or "self".
                 For a contact that exists in your Telegram address book you can use his phone number (str).
 
-            photo (``str`` | ``BinaryIO``):
+            photo (``str`` | ``pathlib.Path`` | ``BinaryIO``):
                 Photo to send.
                 Pass a file_id as string to send a photo that exists on the Telegram servers,
                 pass an HTTP URL as a string for Telegram to get a photo from the Internet,
@@ -192,6 +193,9 @@ class SendPhoto:
             :obj:`~pyrogram.types.Message` | ``None``: On success, the sent photo message is returned, otherwise, in
             case the upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned.
 
+        Raises:
+            FileNotFoundError: In case a local ``pathlib.Path`` doesn't point to an existing file.
+
         Example:
             .. code-block:: python
 
@@ -263,7 +267,7 @@ class SendPhoto:
         file = None
 
         try:
-            if isinstance(photo, str):
+            if isinstance(photo, (str, Path)):
                 if os.path.isfile(photo):
                     file = await self.save_file(
                         photo, progress=progress, progress_args=progress_args
@@ -273,19 +277,21 @@ class SendPhoto:
                         ttl_seconds=(1 << 31) - 1 if view_once else ttl_seconds,
                         spoiler=has_spoiler,
                     )
-                elif re.match("^https?://", photo):
+                elif isinstance(photo, str) and re.match("^https?://", photo):
                     media = raw.types.InputMediaPhotoExternal(
                         url=photo,
                         ttl_seconds=(1 << 31) - 1 if view_once else ttl_seconds,
                         spoiler=has_spoiler,
                     )
-                else:
+                elif isinstance(photo, str):
                     media = utils.get_input_media_from_file_id(
                         photo,
                         FileType.PHOTO,
                         ttl_seconds=(1 << 31) - 1 if view_once else ttl_seconds,
                         has_spoiler=has_spoiler,
                     )
+                else:
+                    raise FileNotFoundError(f"No such file or directory: {photo}")
             else:
                 file = await self.save_file(photo, progress=progress, progress_args=progress_args)
                 media = raw.types.InputMediaUploadedPhoto(

--- a/pyrogram/methods/messages/send_photo.py
+++ b/pyrogram/methods/messages/send_photo.py
@@ -19,12 +19,13 @@
 from __future__ import annotations as _annotations
 
 import logging
-import os
 import re
 from datetime import datetime
 from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
+
+import aiofiles.os
 
 import pyrogram
 from pyrogram import enums, raw, types, utils
@@ -268,7 +269,7 @@ class SendPhoto:
 
         try:
             if isinstance(photo, (str, Path)):
-                if os.path.isfile(photo):
+                if await aiofiles.os.path.isfile(photo):
                     file = await self.save_file(
                         photo, progress=progress, progress_args=progress_args
                     )

--- a/pyrogram/methods/messages/send_photo.py
+++ b/pyrogram/methods/messages/send_photo.py
@@ -19,6 +19,7 @@
 from __future__ import annotations as _annotations
 
 import logging
+import os
 import re
 from datetime import datetime
 from pathlib import Path
@@ -268,7 +269,7 @@ class SendPhoto:
         file = None
 
         try:
-            if isinstance(photo, (str, Path)):
+            if isinstance(photo, (str, os.PathLike)):
                 if await aiofiles.os.path.isfile(photo):
                     file = await self.save_file(
                         photo, progress=progress, progress_args=progress_args

--- a/pyrogram/methods/messages/send_sticker.py
+++ b/pyrogram/methods/messages/send_sticker.py
@@ -19,12 +19,13 @@
 from __future__ import annotations as _annotations
 
 import logging
-import os
 import re
 from datetime import datetime
 from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
+
+import aiofiles.os
 
 import pyrogram
 from pyrogram import StopTransmission, enums, raw, types, utils
@@ -245,7 +246,7 @@ class SendSticker:
 
         try:
             if isinstance(sticker, (str, Path)):
-                if os.path.isfile(sticker):
+                if await aiofiles.os.path.isfile(sticker):
                     file = await self.save_file(
                         sticker, progress=progress, progress_args=progress_args
                     )

--- a/pyrogram/methods/messages/send_sticker.py
+++ b/pyrogram/methods/messages/send_sticker.py
@@ -19,6 +19,7 @@
 from __future__ import annotations as _annotations
 
 import logging
+import os
 import re
 from datetime import datetime
 from pathlib import Path
@@ -245,7 +246,7 @@ class SendSticker:
         file = None
 
         try:
-            if isinstance(sticker, (str, Path)):
+            if isinstance(sticker, (str, os.PathLike)):
                 if await aiofiles.os.path.isfile(sticker):
                     file = await self.save_file(
                         sticker, progress=progress, progress_args=progress_args

--- a/pyrogram/methods/messages/send_sticker.py
+++ b/pyrogram/methods/messages/send_sticker.py
@@ -22,6 +22,7 @@ import logging
 import os
 import re
 from datetime import datetime
+from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
 
@@ -37,7 +38,7 @@ class SendSticker:
     async def send_sticker(
         self: pyrogram.Client,
         chat_id: int | str,
-        sticker: str | BinaryIO,
+        sticker: str | Path | BinaryIO,
         emoji: str = "",
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
@@ -81,7 +82,7 @@ class SendSticker:
                 For your personal cloud (Saved Messages) you can simply use "me" or "self".
                 For a contact that exists in your Telegram address book you can use his phone number (str).
 
-            sticker (``str`` | ``BinaryIO``):
+            sticker (``str`` | ``pathlib.Path`` | ``BinaryIO``):
                 Sticker to send.
                 Pass a file_id as string to send a sticker that exists on the Telegram servers,
                 pass an HTTP URL as a string for Telegram to get a .webp sticker file from the Internet,
@@ -178,6 +179,9 @@ class SendSticker:
             in case the upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is
             returned.
 
+        Raises:
+            FileNotFoundError: In case a local ``pathlib.Path`` doesn't point to an existing file.
+
         Example:
             .. code-block:: python
 
@@ -240,7 +244,7 @@ class SendSticker:
         file = None
 
         try:
-            if isinstance(sticker, str):
+            if isinstance(sticker, (str, Path)):
                 if os.path.isfile(sticker):
                     file = await self.save_file(
                         sticker, progress=progress, progress_args=progress_args
@@ -249,18 +253,18 @@ class SendSticker:
                         mime_type=self.guess_mime_type(sticker) or "image/webp",
                         file=file,
                         attributes=[
-                            raw.types.DocumentAttributeFilename(
-                                file_name=os.path.basename(sticker)
-                            ),
+                            raw.types.DocumentAttributeFilename(file_name=Path(sticker).name),
                             raw.types.DocumentAttributeSticker(
                                 alt=emoji, stickerset=raw.types.InputStickerSetEmpty()
                             ),
                         ],
                     )
-                elif re.match("^https?://", sticker):
+                elif isinstance(sticker, str) and re.match("^https?://", sticker):
                     media = raw.types.InputMediaDocumentExternal(url=sticker)
-                else:
+                elif isinstance(sticker, str):
                     media = utils.get_input_media_from_file_id(sticker, FileType.STICKER)
+                else:
+                    raise FileNotFoundError(f"No such file or directory: {sticker}")
             else:
                 file = await self.save_file(sticker, progress=progress, progress_args=progress_args)
                 media = raw.types.InputMediaUploadedDocument(

--- a/pyrogram/methods/messages/send_video.py
+++ b/pyrogram/methods/messages/send_video.py
@@ -19,12 +19,13 @@
 from __future__ import annotations as _annotations
 
 import logging
-import os
 import re
 from datetime import datetime
 from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
+
+import aiofiles.os
 
 import pyrogram
 from pyrogram import StopTransmission, enums, raw, types, utils
@@ -329,7 +330,7 @@ class SendVideo:
         try:
             if video_cover is not None:
                 if isinstance(video_cover, (str, Path)):
-                    if os.path.isfile(video_cover):
+                    if await aiofiles.os.path.isfile(video_cover):
                         vcover_media = await self.invoke(
                             raw.functions.messages.UploadMedia(
                                 peer=peer,
@@ -368,7 +369,7 @@ class SendVideo:
                     )
 
             if isinstance(video, (str, Path)):
-                if os.path.isfile(video):
+                if await aiofiles.os.path.isfile(video):
                     thumb = await self.save_file(thumb)
                     file = await self.save_file(
                         video, progress=progress, progress_args=progress_args

--- a/pyrogram/methods/messages/send_video.py
+++ b/pyrogram/methods/messages/send_video.py
@@ -19,6 +19,7 @@
 from __future__ import annotations as _annotations
 
 import logging
+import os
 import re
 from datetime import datetime
 from pathlib import Path
@@ -329,7 +330,7 @@ class SendVideo:
 
         try:
             if video_cover is not None:
-                if isinstance(video_cover, (str, Path)):
+                if isinstance(video_cover, (str, os.PathLike)):
                     if await aiofiles.os.path.isfile(video_cover):
                         vcover_media = await self.invoke(
                             raw.functions.messages.UploadMedia(
@@ -368,7 +369,7 @@ class SendVideo:
                         file_reference=vcover_media.photo.file_reference,
                     )
 
-            if isinstance(video, (str, Path)):
+            if isinstance(video, (str, os.PathLike)):
                 if await aiofiles.os.path.isfile(video):
                     thumb = await self.save_file(thumb)
                     file = await self.save_file(

--- a/pyrogram/methods/messages/send_video.py
+++ b/pyrogram/methods/messages/send_video.py
@@ -22,6 +22,7 @@ import logging
 import os
 import re
 from datetime import datetime
+from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
 
@@ -37,7 +38,7 @@ class SendVideo:
     async def send_video(
         self: pyrogram.Client,
         chat_id: int | str,
-        video: str | BinaryIO,
+        video: str | Path | BinaryIO,
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
@@ -48,8 +49,8 @@ class SendVideo:
         width: int = 0,
         height: int = 0,
         video_start_timestamp: int | None = None,
-        video_cover: str | BinaryIO | None = None,
-        thumb: str | BinaryIO | None = None,
+        video_cover: str | Path | BinaryIO | None = None,
+        thumb: str | Path | BinaryIO | None = None,
         file_name: str | None = None,
         supports_streaming: bool = True,
         disable_notification: bool | None = None,
@@ -98,7 +99,7 @@ class SendVideo:
                 For your personal cloud (Saved Messages) you can simply use "me" or "self".
                 For a contact that exists in your Telegram address book you can use his phone number (str).
 
-            video (``str`` | ``BinaryIO``):
+            video (``str`` | ``pathlib.Path`` | ``BinaryIO``):
                 Video to send.
                 Pass a file_id as string to send a video that exists on the Telegram servers,
                 pass an HTTP URL as a string for Telegram to get a video from the Internet,
@@ -139,14 +140,14 @@ class SendVideo:
             video_start_timestamp (``int``, *optional*):
                 Video startpoint, in seconds.
 
-            video_cover (``str`` | ``BinaryIO``, *optional*):
+            video_cover (``str`` | ``pathlib.Path`` | ``BinaryIO``, *optional*):
                 Video cover.
                 Pass a file_id as string to attach a photo that exists on the Telegram servers,
                 pass an HTTP URL as a string for Telegram to get a photo from the Internet,
                 pass a file path as string to upload a new photo that exists on your local machine, or
                 pass a binary file-like object with its attribute ".name" set for in-memory uploads.
 
-            thumb (``str`` | ``BinaryIO``, *optional*):
+            thumb (``str`` | ``pathlib.Path`` | ``BinaryIO``, *optional*):
                 Thumbnail of the video sent.
                 The thumbnail should be in JPEG format and less than 200 KB in size.
                 A thumbnail's width and height should not exceed 320 pixels.
@@ -243,6 +244,9 @@ class SendVideo:
             :obj:`~pyrogram.types.Message` | ``None``: On success, the sent video message is returned, otherwise, in
             case the upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned.
 
+        Raises:
+            FileNotFoundError: In case a local ``pathlib.Path`` doesn't point to an existing file.
+
         Example:
             .. code-block:: python
 
@@ -324,7 +328,7 @@ class SendVideo:
 
         try:
             if video_cover is not None:
-                if isinstance(video_cover, str):
+                if isinstance(video_cover, (str, Path)):
                     if os.path.isfile(video_cover):
                         vcover_media = await self.invoke(
                             raw.functions.messages.UploadMedia(
@@ -334,16 +338,18 @@ class SendVideo:
                                 ),
                             )
                         )
-                    elif re.match("^https?://", video_cover):
+                    elif isinstance(video_cover, str) and re.match("^https?://", video_cover):
                         vcover_media = await self.invoke(
                             raw.functions.messages.UploadMedia(
                                 peer=peer, media=raw.types.InputMediaPhotoExternal(url=video_cover)
                             )
                         )
-                    else:
+                    elif isinstance(video_cover, str):
                         vcover_file = utils.get_input_media_from_file_id(
                             video_cover, FileType.PHOTO
                         ).id
+                    else:
+                        raise FileNotFoundError(f"No such file or directory: {video_cover}")
                 else:
                     vcover_media = await self.invoke(
                         raw.functions.messages.UploadMedia(
@@ -361,7 +367,7 @@ class SendVideo:
                         file_reference=vcover_media.photo.file_reference,
                     )
 
-            if isinstance(video, str):
+            if isinstance(video, (str, Path)):
                 if os.path.isfile(video):
                     thumb = await self.save_file(thumb)
                     file = await self.save_file(
@@ -384,11 +390,11 @@ class SendVideo:
                                 h=height,
                             ),
                             raw.types.DocumentAttributeFilename(
-                                file_name=file_name or os.path.basename(video)
+                                file_name=file_name or Path(video).name
                             ),
                         ],
                     )
-                elif re.match("^https?://", video):
+                elif isinstance(video, str) and re.match("^https?://", video):
                     media = raw.types.InputMediaDocumentExternal(
                         url=video,
                         ttl_seconds=(1 << 31) - 1 if view_once else ttl_seconds,
@@ -396,7 +402,7 @@ class SendVideo:
                         video_cover=vcover_file,
                         video_timestamp=video_start_timestamp,
                     )
-                else:
+                elif isinstance(video, str):
                     media = utils.get_input_media_from_file_id(
                         video,
                         FileType.VIDEO,
@@ -405,6 +411,8 @@ class SendVideo:
                     )
                     media.video_cover = vcover_file
                     media.video_timestamp = video_start_timestamp
+                else:
+                    raise FileNotFoundError(f"No such file or directory: {video}")
             else:
                 thumb = await self.save_file(thumb)
                 file = await self.save_file(video, progress=progress, progress_args=progress_args)

--- a/pyrogram/methods/messages/send_video_note.py
+++ b/pyrogram/methods/messages/send_video_note.py
@@ -21,6 +21,7 @@ from __future__ import annotations as _annotations
 import logging
 import os
 from datetime import datetime
+from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
 
@@ -39,10 +40,10 @@ class SendVideoNote:
     async def send_video_note(
         self: pyrogram.Client,
         chat_id: int | str,
-        video_note: str | BinaryIO,
+        video_note: str | Path | BinaryIO,
         duration: int = 0,
         length: int = 1,
-        thumb: str | BinaryIO | None = None,
+        thumb: str | Path | BinaryIO | None = None,
         disable_notification: bool | None = None,
         message_thread_id: int | None = None,
         direct_messages_topic_id: int | None = None,
@@ -84,7 +85,7 @@ class SendVideoNote:
                 For your personal cloud (Saved Messages) you can simply use "me" or "self".
                 For a contact that exists in your Telegram address book you can use his phone number (str).
 
-            video_note (``str`` | ``BinaryIO``):
+            video_note (``str`` | ``pathlib.Path`` | ``BinaryIO``):
                 Video note to send.
                 Pass a file_id as string to send a video note that exists on the Telegram servers,
                 pass a file path as string to upload a new video note that exists on your local machine, or
@@ -101,7 +102,7 @@ class SendVideoNote:
             length (``int``, *optional*):
                 Video width and height.
 
-            thumb (``str`` | ``BinaryIO``, *optional*):
+            thumb (``str`` | ``pathlib.Path`` | ``BinaryIO``, *optional*):
                 Thumbnail of the video sent.
                 The thumbnail should be in JPEG format and less than 200 KB in size.
                 A thumbnail's width and height should not exceed 320 pixels.
@@ -188,6 +189,9 @@ class SendVideoNote:
             in case the upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is
             returned.
 
+        Raises:
+            FileNotFoundError: In case a local ``pathlib.Path`` doesn't point to an existing file.
+
         Example:
             .. code-block:: python
 
@@ -259,7 +263,7 @@ class SendVideoNote:
         file = None
 
         try:
-            if isinstance(video_note, str):
+            if isinstance(video_note, (str, Path)):
                 if os.path.isfile(video_note):
                     # Notify user why the sent video is not video note
                     file_size = os.path.getsize(video_note)
@@ -285,8 +289,10 @@ class SendVideoNote:
                         ],
                         ttl_seconds=(1 << 31) - 1 if view_once else None,
                     )
-                else:
+                elif isinstance(video_note, str):
                     media = utils.get_input_media_from_file_id(video_note, FileType.VIDEO_NOTE)
+                else:
+                    raise FileNotFoundError(f"No such file or directory: {video_note}")
             else:
                 thumb = await self.save_file(thumb)
                 file = await self.save_file(

--- a/pyrogram/methods/messages/send_video_note.py
+++ b/pyrogram/methods/messages/send_video_note.py
@@ -19,11 +19,12 @@
 from __future__ import annotations as _annotations
 
 import logging
-import os
 from datetime import datetime
 from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
+
+import aiofiles.os
 
 import pyrogram
 from pyrogram import StopTransmission, enums, raw, types, utils
@@ -264,9 +265,9 @@ class SendVideoNote:
 
         try:
             if isinstance(video_note, (str, Path)):
-                if os.path.isfile(video_note):
+                if await aiofiles.os.path.isfile(video_note):
                     # Notify user why the sent video is not video note
-                    file_size = os.path.getsize(video_note)
+                    file_size = await aiofiles.os.path.getsize(video_note)
                     if file_size > _MAX_VIDEO_NOTE_SIZE_BYTES:
                         log.warning(
                             "Video note file size (%.1f MB) exceeds 10 MB limit. "

--- a/pyrogram/methods/messages/send_video_note.py
+++ b/pyrogram/methods/messages/send_video_note.py
@@ -19,6 +19,7 @@
 from __future__ import annotations as _annotations
 
 import logging
+import os
 from datetime import datetime
 from pathlib import Path
 from typing import BinaryIO
@@ -264,7 +265,7 @@ class SendVideoNote:
         file = None
 
         try:
-            if isinstance(video_note, (str, Path)):
+            if isinstance(video_note, (str, os.PathLike)):
                 if await aiofiles.os.path.isfile(video_note):
                     # Notify user why the sent video is not video note
                     file_size = await aiofiles.os.path.getsize(video_note)

--- a/pyrogram/methods/messages/send_voice.py
+++ b/pyrogram/methods/messages/send_voice.py
@@ -19,12 +19,13 @@
 from __future__ import annotations as _annotations
 
 import logging
-import os
 import re
 from datetime import datetime
 from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
+
+import aiofiles.os
 
 import pyrogram
 from pyrogram import StopTransmission, enums, raw, types, utils
@@ -259,7 +260,7 @@ class SendVoice:
 
         try:
             if isinstance(voice, (str, Path)):
-                if os.path.isfile(voice):
+                if await aiofiles.os.path.isfile(voice):
                     mime_type = self.guess_mime_type(voice) or "audio/ogg"
                     if mime_type == "audio/mpeg":
                         mime_type = "audio/ogg"

--- a/pyrogram/methods/messages/send_voice.py
+++ b/pyrogram/methods/messages/send_voice.py
@@ -19,6 +19,7 @@
 from __future__ import annotations as _annotations
 
 import logging
+import os
 import re
 from datetime import datetime
 from pathlib import Path
@@ -259,7 +260,7 @@ class SendVoice:
         file = None
 
         try:
-            if isinstance(voice, (str, Path)):
+            if isinstance(voice, (str, os.PathLike)):
                 if await aiofiles.os.path.isfile(voice):
                     mime_type = self.guess_mime_type(voice) or "audio/ogg"
                     if mime_type == "audio/mpeg":

--- a/pyrogram/methods/messages/send_voice.py
+++ b/pyrogram/methods/messages/send_voice.py
@@ -22,6 +22,7 @@ import logging
 import os
 import re
 from datetime import datetime
+from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
 
@@ -37,7 +38,7 @@ class SendVoice:
     async def send_voice(
         self: pyrogram.Client,
         chat_id: int | str,
-        voice: str | BinaryIO,
+        voice: str | Path | BinaryIO,
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
@@ -83,7 +84,7 @@ class SendVoice:
                 For your personal cloud (Saved Messages) you can simply use "me" or "self".
                 For a contact that exists in your Telegram address book you can use his phone number (str).
 
-            voice (``str`` | ``BinaryIO``):
+            voice (``str`` | ``pathlib.Path`` | ``BinaryIO``):
                 Audio file to send.
                 Pass a file_id as string to send an audio that exists on the Telegram servers,
                 pass an HTTP URL as a string for Telegram to get an audio from the Internet,
@@ -186,6 +187,9 @@ class SendVoice:
             :obj:`~pyrogram.types.Message` | ``None``: On success, the sent voice message is returned, otherwise, in
             case the upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`, None is returned.
 
+        Raises:
+            FileNotFoundError: In case a local ``pathlib.Path`` doesn't point to an existing file.
+
         Example:
             .. code-block:: python
 
@@ -254,7 +258,7 @@ class SendVoice:
         file = None
 
         try:
-            if isinstance(voice, str):
+            if isinstance(voice, (str, Path)):
                 if os.path.isfile(voice):
                     mime_type = self.guess_mime_type(voice) or "audio/ogg"
                     if mime_type == "audio/mpeg":
@@ -274,10 +278,12 @@ class SendVoice:
                         ],
                         ttl_seconds=(1 << 31) - 1 if view_once else None,
                     )
-                elif re.match("^https?://", voice):
+                elif isinstance(voice, str) and re.match("^https?://", voice):
                     media = raw.types.InputMediaDocumentExternal(url=voice)
-                else:
+                elif isinstance(voice, str):
                     media = utils.get_input_media_from_file_id(voice, FileType.VOICE)
+                else:
+                    raise FileNotFoundError(f"No such file or directory: {voice}")
             else:
                 mime_type = self.guess_mime_type(voice.name) or "audio/ogg"
                 if mime_type == "audio/mpeg":

--- a/pyrogram/methods/stories/edit_story_media.py
+++ b/pyrogram/methods/stories/edit_story_media.py
@@ -18,10 +18,11 @@
 
 from __future__ import annotations as _annotations
 
-import os
 from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
+
+import aiofiles.os
 
 import pyrogram
 from pyrogram import raw, types, utils, StopTransmission
@@ -110,7 +111,7 @@ class EditStoryMedia:
         """
         try:
             if isinstance(media, (str, Path)):
-                if os.path.isfile(media):
+                if await aiofiles.os.path.isfile(media):
                     thumb = await self.save_file(thumb)
                     file = await self.save_file(
                         media, progress=progress, progress_args=progress_args

--- a/pyrogram/methods/stories/edit_story_media.py
+++ b/pyrogram/methods/stories/edit_story_media.py
@@ -19,6 +19,7 @@
 from __future__ import annotations as _annotations
 
 import os
+from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
 
@@ -32,12 +33,12 @@ class EditStoryMedia:
         self: pyrogram.Client,
         chat_id: int | str,
         story_id: int,
-        media: str | BinaryIO | None = None,
+        media: str | Path | BinaryIO | None = None,
         media_areas: list[types.MediaArea] | None = None,
         duration: int = 0,
         width: int = 0,
         height: int = 0,
-        thumb: str | BinaryIO | None = None,
+        thumb: str | Path | BinaryIO | None = None,
         supports_streaming: bool = True,
         file_name: str | None = None,
         progress: Callable | None = None,
@@ -55,7 +56,7 @@ class EditStoryMedia:
             story_id (``int``):
                 Story identifier in the chat specified in chat_id.
 
-            media (``str`` | ``BinaryIO``, *optional*):
+            media (``str`` | ``pathlib.Path`` | ``BinaryIO``, *optional*):
                 Video or photo to send.
                 Pass a file_id as string to send a animation that exists on the Telegram servers,
                 pass a file path as string to upload a new animation that exists on your local machine, or
@@ -73,7 +74,7 @@ class EditStoryMedia:
             height (``int``, *optional*):
                 Video height.
 
-            thumb (``str`` | ``BinaryIO``, *optional*):
+            thumb (``str`` | ``pathlib.Path`` | ``BinaryIO``, *optional*):
                 Thumbnail of the video sent.
                 The thumbnail should be in JPEG format and less than 200 KB in size.
                 A thumbnail's width and height should not exceed 320 pixels.
@@ -95,6 +96,9 @@ class EditStoryMedia:
             in case the upload is deliberately stopped with :meth:`~pyrogram.Client.stop_transmission`,
             None is returned.
 
+        Raises:
+            FileNotFoundError: In case a local ``pathlib.Path`` doesn't point to an existing file.
+
         Example:
             .. code-block:: python
 
@@ -105,7 +109,7 @@ class EditStoryMedia:
                 await app.edit_story_media(chat_id, story_id, "new_video.mp4")
         """
         try:
-            if isinstance(media, str):
+            if isinstance(media, (str, Path)):
                 if os.path.isfile(media):
                     thumb = await self.save_file(thumb)
                     file = await self.save_file(
@@ -124,7 +128,7 @@ class EditStoryMedia:
                                     h=height,
                                 ),
                                 raw.types.DocumentAttributeFilename(
-                                    file_name=file_name or os.path.basename(media)
+                                    file_name=file_name or Path(media).name
                                 ),
                             ],
                         )
@@ -132,8 +136,10 @@ class EditStoryMedia:
                         media = raw.types.InputMediaUploadedPhoto(
                             file=file,
                         )
-                else:
+                elif isinstance(media, str):
                     media = utils.get_input_media_from_file_id(media)
+                else:
+                    raise FileNotFoundError(f"No such file or directory: {media}")
             else:
                 thumb = await self.save_file(thumb)
                 file = await self.save_file(media, progress=progress, progress_args=progress_args)

--- a/pyrogram/methods/stories/edit_story_media.py
+++ b/pyrogram/methods/stories/edit_story_media.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations as _annotations
 
+import os
 from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
@@ -110,7 +111,7 @@ class EditStoryMedia:
                 await app.edit_story_media(chat_id, story_id, "new_video.mp4")
         """
         try:
-            if isinstance(media, (str, Path)):
+            if isinstance(media, (str, os.PathLike)):
                 if await aiofiles.os.path.isfile(media):
                     thumb = await self.save_file(thumb)
                     file = await self.save_file(

--- a/pyrogram/methods/stories/send_story.py
+++ b/pyrogram/methods/stories/send_story.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations as _annotations
 
+import os
 from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
@@ -163,7 +164,7 @@ class SendStory:
         ).values()
 
         try:
-            if isinstance(media, (str, Path)):
+            if isinstance(media, (str, os.PathLike)):
                 if await aiofiles.os.path.isfile(media):
                     thumb = await self.save_file(thumb)
                     file = await self.save_file(

--- a/pyrogram/methods/stories/send_story.py
+++ b/pyrogram/methods/stories/send_story.py
@@ -18,10 +18,11 @@
 
 from __future__ import annotations as _annotations
 
-import os
 from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
+
+import aiofiles.os
 
 import pyrogram
 from pyrogram import StopTransmission, enums, raw, types, utils
@@ -163,7 +164,7 @@ class SendStory:
 
         try:
             if isinstance(media, (str, Path)):
-                if os.path.isfile(media):
+                if await aiofiles.os.path.isfile(media):
                     thumb = await self.save_file(thumb)
                     file = await self.save_file(
                         media, progress=progress, progress_args=progress_args

--- a/pyrogram/methods/stories/send_story.py
+++ b/pyrogram/methods/stories/send_story.py
@@ -19,6 +19,7 @@
 from __future__ import annotations as _annotations
 
 import os
+from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
 
@@ -31,14 +32,14 @@ class SendStory:
     async def send_story(
         self: pyrogram.Client,
         chat_id: int | str,
-        media: str | BinaryIO,
+        media: str | Path | BinaryIO,
         caption: str | None = None,
         period: int | None = None,
         media_areas: list[types.MediaArea] | None = None,
         duration: int = 0,
         width: int = 0,
         height: int = 0,
-        thumb: str | BinaryIO | None = None,
+        thumb: str | Path | BinaryIO | None = None,
         supports_streaming: bool = True,
         file_name: str | None = None,
         privacy: enums.StoriesPrivacyRules | None = None,
@@ -60,7 +61,7 @@ class SendStory:
                 Unique identifier (int) or username (str) of the target chat.
                 For your personal cloud (Saved Messages) you can simply use "me" or "self".
 
-            media (``str`` | ``BinaryIO``):
+            media (``str`` | ``pathlib.Path`` | ``BinaryIO``):
                 Video or photo to send.
                 Pass a file_id as string to send a animation that exists on the Telegram servers,
                 pass a file path as string to upload a new animation that exists on your local machine, or
@@ -86,7 +87,7 @@ class SendStory:
             height (``int``, *optional*):
                 Video height.
 
-            thumb (``str`` | ``BinaryIO``, *optional*):
+            thumb (``str`` | ``pathlib.Path`` | ``BinaryIO``, *optional*):
                 Thumbnail of the video sent.
                 The thumbnail should be in JPEG format and less than 200 KB in size.
                 A thumbnail's width and height should not exceed 320 pixels.
@@ -154,13 +155,14 @@ class SendStory:
 
         Raises:
             ValueError: In case of invalid arguments.
+            FileNotFoundError: In case a local ``pathlib.Path`` doesn't point to an existing file.
         """
         message, entities = (
             await utils.parse_text_entities(self, caption, parse_mode, caption_entities)
         ).values()
 
         try:
-            if isinstance(media, str):
+            if isinstance(media, (str, Path)):
                 if os.path.isfile(media):
                     thumb = await self.save_file(thumb)
                     file = await self.save_file(
@@ -179,7 +181,7 @@ class SendStory:
                                     h=height,
                                 ),
                                 raw.types.DocumentAttributeFilename(
-                                    file_name=file_name or os.path.basename(media)
+                                    file_name=file_name or Path(media).name
                                 ),
                             ],
                         )
@@ -187,8 +189,10 @@ class SendStory:
                         media = raw.types.InputMediaUploadedPhoto(
                             file=file,
                         )
-                else:
+                elif isinstance(media, str):
                     media = utils.get_input_media_from_file_id(media)
+                else:
+                    raise FileNotFoundError(f"No such file or directory: {media}")
             else:
                 thumb = await self.save_file(thumb)
                 file = await self.save_file(media, progress=progress, progress_args=progress_args)

--- a/pyrogram/methods/users/set_profile_photo.py
+++ b/pyrogram/methods/users/set_profile_photo.py
@@ -19,6 +19,7 @@
 from __future__ import annotations as _annotations
 
 import logging
+from pathlib import Path
 from typing import BinaryIO
 
 import pyrogram
@@ -33,7 +34,7 @@ class SetProfilePhoto:
         photo: types.InputChatPhoto | None = None,
         is_public: bool | None = None,
         *,
-        video: str | BinaryIO | None = None,
+        video: str | Path | BinaryIO | None = None,
     ) -> bool:
         """Changes a profile photo for the current user.
 

--- a/pyrogram/storage/sqlite_storage.py
+++ b/pyrogram/storage/sqlite_storage.py
@@ -27,6 +27,8 @@ from pathlib import Path
 from typing import Any
 from collections.abc import Iterable
 
+import aiofiles.os
+
 from pyrogram import raw
 
 from .. import utils
@@ -307,7 +309,7 @@ class SQLiteStorage(Storage):
             return
 
         path = self.database
-        file_exists = isinstance(path, Path) and path.is_file()
+        file_exists = isinstance(path, Path) and await aiofiles.os.path.isfile(path)
 
         self.conn = sqlite3.connect(str(path), timeout=1, check_same_thread=False)
 
@@ -333,7 +335,7 @@ class SQLiteStorage(Storage):
 
     async def delete(self):
         if not self.in_memory:
-            Path(self.database).unlink()
+            await aiofiles.os.remove(self.database)
 
     async def update_peers(self, peers: Iterable[tuple[int, int, str, str | None]]):
         self.conn.executemany(

--- a/pyrogram/types/input_content/input_chat_photo.py
+++ b/pyrogram/types/input_content/input_chat_photo.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations as _annotations
 
+from pathlib import Path
 from typing import BinaryIO, cast
 
 import pyrogram
@@ -73,11 +74,11 @@ class InputChatPhotoStatic(InputChatPhoto):
     """A static photo in JPEG format.
 
     Parameters:
-        photo (``str`` | ``BinaryIO``):
+        photo (``str`` | ``pathlib.Path`` | ``BinaryIO``):
             Photo to be set as profile photo.
     """
 
-    def __init__(self, photo: str | BinaryIO):
+    def __init__(self, photo: str | Path | BinaryIO):
         super().__init__()
 
         self.photo = photo
@@ -94,14 +95,14 @@ class InputChatPhotoAnimation(InputChatPhoto):
         Must be square, at most 10 seconds long, have width between 160 and 1280 and be at most 2MB in size
 
     Parameters:
-        animation (``str`` | ``BinaryIO``):
+        animation (``str`` | ``pathlib.Path`` | ``BinaryIO``):
             Animation to be set as profile photo.
 
         main_frame_timestamp (``float``):
             Timestamp of the frame, which will be used as static chat photo.
     """
 
-    def __init__(self, animation: str | BinaryIO, main_frame_timestamp: float | None = None):
+    def __init__(self, animation: str | Path | BinaryIO, main_frame_timestamp: float | None = None):
         super().__init__()
 
         self.animation = animation

--- a/pyrogram/types/input_content/input_media.py
+++ b/pyrogram/types/input_content/input_media.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations as _annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING, BinaryIO
 
 from ..messages_and_media import MessageEntity
@@ -42,7 +43,7 @@ class InputMedia(Object):
 
     def __init__(
         self,
-        media: str | BinaryIO | None = None,
+        media: str | Path | BinaryIO | None = None,
         caption: str = "",
         parse_mode: str | None = None,
         caption_entities: list[MessageEntity] | None = None,

--- a/pyrogram/types/input_content/input_media_animation.py
+++ b/pyrogram/types/input_content/input_media_animation.py
@@ -19,6 +19,7 @@
 from __future__ import annotations as _annotations
 
 import io
+import os
 import re
 from pathlib import Path
 from typing import BinaryIO
@@ -155,7 +156,7 @@ class InputMediaAnimation(InputMedia):
                 spoiler=self.has_spoiler,
             )
 
-        if isinstance(self.media, Path):
+        if isinstance(self.media, os.PathLike):
             raise FileNotFoundError(f"No such file or directory: {self.media}")
 
         if re.match("^https?://", self.media):

--- a/pyrogram/types/input_content/input_media_animation.py
+++ b/pyrogram/types/input_content/input_media_animation.py
@@ -24,6 +24,8 @@ from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
 
+import aiofiles.os
+
 import pyrogram
 from pyrogram import raw, utils
 from pyrogram.file_id import FileType
@@ -117,7 +119,7 @@ class InputMediaAnimation(InputMedia):
         else:
             peer = await client.resolve_peer(chat_id)
 
-        if isinstance(self.media, io.BytesIO) or Path(self.media).is_file():
+        if isinstance(self.media, io.BytesIO) or await aiofiles.os.path.isfile(self.media):
             uploaded_media = await client.invoke(
                 raw.functions.messages.UploadMedia(
                     peer=peer,

--- a/pyrogram/types/input_content/input_media_animation.py
+++ b/pyrogram/types/input_content/input_media_animation.py
@@ -19,8 +19,8 @@
 from __future__ import annotations as _annotations
 
 import io
-import pathlib
 import re
+from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
 
@@ -37,14 +37,14 @@ class InputMediaAnimation(InputMedia):
     """An animation file (GIF or H.264/MPEG-4 AVC video without sound) to be sent inside an album.
 
     Parameters:
-        media (``str`` | ``BinaryIO``):
+        media (``str`` | ``pathlib.Path`` | ``BinaryIO``):
             Animation to send.
             Pass a file_id as string to send a file that exists on the Telegram servers or
             pass a file path as string to upload a new file that exists on your local machine or
             pass a binary file-like object with its attribute “.name” set for in-memory uploads or
             pass an HTTP URL as a string for Telegram to get an animation from the Internet.
 
-        thumb (``str``, *optional*):
+        thumb (``str`` | ``pathlib.Path``, *optional*):
             Thumbnail of the animation file sent.
             The thumbnail should be in JPEG format and less than 200 KB in size.
             A thumbnail's width and height should not exceed 320 pixels.
@@ -76,12 +76,15 @@ class InputMediaAnimation(InputMedia):
         file_name (``str``, *optional*):
             File name of the animation sent.
             Defaults to file's path basename.
+
+    Raises:
+        FileNotFoundError: In case a local ``pathlib.Path`` doesn't point to an existing file.
     """
 
     def __init__(
         self,
-        media: str | BinaryIO,
-        thumb: str | None = None,
+        media: str | Path | BinaryIO,
+        thumb: str | Path | None = None,
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[MessageEntity] | None = None,
@@ -114,7 +117,7 @@ class InputMediaAnimation(InputMedia):
         else:
             peer = await client.resolve_peer(chat_id)
 
-        if isinstance(self.media, io.BytesIO) or pathlib.Path(self.media).is_file():
+        if isinstance(self.media, io.BytesIO) or Path(self.media).is_file():
             uploaded_media = await client.invoke(
                 raw.functions.messages.UploadMedia(
                     peer=peer,
@@ -149,6 +152,9 @@ class InputMediaAnimation(InputMedia):
                 ),
                 spoiler=self.has_spoiler,
             )
+
+        if isinstance(self.media, Path):
+            raise FileNotFoundError(f"No such file or directory: {self.media}")
 
         if re.match("^https?://", self.media):
             return raw.types.InputMediaDocumentExternal(

--- a/pyrogram/types/input_content/input_media_audio.py
+++ b/pyrogram/types/input_content/input_media_audio.py
@@ -19,8 +19,8 @@
 from __future__ import annotations as _annotations
 
 import io
-import pathlib
 import re
+from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
 
@@ -39,14 +39,14 @@ class InputMediaAudio(InputMedia):
     It is intended to be used with :meth:`~pyrogram.Client.send_media_group`.
 
     Parameters:
-        media (``str`` | ``BinaryIO``):
+        media (``str`` | ``pathlib.Path`` | ``BinaryIO``):
             Audio to send.
             Pass a file_id as string to send an audio that exists on the Telegram servers or
             pass a file path as string to upload a new audio that exists on your local machine or
             pass a binary file-like object with its attribute “.name” set for in-memory uploads or
             pass an HTTP URL as a string for Telegram to get an audio file from the Internet.
 
-        thumb (``str``, *optional*):
+        thumb (``str`` | ``pathlib.Path``, *optional*):
             Thumbnail of the music file album cover.
             The thumbnail should be in JPEG format and less than 200 KB in size.
             A thumbnail's width and height should not exceed 320 pixels.
@@ -75,12 +75,15 @@ class InputMediaAudio(InputMedia):
         file_name (``str``, *optional*):
             File name of the audio sent.
             Defaults to file's path basename.
+
+    Raises:
+        FileNotFoundError: In case a local ``pathlib.Path`` doesn't point to an existing file.
     """
 
     def __init__(
         self,
-        media: str | BinaryIO,
-        thumb: str | None = None,
+        media: str | Path | BinaryIO,
+        thumb: str | Path | None = None,
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[MessageEntity] | None = None,
@@ -112,7 +115,7 @@ class InputMediaAudio(InputMedia):
         else:
             peer = await client.resolve_peer(chat_id)
 
-        if isinstance(self.media, io.BytesIO) or pathlib.Path(self.media).is_file():
+        if isinstance(self.media, io.BytesIO) or Path(self.media).is_file():
             mime_type = client.guess_mime_type(self.media) or "audio/mpeg"
 
             if mime_type == "audio/ogg":
@@ -150,6 +153,9 @@ class InputMediaAudio(InputMedia):
                     file_reference=uploaded_media.document.file_reference,
                 ),
             )
+
+        if isinstance(self.media, Path):
+            raise FileNotFoundError(f"No such file or directory: {self.media}")
 
         if re.match("^https?://", self.media):
             return raw.types.InputMediaDocumentExternal(

--- a/pyrogram/types/input_content/input_media_audio.py
+++ b/pyrogram/types/input_content/input_media_audio.py
@@ -24,6 +24,8 @@ from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
 
+import aiofiles.os
+
 import pyrogram
 from pyrogram import raw, utils
 from pyrogram.file_id import FileType
@@ -115,7 +117,7 @@ class InputMediaAudio(InputMedia):
         else:
             peer = await client.resolve_peer(chat_id)
 
-        if isinstance(self.media, io.BytesIO) or Path(self.media).is_file():
+        if isinstance(self.media, io.BytesIO) or await aiofiles.os.path.isfile(self.media):
             mime_type = client.guess_mime_type(self.media) or "audio/mpeg"
 
             if mime_type == "audio/ogg":

--- a/pyrogram/types/input_content/input_media_audio.py
+++ b/pyrogram/types/input_content/input_media_audio.py
@@ -19,6 +19,7 @@
 from __future__ import annotations as _annotations
 
 import io
+import os
 import re
 from pathlib import Path
 from typing import BinaryIO
@@ -156,7 +157,7 @@ class InputMediaAudio(InputMedia):
                 ),
             )
 
-        if isinstance(self.media, Path):
+        if isinstance(self.media, os.PathLike):
             raise FileNotFoundError(f"No such file or directory: {self.media}")
 
         if re.match("^https?://", self.media):

--- a/pyrogram/types/input_content/input_media_document.py
+++ b/pyrogram/types/input_content/input_media_document.py
@@ -19,6 +19,7 @@
 from __future__ import annotations as _annotations
 
 import io
+import os
 import re
 from pathlib import Path
 from typing import BinaryIO
@@ -127,7 +128,7 @@ class InputMediaDocument(InputMedia):
                 ),
             )
 
-        if isinstance(self.media, Path):
+        if isinstance(self.media, os.PathLike):
             raise FileNotFoundError(f"No such file or directory: {self.media}")
 
         if re.match("^https?://", self.media):

--- a/pyrogram/types/input_content/input_media_document.py
+++ b/pyrogram/types/input_content/input_media_document.py
@@ -24,6 +24,8 @@ from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
 
+import aiofiles.os
+
 import pyrogram
 from pyrogram import raw, utils
 from pyrogram.file_id import FileType
@@ -97,7 +99,7 @@ class InputMediaDocument(InputMedia):
         else:
             peer = await client.resolve_peer(chat_id)
 
-        if isinstance(self.media, io.BytesIO) or Path(self.media).is_file():
+        if isinstance(self.media, io.BytesIO) or await aiofiles.os.path.isfile(self.media):
             uploaded_media = await client.invoke(
                 raw.functions.messages.UploadMedia(
                     peer=peer,

--- a/pyrogram/types/input_content/input_media_document.py
+++ b/pyrogram/types/input_content/input_media_document.py
@@ -19,8 +19,8 @@
 from __future__ import annotations as _annotations
 
 import io
-import pathlib
 import re
+from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
 
@@ -37,14 +37,14 @@ class InputMediaDocument(InputMedia):
     """A generic file to be sent inside an album.
 
     Parameters:
-        media (``str`` | ``BinaryIO``):
+        media (``str`` | ``pathlib.Path`` | ``BinaryIO``):
             File to send.
             Pass a file_id as string to send a file that exists on the Telegram servers or
             pass a file path as string to upload a new file that exists on your local machine or
             pass a binary file-like object with its attribute “.name” set for in-memory uploads or
             pass an HTTP URL as a string for Telegram to get a file from the Internet.
 
-        thumb (``str``):
+        thumb (``str`` | ``pathlib.Path``):
             Thumbnail of the file sent.
             The thumbnail should be in JPEG format and less than 200 KB in size.
             A thumbnail's width and height should not exceed 320 pixels.
@@ -64,12 +64,15 @@ class InputMediaDocument(InputMedia):
         file_name (``str``, *optional*):
             File name of the document sent.
             Defaults to file's path basename.
+
+    Raises:
+        FileNotFoundError: In case a local ``pathlib.Path`` doesn't point to an existing file.
     """
 
     def __init__(
         self,
-        media: str | BinaryIO,
-        thumb: str | None = None,
+        media: str | Path | BinaryIO,
+        thumb: str | Path | None = None,
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[MessageEntity] | None = None,
@@ -94,7 +97,7 @@ class InputMediaDocument(InputMedia):
         else:
             peer = await client.resolve_peer(chat_id)
 
-        if isinstance(self.media, io.BytesIO) or pathlib.Path(self.media).is_file():
+        if isinstance(self.media, io.BytesIO) or Path(self.media).is_file():
             uploaded_media = await client.invoke(
                 raw.functions.messages.UploadMedia(
                     peer=peer,
@@ -121,6 +124,9 @@ class InputMediaDocument(InputMedia):
                     file_reference=uploaded_media.document.file_reference,
                 ),
             )
+
+        if isinstance(self.media, Path):
+            raise FileNotFoundError(f"No such file or directory: {self.media}")
 
         if re.match("^https?://", self.media):
             return raw.types.InputMediaDocumentExternal(

--- a/pyrogram/types/input_content/input_media_live_photo.py
+++ b/pyrogram/types/input_content/input_media_live_photo.py
@@ -167,7 +167,7 @@ class InputMediaLivePhoto(InputMedia):
         # Only reachable while `media` is not a local file, so an existing `photo` cannot be
         #  uploaded either: the call below addresses both of them by file_id.
         if isinstance(self.photo, os.PathLike):
-            if not Path(self.photo).is_file():
+            if not await aiofiles.os.path.isfile(self.photo):
                 raise FileNotFoundError(f"No such file or directory: {self.photo}")
 
             raise ValueError(

--- a/pyrogram/types/input_content/input_media_live_photo.py
+++ b/pyrogram/types/input_content/input_media_live_photo.py
@@ -19,7 +19,7 @@
 from __future__ import annotations as _annotations
 
 import io
-import pathlib
+from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
 
@@ -36,14 +36,14 @@ class InputMediaLivePhoto(InputMedia):
     """Represents a live photo to be sent.
 
     Parameters:
-        media (``str`` | ``BinaryIO``):
+        media (``str`` | ``pathlib.Path`` | ``BinaryIO``):
             Video of the live photo to send.
             Pass a file_id as string to send a video that exists on the Telegram servers or
             pass a file path as string to upload a new video that exists on your local machine or
             pass a binary file-like object with its attribute “.name” set for in-memory uploads or
             pass an HTTP URL as a string for Telegram to get a video from the Internet.
 
-        photo (``str`` | ``BinaryIO``):
+        photo (``str`` | ``pathlib.Path`` | ``BinaryIO``):
             The static photo to send.
             Pass a file_id as string to send a video that exists on the Telegram servers or
             pass a file path as string to upload a new video that exists on your local machine or
@@ -66,13 +66,16 @@ class InputMediaLivePhoto(InputMedia):
 
         has_spoiler (``bool``, *optional*):
             Pass True if the photo needs to be covered with a spoiler animation.
+
+    Raises:
+        FileNotFoundError: In case a local ``pathlib.Path`` doesn't point to an existing file.
     """
 
     def __init__(
         self,
-        media: str | BinaryIO,
-        photo: str | BinaryIO,
-        thumb: str | None = None,
+        media: str | Path | BinaryIO,
+        photo: str | Path | BinaryIO,
+        thumb: str | Path | None = None,
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[MessageEntity] | None = None,
@@ -102,7 +105,7 @@ class InputMediaLivePhoto(InputMedia):
         else:
             peer = await client.resolve_peer(chat_id)
 
-        if isinstance(self.media, io.BytesIO) or pathlib.Path(self.media).is_file():
+        if isinstance(self.media, io.BytesIO) or Path(self.media).is_file():
             uploaded_media = await client.invoke(
                 raw.functions.messages.UploadMedia(
                     peer=peer,
@@ -153,6 +156,12 @@ class InputMediaLivePhoto(InputMedia):
                     file_reference=uploaded_media.document.file_reference,
                 ),
             )
+
+        if isinstance(self.media, Path):
+            raise FileNotFoundError(f"No such file or directory: {self.media}")
+
+        if isinstance(self.photo, Path):
+            raise FileNotFoundError(f"No such file or directory: {self.photo}")
 
         return utils.get_input_media_from_file_id(
             self.photo,

--- a/pyrogram/types/input_content/input_media_live_photo.py
+++ b/pyrogram/types/input_content/input_media_live_photo.py
@@ -19,6 +19,7 @@
 from __future__ import annotations as _annotations
 
 import io
+import os
 from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
@@ -159,10 +160,10 @@ class InputMediaLivePhoto(InputMedia):
                 ),
             )
 
-        if isinstance(self.media, Path):
+        if isinstance(self.media, os.PathLike):
             raise FileNotFoundError(f"No such file or directory: {self.media}")
 
-        if isinstance(self.photo, Path):
+        if isinstance(self.photo, os.PathLike):
             raise FileNotFoundError(f"No such file or directory: {self.photo}")
 
         return utils.get_input_media_from_file_id(

--- a/pyrogram/types/input_content/input_media_live_photo.py
+++ b/pyrogram/types/input_content/input_media_live_photo.py
@@ -23,6 +23,8 @@ from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
 
+import aiofiles.os
+
 import pyrogram
 from pyrogram import raw, utils
 from pyrogram.file_id import FileType
@@ -105,7 +107,7 @@ class InputMediaLivePhoto(InputMedia):
         else:
             peer = await client.resolve_peer(chat_id)
 
-        if isinstance(self.media, io.BytesIO) or Path(self.media).is_file():
+        if isinstance(self.media, io.BytesIO) or await aiofiles.os.path.isfile(self.media):
             uploaded_media = await client.invoke(
                 raw.functions.messages.UploadMedia(
                     peer=peer,

--- a/pyrogram/types/input_content/input_media_live_photo.py
+++ b/pyrogram/types/input_content/input_media_live_photo.py
@@ -72,6 +72,7 @@ class InputMediaLivePhoto(InputMedia):
 
     Raises:
         FileNotFoundError: In case a local ``pathlib.Path`` doesn't point to an existing file.
+        ValueError: In case ``media`` and ``photo`` are not both local files or both file_ids.
     """
 
     def __init__(
@@ -163,8 +164,16 @@ class InputMediaLivePhoto(InputMedia):
         if isinstance(self.media, os.PathLike):
             raise FileNotFoundError(f"No such file or directory: {self.media}")
 
+        # Only reachable while `media` is not a local file, so an existing `photo` cannot be
+        #  uploaded either: the call below addresses both of them by file_id.
         if isinstance(self.photo, os.PathLike):
-            raise FileNotFoundError(f"No such file or directory: {self.photo}")
+            if not Path(self.photo).is_file():
+                raise FileNotFoundError(f"No such file or directory: {self.photo}")
+
+            raise ValueError(
+                "`media` and `photo` must both be local files or both be file_ids, "
+                f"but `photo` is a local file while `media` is not: {self.media}"
+            )
 
         return utils.get_input_media_from_file_id(
             self.photo,

--- a/pyrogram/types/input_content/input_media_photo.py
+++ b/pyrogram/types/input_content/input_media_photo.py
@@ -19,8 +19,8 @@
 from __future__ import annotations as _annotations
 
 import io
-import pathlib
 import re
+from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
 
@@ -38,7 +38,7 @@ class InputMediaPhoto(InputMedia):
     It is intended to be used with :obj:`~pyrogram.Client.send_media_group`.
 
     Parameters:
-        media (``str`` | ``BinaryIO``):
+        media (``str`` | ``pathlib.Path`` | ``BinaryIO``):
             Photo to send.
             Pass a file_id as string to send a photo that exists on the Telegram servers or
             pass a file path as string to upload a new photo that exists on your local machine or
@@ -58,11 +58,14 @@ class InputMediaPhoto(InputMedia):
 
         has_spoiler (``bool``, *optional*):
             Pass True if the photo needs to be covered with a spoiler animation.
+
+    Raises:
+        FileNotFoundError: In case a local ``pathlib.Path`` doesn't point to an existing file.
     """
 
     def __init__(
         self,
-        media: str | BinaryIO,
+        media: str | Path | BinaryIO,
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[MessageEntity] | None = None,
@@ -87,7 +90,7 @@ class InputMediaPhoto(InputMedia):
         else:
             peer = await client.resolve_peer(chat_id)
 
-        if isinstance(self.media, io.BytesIO) or pathlib.Path(self.media).is_file():
+        if isinstance(self.media, io.BytesIO) or Path(self.media).is_file():
             uploaded_media = await client.invoke(
                 raw.functions.messages.UploadMedia(
                     peer=peer,
@@ -110,6 +113,9 @@ class InputMediaPhoto(InputMedia):
                 spoiler=self.has_spoiler,
                 ttl_seconds=ttl_seconds,
             )
+
+        if isinstance(self.media, Path):
+            raise FileNotFoundError(f"No such file or directory: {self.media}")
 
         if re.match("^https?://", self.media):
             return raw.types.InputMediaPhotoExternal(

--- a/pyrogram/types/input_content/input_media_photo.py
+++ b/pyrogram/types/input_content/input_media_photo.py
@@ -19,6 +19,7 @@
 from __future__ import annotations as _annotations
 
 import io
+import os
 import re
 from pathlib import Path
 from typing import BinaryIO
@@ -116,7 +117,7 @@ class InputMediaPhoto(InputMedia):
                 ttl_seconds=ttl_seconds,
             )
 
-        if isinstance(self.media, Path):
+        if isinstance(self.media, os.PathLike):
             raise FileNotFoundError(f"No such file or directory: {self.media}")
 
         if re.match("^https?://", self.media):

--- a/pyrogram/types/input_content/input_media_photo.py
+++ b/pyrogram/types/input_content/input_media_photo.py
@@ -24,6 +24,8 @@ from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
 
+import aiofiles.os
+
 import pyrogram
 from pyrogram import raw, utils
 from pyrogram.file_id import FileType
@@ -90,7 +92,7 @@ class InputMediaPhoto(InputMedia):
         else:
             peer = await client.resolve_peer(chat_id)
 
-        if isinstance(self.media, io.BytesIO) or Path(self.media).is_file():
+        if isinstance(self.media, io.BytesIO) or await aiofiles.os.path.isfile(self.media):
             uploaded_media = await client.invoke(
                 raw.functions.messages.UploadMedia(
                     peer=peer,

--- a/pyrogram/types/input_content/input_media_sticker.py
+++ b/pyrogram/types/input_content/input_media_sticker.py
@@ -24,6 +24,8 @@ from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
 
+import aiofiles.os
+
 import pyrogram
 from pyrogram import raw, utils
 from pyrogram.file_id import FileType
@@ -73,7 +75,7 @@ class InputMediaSticker(InputMedia):
         else:
             peer = await client.resolve_peer(chat_id)
 
-        if isinstance(self.media, io.BytesIO) or Path(self.media).is_file():
+        if isinstance(self.media, io.BytesIO) or await aiofiles.os.path.isfile(self.media):
             uploaded_media = await client.invoke(
                 raw.functions.messages.UploadMedia(
                     peer=peer,

--- a/pyrogram/types/input_content/input_media_sticker.py
+++ b/pyrogram/types/input_content/input_media_sticker.py
@@ -19,6 +19,7 @@
 from __future__ import annotations as _annotations
 
 import io
+import os
 import re
 from pathlib import Path
 from typing import BinaryIO
@@ -104,7 +105,7 @@ class InputMediaSticker(InputMedia):
                 ),
             )
 
-        if isinstance(self.media, Path):
+        if isinstance(self.media, os.PathLike):
             raise FileNotFoundError(f"No such file or directory: {self.media}")
 
         if re.match("^https?://", self.media):

--- a/pyrogram/types/input_content/input_media_sticker.py
+++ b/pyrogram/types/input_content/input_media_sticker.py
@@ -19,8 +19,8 @@
 from __future__ import annotations as _annotations
 
 import io
-import pathlib
 import re
+from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
 
@@ -35,7 +35,7 @@ class InputMediaSticker(InputMedia):
     """A sticker to be attached.
 
     Parameters:
-        media (``str`` | ``BinaryIO``):
+        media (``str`` | ``pathlib.Path`` | ``BinaryIO``):
             Sticker to send.
             Pass a file_id as string to send a file that exists on the Telegram servers or
             pass a file path as string to upload a new file that exists on your local machine or
@@ -45,11 +45,14 @@ class InputMediaSticker(InputMedia):
         emoji (``str``, *optional*):
             Emoji associated with this sticker.
             Only for just uploaded stickers.
+
+    Raises:
+        FileNotFoundError: In case a local ``pathlib.Path`` doesn't point to an existing file.
     """
 
     def __init__(
         self,
-        media: str | BinaryIO,
+        media: str | Path | BinaryIO,
         emoji: str = "",
     ) -> None:
         super().__init__(media)
@@ -70,7 +73,7 @@ class InputMediaSticker(InputMedia):
         else:
             peer = await client.resolve_peer(chat_id)
 
-        if isinstance(self.media, io.BytesIO) or pathlib.Path(self.media).is_file():
+        if isinstance(self.media, io.BytesIO) or Path(self.media).is_file():
             uploaded_media = await client.invoke(
                 raw.functions.messages.UploadMedia(
                     peer=peer,
@@ -98,6 +101,9 @@ class InputMediaSticker(InputMedia):
                     file_reference=uploaded_media.document.file_reference,
                 ),
             )
+
+        if isinstance(self.media, Path):
+            raise FileNotFoundError(f"No such file or directory: {self.media}")
 
         if re.match("^https?://", self.media):
             return raw.types.InputMediaDocumentExternal(

--- a/pyrogram/types/input_content/input_media_video.py
+++ b/pyrogram/types/input_content/input_media_video.py
@@ -19,6 +19,7 @@
 from __future__ import annotations as _annotations
 
 import io
+import os
 import re
 from pathlib import Path
 from typing import BinaryIO
@@ -167,7 +168,7 @@ class InputMediaVideo(InputMedia):
                     access_hash=uploaded_media.photo.access_hash,
                     file_reference=uploaded_media.photo.file_reference,
                 )
-            elif isinstance(self.video_cover, Path):
+            elif isinstance(self.video_cover, os.PathLike):
                 raise FileNotFoundError(f"No such file or directory: {self.video_cover}")
             elif re.match("^https?://", self.video_cover):
                 uploaded_media = await client.invoke(
@@ -228,7 +229,7 @@ class InputMediaVideo(InputMedia):
                 video_timestamp=self.video_start_timestamp,
             )
 
-        if isinstance(self.media, Path):
+        if isinstance(self.media, os.PathLike):
             raise FileNotFoundError(f"No such file or directory: {self.media}")
 
         if re.match("^https?://", self.media):

--- a/pyrogram/types/input_content/input_media_video.py
+++ b/pyrogram/types/input_content/input_media_video.py
@@ -24,6 +24,8 @@ from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
 
+import aiofiles.os
+
 import pyrogram
 from pyrogram import raw, utils
 from pyrogram.file_id import FileType
@@ -148,7 +150,9 @@ class InputMediaVideo(InputMedia):
         input_video_cover = None
 
         if self.video_cover is not None:
-            if isinstance(self.video_cover, io.BytesIO) or Path(self.video_cover).is_file():
+            if isinstance(self.video_cover, io.BytesIO) or await aiofiles.os.path.isfile(
+                self.video_cover
+            ):
                 uploaded_media = await client.invoke(
                     raw.functions.messages.UploadMedia(
                         peer=peer,
@@ -182,7 +186,7 @@ class InputMediaVideo(InputMedia):
                     self.video_cover, FileType.PHOTO
                 ).id
 
-        if isinstance(self.media, io.BytesIO) or Path(self.media).is_file():
+        if isinstance(self.media, io.BytesIO) or await aiofiles.os.path.isfile(self.media):
             uploaded_media = await client.invoke(
                 raw.functions.messages.UploadMedia(
                     peer=peer,

--- a/pyrogram/types/input_content/input_media_video.py
+++ b/pyrogram/types/input_content/input_media_video.py
@@ -19,8 +19,8 @@
 from __future__ import annotations as _annotations
 
 import io
-import pathlib
 import re
+from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
 
@@ -39,7 +39,7 @@ class InputMediaVideo(InputMedia):
     It is intended to be used with :obj:`~pyrogram.Client.send_media_group` or :obj:`~pyrogram.Client.send_paid_media`.
 
     Parameters:
-        media (``str`` | ``BinaryIO``):
+        media (``str`` | ``pathlib.Path`` | ``BinaryIO``):
             Video to send.
             Pass a file_id as string to send a video that exists on the Telegram servers or
             pass a file path as string to upload a new video that exists on your local machine or
@@ -89,18 +89,21 @@ class InputMediaVideo(InputMedia):
         video_start_timestamp (``int``, *optional*):
             Video startpoint, in seconds.
 
-        video_cover (``str`` | ``BinaryIO``, *optional*):
+        video_cover (``str`` | ``pathlib.Path`` | ``BinaryIO``, *optional*):
             Video cover.
             Pass a file_id as string to attach a photo that exists on the Telegram servers,
             pass an HTTP URL as a string for Telegram to get a photo from the Internet,
             pass a file path as string to upload a new photo that exists on your local machine, or
             pass a binary file-like object with its attribute ".name" set for in-memory uploads.
+
+    Raises:
+        FileNotFoundError: In case a local ``pathlib.Path`` doesn't point to an existing file.
     """
 
     def __init__(
         self,
-        media: str | BinaryIO,
-        thumb: str | None = None,
+        media: str | Path | BinaryIO,
+        thumb: str | Path | None = None,
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[MessageEntity] | None = None,
@@ -112,7 +115,7 @@ class InputMediaVideo(InputMedia):
         has_spoiler: bool | None = None,
         no_sound: bool | None = None,
         video_start_timestamp: int | None = None,
-        video_cover: str | BinaryIO | None = None,
+        video_cover: str | Path | BinaryIO | None = None,
     ):
         super().__init__(media, caption, parse_mode, caption_entities)
 
@@ -145,7 +148,7 @@ class InputMediaVideo(InputMedia):
         input_video_cover = None
 
         if self.video_cover is not None:
-            if isinstance(self.video_cover, io.BytesIO) or pathlib.Path(self.video_cover).is_file():
+            if isinstance(self.video_cover, io.BytesIO) or Path(self.video_cover).is_file():
                 uploaded_media = await client.invoke(
                     raw.functions.messages.UploadMedia(
                         peer=peer,
@@ -160,6 +163,8 @@ class InputMediaVideo(InputMedia):
                     access_hash=uploaded_media.photo.access_hash,
                     file_reference=uploaded_media.photo.file_reference,
                 )
+            elif isinstance(self.video_cover, Path):
+                raise FileNotFoundError(f"No such file or directory: {self.video_cover}")
             elif re.match("^https?://", self.video_cover):
                 uploaded_media = await client.invoke(
                     raw.functions.messages.UploadMedia(
@@ -177,7 +182,7 @@ class InputMediaVideo(InputMedia):
                     self.video_cover, FileType.PHOTO
                 ).id
 
-        if isinstance(self.media, io.BytesIO) or pathlib.Path(self.media).is_file():
+        if isinstance(self.media, io.BytesIO) or Path(self.media).is_file():
             uploaded_media = await client.invoke(
                 raw.functions.messages.UploadMedia(
                     peer=peer,
@@ -218,6 +223,9 @@ class InputMediaVideo(InputMedia):
                 video_cover=input_video_cover,
                 video_timestamp=self.video_start_timestamp,
             )
+
+        if isinstance(self.media, Path):
+            raise FileNotFoundError(f"No such file or directory: {self.media}")
 
         if re.match("^https?://", self.media):
             return raw.types.InputMediaDocumentExternal(

--- a/pyrogram/types/input_content/input_media_voice_note.py
+++ b/pyrogram/types/input_content/input_media_voice_note.py
@@ -19,6 +19,7 @@
 from __future__ import annotations as _annotations
 
 import io
+import os
 import re
 from pathlib import Path
 from typing import BinaryIO
@@ -128,7 +129,7 @@ class InputMediaVoiceNote(InputMedia):
                 ),
             )
 
-        if isinstance(self.media, Path):
+        if isinstance(self.media, os.PathLike):
             raise FileNotFoundError(f"No such file or directory: {self.media}")
 
         if re.match("^https?://", self.media):

--- a/pyrogram/types/input_content/input_media_voice_note.py
+++ b/pyrogram/types/input_content/input_media_voice_note.py
@@ -19,8 +19,8 @@
 from __future__ import annotations as _annotations
 
 import io
-import pathlib
 import re
+from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
 
@@ -39,7 +39,7 @@ class InputMediaVoiceNote(InputMedia):
     It is intended to be used with :obj:`~pyrogram.types.InputRichBlockVoiceNote`.
 
     Parameters:
-        media (``str`` | ``BinaryIO``):
+        media (``str`` | ``pathlib.Path`` | ``BinaryIO``):
             Voice note to send.
             Pass a file_id as string to send a voice note that exists on the Telegram servers or
             pass a file path as string to upload a new voice note that exists on your local machine or
@@ -59,11 +59,14 @@ class InputMediaVoiceNote(InputMedia):
 
         duration (``int``, *optional*):
             Duration of the voice note in seconds
+
+    Raises:
+        FileNotFoundError: In case a local ``pathlib.Path`` doesn't point to an existing file.
     """
 
     def __init__(
         self,
-        media: str | BinaryIO,
+        media: str | Path | BinaryIO,
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[MessageEntity] | None = None,
@@ -88,7 +91,7 @@ class InputMediaVoiceNote(InputMedia):
         else:
             peer = await client.resolve_peer(chat_id)
 
-        if isinstance(self.media, io.BytesIO) or pathlib.Path(self.media).is_file():
+        if isinstance(self.media, io.BytesIO) or Path(self.media).is_file():
             mime_type: str = client.guess_mime_type(self.media) or "audio/ogg"
 
             if mime_type == "audio/mpeg":
@@ -122,6 +125,9 @@ class InputMediaVoiceNote(InputMedia):
                     file_reference=uploaded_media.document.file_reference,
                 ),
             )
+
+        if isinstance(self.media, Path):
+            raise FileNotFoundError(f"No such file or directory: {self.media}")
 
         if re.match("^https?://", self.media):
             return raw.types.InputMediaDocumentExternal(

--- a/pyrogram/types/input_content/input_media_voice_note.py
+++ b/pyrogram/types/input_content/input_media_voice_note.py
@@ -24,6 +24,8 @@ from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
 
+import aiofiles.os
+
 import pyrogram
 from pyrogram import raw, utils
 from pyrogram.file_id import FileType
@@ -91,7 +93,7 @@ class InputMediaVoiceNote(InputMedia):
         else:
             peer = await client.resolve_peer(chat_id)
 
-        if isinstance(self.media, io.BytesIO) or Path(self.media).is_file():
+        if isinstance(self.media, io.BytesIO) or await aiofiles.os.path.isfile(self.media):
             mime_type: str = client.guess_mime_type(self.media) or "audio/ogg"
 
             if mime_type == "audio/mpeg":

--- a/pyrogram/types/input_content/input_poll_media.py
+++ b/pyrogram/types/input_content/input_poll_media.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations as _annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING, BinaryIO
 
 from ..messages_and_media import MessageEntity
@@ -44,7 +45,7 @@ class InputPollMedia(InputMedia):
 
     def __init__(
         self,
-        media: str | BinaryIO | None = None,
+        media: str | Path | BinaryIO | None = None,
         caption: str = "",
         parse_mode: str | None = None,
         caption_entities: list[MessageEntity] | None = None,

--- a/pyrogram/types/input_content/input_poll_option_media.py
+++ b/pyrogram/types/input_content/input_poll_option_media.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations as _annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING, BinaryIO
 
 from ..messages_and_media import MessageEntity
@@ -43,7 +44,7 @@ class InputPollOptionMedia(InputMedia):
 
     def __init__(
         self,
-        media: str | BinaryIO | None = None,
+        media: str | Path | BinaryIO | None = None,
         caption: str = "",
         parse_mode: str | None = None,
         caption_entities: list[MessageEntity] | None = None,

--- a/pyrogram/types/messages_and_media/message.py
+++ b/pyrogram/types/messages_and_media/message.py
@@ -22,6 +22,7 @@ import contextlib
 import logging
 from datetime import datetime
 from functools import partial
+from pathlib import Path
 from typing import BinaryIO
 from re import Match
 from collections.abc import Callable
@@ -2479,7 +2480,7 @@ class Message(Object, Update):
 
     async def reply_animation(
         self,
-        animation: str | BinaryIO,
+        animation: str | Path | BinaryIO,
         caption: str = "",
         unsave: bool = False,
         parse_mode: enums.ParseMode | None = None,
@@ -2489,7 +2490,7 @@ class Message(Object, Update):
         duration: int = 0,
         width: int = 0,
         height: int = 0,
-        thumb: str | BinaryIO | None = None,
+        thumb: str | Path | BinaryIO | None = None,
         file_name: str | None = None,
         disable_notification: bool | None = None,
         effect_id: int | None = None,
@@ -2554,7 +2555,7 @@ class Message(Object, Update):
             height (``int``, *optional*):
                 Animation height.
 
-            thumb (``str`` | ``BinaryIO``, *optional*):
+            thumb (``str`` | ``pathlib.Path`` | ``BinaryIO``, *optional*):
                 Thumbnail of the animation file sent.
                 The thumbnail should be in JPEG format and less than 200 KB in size.
                 A thumbnail's width and height should not exceed 320 pixels.
@@ -2669,7 +2670,7 @@ class Message(Object, Update):
 
     async def answer_animation(
         self,
-        animation: str | BinaryIO,
+        animation: str | Path | BinaryIO,
         caption: str = "",
         unsave: bool = False,
         parse_mode: enums.ParseMode | None = None,
@@ -2679,7 +2680,7 @@ class Message(Object, Update):
         duration: int = 0,
         width: int = 0,
         height: int = 0,
-        thumb: str | BinaryIO | None = None,
+        thumb: str | Path | BinaryIO | None = None,
         file_name: str | None = None,
         disable_notification: bool | None = None,
         effect_id: int | None = None,
@@ -2744,7 +2745,7 @@ class Message(Object, Update):
             height (``int``, *optional*):
                 Animation height.
 
-            thumb (``str`` | ``BinaryIO``, *optional*):
+            thumb (``str`` | ``pathlib.Path`` | ``BinaryIO``, *optional*):
                 Thumbnail of the animation file sent.
                 The thumbnail should be in JPEG format and less than 200 KB in size.
                 A thumbnail's width and height should not exceed 320 pixels.
@@ -2857,14 +2858,14 @@ class Message(Object, Update):
 
     async def reply_audio(
         self,
-        audio: str | BinaryIO,
+        audio: str | Path | BinaryIO,
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
         duration: int = 0,
         performer: str | None = None,
         title: str | None = None,
-        thumb: str | BinaryIO | None = None,
+        thumb: str | Path | BinaryIO | None = None,
         file_name: str | None = None,
         disable_notification: bool | None = None,
         effect_id: int | None = None,
@@ -2919,7 +2920,7 @@ class Message(Object, Update):
             title (``str``, *optional*):
                 Track name.
 
-            thumb (``str`` | ``BinaryIO``, *optional*):
+            thumb (``str`` | ``pathlib.Path`` | ``BinaryIO``, *optional*):
                 Thumbnail of the music file album cover.
                 The thumbnail should be in JPEG format and less than 200 KB in size.
                 A thumbnail's width and height should not exceed 320 pixels.
@@ -3031,14 +3032,14 @@ class Message(Object, Update):
 
     async def answer_audio(
         self,
-        audio: str | BinaryIO,
+        audio: str | Path | BinaryIO,
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
         duration: int = 0,
         performer: str | None = None,
         title: str | None = None,
-        thumb: str | BinaryIO | None = None,
+        thumb: str | Path | BinaryIO | None = None,
         file_name: str | None = None,
         disable_notification: bool | None = None,
         effect_id: int | None = None,
@@ -3093,7 +3094,7 @@ class Message(Object, Update):
             title (``str``, *optional*):
                 Track name.
 
-            thumb (``str`` | ``BinaryIO``, *optional*):
+            thumb (``str`` | ``pathlib.Path`` | ``BinaryIO``, *optional*):
                 Thumbnail of the music file album cover.
                 The thumbnail should be in JPEG format and less than 200 KB in size.
                 A thumbnail's width and height should not exceed 320 pixels.
@@ -3421,8 +3422,8 @@ class Message(Object, Update):
 
     async def reply_document(
         self,
-        document: str | BinaryIO,
-        thumb: str | BinaryIO | None = None,
+        document: str | Path | BinaryIO,
+        thumb: str | Path | BinaryIO | None = None,
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
@@ -3462,7 +3463,7 @@ class Message(Object, Update):
                 pass an HTTP URL as a string for Telegram to get a file from the Internet, or
                 pass a file path as string to upload a new file that exists on your local machine.
 
-            thumb (``str`` | ``BinaryIO``, *optional*):
+            thumb (``str`` | ``pathlib.Path`` | ``BinaryIO``, *optional*):
                 Thumbnail of the file sent.
                 The thumbnail should be in JPEG format and less than 200 KB in size.
                 A thumbnail's width and height should not exceed 320 pixels.
@@ -3587,8 +3588,8 @@ class Message(Object, Update):
 
     async def answer_document(
         self,
-        document: str | BinaryIO,
-        thumb: str | BinaryIO | None = None,
+        document: str | Path | BinaryIO,
+        thumb: str | Path | BinaryIO | None = None,
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
@@ -3628,7 +3629,7 @@ class Message(Object, Update):
                 pass an HTTP URL as a string for Telegram to get a file from the Internet, or
                 pass a file path as string to upload a new file that exists on your local machine.
 
-            thumb (``str`` | ``BinaryIO``, *optional*):
+            thumb (``str`` | ``pathlib.Path`` | ``BinaryIO``, *optional*):
                 Thumbnail of the file sent.
                 The thumbnail should be in JPEG format and less than 200 KB in size.
                 A thumbnail's width and height should not exceed 320 pixels.
@@ -4908,7 +4909,7 @@ class Message(Object, Update):
 
     async def reply_photo(
         self,
-        photo: str | BinaryIO,
+        photo: str | Path | BinaryIO,
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
@@ -5076,7 +5077,7 @@ class Message(Object, Update):
 
     async def answer_photo(
         self,
-        photo: str | BinaryIO,
+        photo: str | Path | BinaryIO,
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
@@ -5242,8 +5243,8 @@ class Message(Object, Update):
 
     async def reply_live_photo(
         self,
-        live_photo: str | BinaryIO,
-        photo: str | BinaryIO,
+        live_photo: str | Path | BinaryIO,
+        photo: str | Path | BinaryIO,
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
@@ -5279,7 +5280,7 @@ class Message(Object, Update):
         * ephemeral_message_parameters
 
         Parameters:
-            live_photo (``str`` | ``BinaryIO``):
+            live_photo (``str`` | ``pathlib.Path`` | ``BinaryIO``):
                 Live photo video to send.
                 The video must be no longer than 10 seconds and must not exceed 10 MB in size.
                 Pass a file_id as string to send a video that exists on the Telegram servers,
@@ -5287,7 +5288,7 @@ class Message(Object, Update):
                 pass a file path as string to upload a new video that exists on your local machine, or
                 pass a binary file-like object with its attribute ".name" set for in-memory uploads.
 
-            photo (``str`` | ``BinaryIO``):
+            photo (``str`` | ``pathlib.Path`` | ``BinaryIO``):
                 The static photo to send.
                 The video must be no longer than 10 seconds and must not exceed 10 MB in size.
                 Pass a file_id as string to send a video that exists on the Telegram servers,
@@ -5419,8 +5420,8 @@ class Message(Object, Update):
 
     async def answer_live_photo(
         self,
-        live_photo: str | BinaryIO,
-        photo: str | BinaryIO,
+        live_photo: str | Path | BinaryIO,
+        photo: str | Path | BinaryIO,
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
@@ -5456,7 +5457,7 @@ class Message(Object, Update):
         * ephemeral_message_parameters
 
         Parameters:
-            live_photo (``str`` | ``BinaryIO``):
+            live_photo (``str`` | ``pathlib.Path`` | ``BinaryIO``):
                 Live photo video to send.
                 The video must be no longer than 10 seconds and must not exceed 10 MB in size.
                 Pass a file_id as string to send a video that exists on the Telegram servers,
@@ -5464,7 +5465,7 @@ class Message(Object, Update):
                 pass a file path as string to upload a new video that exists on your local machine, or
                 pass a binary file-like object with its attribute ".name" set for in-memory uploads.
 
-            photo (``str`` | ``BinaryIO``):
+            photo (``str`` | ``pathlib.Path`` | ``BinaryIO``):
                 The static photo to send.
                 The video must be no longer than 10 seconds and must not exceed 10 MB in size.
                 Pass a file_id as string to send a video that exists on the Telegram servers,
@@ -6150,7 +6151,7 @@ class Message(Object, Update):
 
     async def reply_sticker(
         self,
-        sticker: str | BinaryIO,
+        sticker: str | Path | BinaryIO,
         emoji: str = "",
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
@@ -6300,7 +6301,7 @@ class Message(Object, Update):
 
     async def answer_sticker(
         self,
-        sticker: str | BinaryIO,
+        sticker: str | Path | BinaryIO,
         emoji: str = "",
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
@@ -6688,7 +6689,7 @@ class Message(Object, Update):
 
     async def reply_video(
         self,
-        video: str | BinaryIO,
+        video: str | Path | BinaryIO,
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
@@ -6700,8 +6701,8 @@ class Message(Object, Update):
         width: int = 0,
         height: int = 0,
         video_start_timestamp: int | None = None,
-        video_cover: str | BinaryIO | None = None,
-        thumb: str | BinaryIO | None = None,
+        video_cover: str | Path | BinaryIO | None = None,
+        thumb: str | Path | BinaryIO | None = None,
         file_name: str | None = None,
         supports_streaming: bool = True,
         disable_notification: bool | None = None,
@@ -6776,14 +6777,14 @@ class Message(Object, Update):
             video_start_timestamp (``int``, *optional*):
                 Video startpoint, in seconds.
 
-            video_cover (``str`` | ``BinaryIO``, *optional*):
+            video_cover (``str`` | ``pathlib.Path`` | ``BinaryIO``, *optional*):
                 Video cover.
                 Pass a file_id as string to attach a photo that exists on the Telegram servers,
                 pass an HTTP URL as a string for Telegram to get a photo from the Internet,
                 pass a file path as string to upload a new photo that exists on your local machine, or
                 pass a binary file-like object with its attribute ".name" set for in-memory uploads.
 
-            thumb (``str`` | ``BinaryIO``, *optional*):
+            thumb (``str`` | ``pathlib.Path`` | ``BinaryIO``, *optional*):
                 Thumbnail of the video sent.
                 The thumbnail should be in JPEG format and less than 200 KB in size.
                 A thumbnail's width and height should not exceed 320 pixels.
@@ -6910,7 +6911,7 @@ class Message(Object, Update):
 
     async def answer_video(
         self,
-        video: str | BinaryIO,
+        video: str | Path | BinaryIO,
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
@@ -6922,8 +6923,8 @@ class Message(Object, Update):
         width: int = 0,
         height: int = 0,
         video_start_timestamp: int | None = None,
-        video_cover: str | BinaryIO | None = None,
-        thumb: str | BinaryIO | None = None,
+        video_cover: str | Path | BinaryIO | None = None,
+        thumb: str | Path | BinaryIO | None = None,
         file_name: str | None = None,
         supports_streaming: bool = True,
         disable_notification: bool | None = None,
@@ -6998,14 +6999,14 @@ class Message(Object, Update):
             video_start_timestamp (``int``, *optional*):
                 Video startpoint, in seconds.
 
-            video_cover (``str`` | ``BinaryIO``, *optional*):
+            video_cover (``str`` | ``pathlib.Path`` | ``BinaryIO``, *optional*):
                 Video cover.
                 Pass a file_id as string to attach a photo that exists on the Telegram servers,
                 pass an HTTP URL as a string for Telegram to get a photo from the Internet,
                 pass a file path as string to upload a new photo that exists on your local machine, or
                 pass a binary file-like object with its attribute ".name" set for in-memory uploads.
 
-            thumb (``str`` | ``BinaryIO``, *optional*):
+            thumb (``str`` | ``pathlib.Path`` | ``BinaryIO``, *optional*):
                 Thumbnail of the video sent.
                 The thumbnail should be in JPEG format and less than 200 KB in size.
                 A thumbnail's width and height should not exceed 320 pixels.
@@ -7130,10 +7131,10 @@ class Message(Object, Update):
 
     async def reply_video_note(
         self,
-        video_note: str | BinaryIO,
+        video_note: str | Path | BinaryIO,
         duration: int = 0,
         length: int = 1,
-        thumb: str | BinaryIO | None = None,
+        thumb: str | Path | BinaryIO | None = None,
         disable_notification: bool | None = None,
         effect_id: int | None = None,
         schedule_date: datetime | None = None,
@@ -7175,7 +7176,7 @@ class Message(Object, Update):
             length (``int``, *optional*):
                 Video width and height.
 
-            thumb (``str`` | ``BinaryIO``, *optional*):
+            thumb (``str`` | ``pathlib.Path`` | ``BinaryIO``, *optional*):
                 Thumbnail of the video sent.
                 The thumbnail should be in JPEG format and less than 200 KB in size.
                 A thumbnail's width and height should not exceed 320 pixels.
@@ -7283,10 +7284,10 @@ class Message(Object, Update):
 
     async def answer_video_note(
         self,
-        video_note: str | BinaryIO,
+        video_note: str | Path | BinaryIO,
         duration: int = 0,
         length: int = 1,
-        thumb: str | BinaryIO | None = None,
+        thumb: str | Path | BinaryIO | None = None,
         disable_notification: bool | None = None,
         effect_id: int | None = None,
         reply_parameters: types.ReplyParameters | None = None,
@@ -7328,7 +7329,7 @@ class Message(Object, Update):
             length (``int``, *optional*):
                 Video width and height.
 
-            thumb (``str`` | ``BinaryIO``, *optional*):
+            thumb (``str`` | ``pathlib.Path`` | ``BinaryIO``, *optional*):
                 Thumbnail of the video sent.
                 The thumbnail should be in JPEG format and less than 200 KB in size.
                 A thumbnail's width and height should not exceed 320 pixels.
@@ -7434,7 +7435,7 @@ class Message(Object, Update):
 
     async def reply_voice(
         self,
-        voice: str | BinaryIO,
+        voice: str | Path | BinaryIO,
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
@@ -7596,7 +7597,7 @@ class Message(Object, Update):
 
     async def answer_voice(
         self,
-        voice: str | BinaryIO,
+        voice: str | Path | BinaryIO,
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,

--- a/pyrogram/types/messages_and_media/story.py
+++ b/pyrogram/types/messages_and_media/story.py
@@ -19,6 +19,7 @@
 from __future__ import annotations as _annotations
 
 from datetime import datetime
+from pathlib import Path
 from typing import BinaryIO
 from collections.abc import Callable
 
@@ -612,7 +613,7 @@ class Story(Object, Update):
 
     async def reply_animation(
         self,
-        animation: str | BinaryIO,
+        animation: str | Path | BinaryIO,
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
@@ -620,7 +621,7 @@ class Story(Object, Update):
         duration: int = 0,
         width: int = 0,
         height: int = 0,
-        thumb: str | BinaryIO | None = None,
+        thumb: str | Path | BinaryIO | None = None,
         file_name: str | None = None,
         disable_notification: bool | None = None,
         schedule_date: datetime | None = None,
@@ -685,7 +686,7 @@ class Story(Object, Update):
             height (``int``, *optional*):
                 Animation height.
 
-            thumb (``str`` | ``BinaryIO``, *optional*):
+            thumb (``str`` | ``pathlib.Path`` | ``BinaryIO``, *optional*):
                 Thumbnail of the animation file sent.
                 The thumbnail should be in JPEG format and less than 200 KB in size.
                 A thumbnail's width and height should not exceed 320 pixels.
@@ -765,14 +766,14 @@ class Story(Object, Update):
 
     async def reply_audio(
         self,
-        audio: str | BinaryIO,
+        audio: str | Path | BinaryIO,
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
         duration: int = 0,
         performer: str | None = None,
         title: str | None = None,
-        thumb: str | BinaryIO | None = None,
+        thumb: str | Path | BinaryIO | None = None,
         file_name: str | None = None,
         disable_notification: bool | None = None,
         schedule_date: datetime | None = None,
@@ -834,7 +835,7 @@ class Story(Object, Update):
             title (``str``, *optional*):
                 Track name.
 
-            thumb (``str`` | ``BinaryIO``, *optional*):
+            thumb (``str`` | ``pathlib.Path`` | ``BinaryIO``, *optional*):
                 Thumbnail of the music file album cover.
                 The thumbnail should be in JPEG format and less than 200 KB in size.
                 A thumbnail's width and height should not exceed 320 pixels.
@@ -1052,7 +1053,7 @@ class Story(Object, Update):
 
     async def reply_photo(
         self,
-        photo: str | BinaryIO,
+        photo: str | Path | BinaryIO,
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
@@ -1189,7 +1190,7 @@ class Story(Object, Update):
 
     async def reply_sticker(
         self,
-        sticker: str | BinaryIO,
+        sticker: str | Path | BinaryIO,
         disable_notification: bool | None = None,
         paid_message_star_count: int | None = None,
         schedule_date: datetime | None = None,
@@ -1292,7 +1293,7 @@ class Story(Object, Update):
 
     async def reply_video(
         self,
-        video: str | BinaryIO,
+        video: str | Path | BinaryIO,
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
@@ -1303,8 +1304,8 @@ class Story(Object, Update):
         width: int = 0,
         height: int = 0,
         video_start_timestamp: int | None = None,
-        video_cover: str | BinaryIO | None = None,
-        thumb: str | BinaryIO | None = None,
+        video_cover: str | Path | BinaryIO | None = None,
+        thumb: str | Path | BinaryIO | None = None,
         file_name: str | None = None,
         supports_streaming: bool = True,
         disable_notification: bool | None = None,
@@ -1383,14 +1384,14 @@ class Story(Object, Update):
             video_start_timestamp (``int``, *optional*):
                 Video startpoint, in seconds.
 
-            video_cover (``str`` | ``BinaryIO``, *optional*):
+            video_cover (``str`` | ``pathlib.Path`` | ``BinaryIO``, *optional*):
                 Video cover.
                 Pass a file_id as string to attach a photo that exists on the Telegram servers,
                 pass an HTTP URL as a string for Telegram to get a photo from the Internet,
                 pass a file path as string to upload a new photo that exists on your local machine, or
                 pass a binary file-like object with its attribute ".name" set for in-memory uploads.
 
-            thumb (``str`` | ``BinaryIO``, *optional*):
+            thumb (``str`` | ``pathlib.Path`` | ``BinaryIO``, *optional*):
                 Thumbnail of the video sent.
                 The thumbnail should be in JPEG format and less than 200 KB in size.
                 A thumbnail's width and height should not exceed 320 pixels.
@@ -1483,10 +1484,10 @@ class Story(Object, Update):
 
     async def reply_video_note(
         self,
-        video_note: str | BinaryIO,
+        video_note: str | Path | BinaryIO,
         duration: int = 0,
         length: int = 1,
-        thumb: str | BinaryIO | None = None,
+        thumb: str | Path | BinaryIO | None = None,
         disable_notification: bool | None = None,
         schedule_date: datetime | None = None,
         repeat_period: int | None = None,
@@ -1535,7 +1536,7 @@ class Story(Object, Update):
             length (``int``, *optional*):
                 Video width and height.
 
-            thumb (``str`` | ``BinaryIO``, *optional*):
+            thumb (``str`` | ``pathlib.Path`` | ``BinaryIO``, *optional*):
                 Thumbnail of the video sent.
                 The thumbnail should be in JPEG format and less than 200 KB in size.
                 A thumbnail's width and height should not exceed 320 pixels.
@@ -1610,7 +1611,7 @@ class Story(Object, Update):
 
     async def reply_voice(
         self,
-        voice: str | BinaryIO,
+        voice: str | Path | BinaryIO,
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
@@ -1864,7 +1865,7 @@ class Story(Object, Update):
 
     async def edit_media(
         self,
-        media: str | BinaryIO | None = None,
+        media: str | Path | BinaryIO | None = None,
     ) -> types.Story | None:
         """Bound method *edit_media* of :obj:`~pyrogram.types.Story`.
 
@@ -1884,7 +1885,7 @@ class Story(Object, Update):
                 await story.edit_media("new_video.mp4")
 
         Parameters:
-            media (``str`` | ``BinaryIO``, *optional*):
+            media (``str`` | ``pathlib.Path`` | ``BinaryIO``, *optional*):
                 New story media.
                 Pass a file_id as string to send a photo that exists on the Telegram servers,
                 pass an HTTP URL as a string for Telegram to get a photo from the Internet,

--- a/pyrogram/types/user_and_chats/chat.py
+++ b/pyrogram/types/user_and_chats/chat.py
@@ -20,6 +20,7 @@ from __future__ import annotations as _annotations
 
 import logging
 from datetime import datetime
+from pathlib import Path
 from typing import BinaryIO
 from collections.abc import AsyncGenerator
 
@@ -1599,8 +1600,8 @@ class Chat(Object):
     async def set_photo(
         self,
         *,
-        photo: str | BinaryIO | None = None,
-        video: str | BinaryIO | None = None,
+        photo: str | Path | BinaryIO | None = None,
+        video: str | Path | BinaryIO | None = None,
         video_start_ts: float | None = None,
     ) -> types.Message | None:
         """Bound method *set_photo* of :obj:`~pyrogram.types.Chat`.
@@ -1631,12 +1632,12 @@ class Chat(Object):
                 await chat.set_photo(video=video.file_id)
 
         Parameters:
-            photo (``str`` | ``BinaryIO``, *optional*):
+            photo (``str`` | ``pathlib.Path`` | ``BinaryIO``, *optional*):
                 New chat photo. You can pass a :obj:`~pyrogram.types.Photo` file_id, a file path to upload a new photo
                 from your local machine or a binary file-like object with its attribute
                 ".name" set for in-memory uploads.
 
-            video (``str`` | ``BinaryIO``, *optional*):
+            video (``str`` | ``pathlib.Path`` | ``BinaryIO``, *optional*):
                 New chat video. You can pass a :obj:`~pyrogram.types.Video` file_id, a file path to upload a new video
                 from your local machine or a binary file-like object with its attribute
                 ".name" set for in-memory uploads.

--- a/tests/unit/methods/test_save_file.py
+++ b/tests/unit/methods/test_save_file.py
@@ -20,7 +20,9 @@ from __future__ import annotations as _annotations
 
 import asyncio
 from concurrent.futures import Executor
+from io import BytesIO
 from pathlib import Path
+from tempfile import SpooledTemporaryFile
 from typing import Final
 
 import pytest
@@ -139,3 +141,62 @@ async def test_a_missing_part_the_server_refused_reaches_the_caller_too(three_pa
 @pytest.mark.asyncio
 async def test_no_path_is_not_an_upload_at_all() -> None:
     assert await Uploader(Media()).save_file(None) is None
+
+
+@pytest.mark.asyncio
+async def test_a_file_object_is_uploaded_part_by_part_like_a_path() -> None:
+    media = Media()
+
+    file = await Uploader(media).save_file(BytesIO(b"x" * (2 * _PART_SIZE + 1)))
+
+    assert isinstance(file, raw.types.InputFile)
+    assert file.parts == 3
+    assert media.saved_parts == [0, 1, 2]
+
+
+@pytest.mark.asyncio
+async def test_a_file_object_without_a_name_uploads_under_the_fallback_one() -> None:
+    # A `BytesIO` carries no `.name`, and the answer for one that does not is "file.jpg".
+    #  Anything standing in for the file that answers `.name` with `None` rather than not
+    #  answering at all puts that `None` into `InputFile`, where it fails to serialize.
+    file = await Uploader(Media()).save_file(BytesIO(b"x"))
+
+    assert isinstance(file, raw.types.InputFile)
+    assert file.name == "file.jpg"
+
+
+@pytest.mark.asyncio
+async def test_a_file_object_that_has_a_name_uploads_under_it() -> None:
+    payload = BytesIO(b"x")
+    payload.name = "note.txt"
+
+    file = await Uploader(Media()).save_file(payload)
+
+    assert isinstance(file, raw.types.InputFile)
+    assert file.name == "note.txt"
+
+
+@pytest.mark.asyncio
+async def test_a_file_object_the_caller_opened_stays_open(three_parts: str) -> None:
+    # It is the caller's file: they may still read it, and they are the ones who close it.
+    with open(three_parts, "rb") as fp:
+        await Uploader(Media()).save_file(fp)
+
+        assert not fp.closed
+
+
+@pytest.mark.asyncio
+async def test_a_spooled_temporary_file_is_a_file_object_too() -> None:
+    # It is an `io.IOBase`, so it has always been accepted here, but it is not one of the
+    #  concrete types `aiofiles.threadpool.wrap()` dispatches on - hence the wrapper being
+    #  built directly rather than looked up.
+    media = Media()
+
+    with SpooledTemporaryFile() as fp:
+        fp.write(b"x" * (_PART_SIZE + 1))
+
+        file = await Uploader(media).save_file(fp)
+
+    assert isinstance(file, raw.types.InputFile)
+    assert file.parts == 2
+    assert media.saved_parts == [0, 1]

--- a/tests/unit/methods/test_save_file.py
+++ b/tests/unit/methods/test_save_file.py
@@ -179,7 +179,8 @@ async def test_a_file_object_that_has_a_name_uploads_under_it() -> None:
 @pytest.mark.asyncio
 async def test_a_file_object_the_caller_opened_stays_open(three_parts: str) -> None:
     # It is the caller's file: they may still read it, and they are the ones who close it.
-    with open(three_parts, "rb") as fp:
+    #  A real sync `io.IOBase` is the point of the test, not a stand-in `aiofiles` would give.
+    with open(three_parts, "rb") as fp:  # noqa: ASYNC230 - needs a real sync file object
         await Uploader(Media()).save_file(fp)
 
         assert not fp.closed

--- a/tests/unit/storage/test_sqlite_storage.py
+++ b/tests/unit/storage/test_sqlite_storage.py
@@ -31,7 +31,7 @@ async def test_conn_property_round_trips_the_connection() -> None:
     #  `# type:` comment but assigned None in __init__) to a property backed by
     #  self._conn, so open()/close() and every query still have to see the same
     #  connection object through the ordinary self.conn read/write syntax.
-    storage = SQLiteStorage("test", Path("."), in_memory=True)
+    storage = SQLiteStorage("test", Path(), in_memory=True)
 
     await storage.open()
     assert await storage.is_bot() is None
@@ -43,7 +43,7 @@ async def test_conn_property_round_trips_the_connection() -> None:
 
 
 def test_conn_raises_before_open() -> None:
-    storage = SQLiteStorage("test", Path("."), in_memory=True)
+    storage = SQLiteStorage("test", Path(), in_memory=True)
 
     with pytest.raises(RuntimeError):
         _ = storage.conn

--- a/tests/unit/types/input_content/test_input_media_path_dispatch.py
+++ b/tests/unit/types/input_content/test_input_media_path_dispatch.py
@@ -1,0 +1,76 @@
+#  Pyrogram - Telegram MTProto API Client Library for Python
+#  Copyright (C) 2017-present Dan <https://github.com/delivrance>
+#
+#  This file is part of Pyrogram.
+#
+#  Pyrogram is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU Lesser General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Pyrogram is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with Pyrogram.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations as _annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from pyrogram import types
+
+# `write()` only ever touches `client` through `client.resolve_peer(chat_id)`, and that
+#  call is skipped whenever `chat_id` stays at its default `None` (see e.g.
+#  `InputMediaPhoto.write`). Every case below raises before reaching any other use of
+#  `client`, so passing `None` for it - already how tests/unit/types/input_content/
+#  test_input_rich_message.py exercises `write()` - keeps these tests mock-free.
+_MEDIA_FACTORIES = [
+    types.InputMediaPhoto,
+    types.InputMediaAnimation,
+    types.InputMediaAudio,
+    types.InputMediaDocument,
+    types.InputMediaSticker,
+    types.InputMediaVoiceNote,
+    types.InputMediaVideo,
+    lambda media: types.InputMediaLivePhoto(media, photo="file_id_placeholder"),
+]
+
+
+@pytest.mark.parametrize("factory", _MEDIA_FACTORIES)
+async def test_write_raises_for_a_media_path_that_does_not_exist(tmp_path: Path, factory) -> None:
+    missing = tmp_path / "missing.jpg"
+
+    with pytest.raises(FileNotFoundError, match=re.escape(str(missing))):
+        await factory(missing).write(client=None)
+
+
+async def test_live_photo_write_raises_for_a_photo_path_that_does_not_exist(
+    tmp_path: Path,
+) -> None:
+    # `media` has to survive its own is-a-local-file check to reach the `photo` guard,
+    #  so it is a string that is neither an existing path nor a URL - a bare file_id
+    #  shape is enough since `write()` never gets far enough to decode it.
+    missing = tmp_path / "missing.jpg"
+    media = types.InputMediaLivePhoto("not-a-local-path", photo=missing)
+
+    with pytest.raises(FileNotFoundError, match=re.escape(str(missing))):
+        await media.write(client=None)
+
+
+async def test_video_write_raises_for_a_video_cover_path_that_does_not_exist(
+    tmp_path: Path,
+) -> None:
+    # Regression test for the video_cover guard having been placed after the
+    #  `re.match("^https?://", ...)` URL check instead of before it: a non-existent
+    #  `Path` reached `re.match()` there and raised `TypeError` instead of this.
+    missing = tmp_path / "cover.jpg"
+    media = types.InputMediaVideo("not-a-local-path", video_cover=missing)
+
+    with pytest.raises(FileNotFoundError, match=re.escape(str(missing))):
+        await media.write(client=None)

--- a/tests/unit/types/input_content/test_input_media_path_dispatch.py
+++ b/tests/unit/types/input_content/test_input_media_path_dispatch.py
@@ -19,7 +19,7 @@
 from __future__ import annotations as _annotations
 
 import re
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 import pytest
 
@@ -74,3 +74,14 @@ async def test_video_write_raises_for_a_video_cover_path_that_does_not_exist(
 
     with pytest.raises(FileNotFoundError, match=re.escape(str(missing))):
         await media.write(client=None)
+
+
+async def test_write_raises_for_a_path_like_that_is_not_a_pathlib_path(tmp_path: Path) -> None:
+    # `save_file` opens anything `os.PathLike`, so the dispatch has to recognise the same
+    #  set. Narrowing on `pathlib.Path` alone let a `PurePath` fall through to
+    #  `re.match()`, which raised `TypeError: expected string or bytes-like object, got
+    #  'PurePosixPath'` instead of naming the missing file.
+    missing = PurePosixPath(tmp_path / "missing.jpg")
+
+    with pytest.raises(FileNotFoundError, match=re.escape(str(missing))):
+        await types.InputMediaPhoto(missing).write(client=None)

--- a/tests/unit/types/input_content/test_input_media_path_dispatch.py
+++ b/tests/unit/types/input_content/test_input_media_path_dispatch.py
@@ -20,10 +20,12 @@ from __future__ import annotations as _annotations
 
 import re
 from pathlib import Path, PurePosixPath
+from typing import BinaryIO, Protocol
+from collections.abc import Callable
 
 import pytest
 
-from pyrogram import types
+from pyrogram import raw, types
 
 # `write()` only ever touches `client` through `client.resolve_peer(chat_id)`, and that
 #  call is skipped whenever `chat_id` stays at its default `None` (see e.g.
@@ -31,19 +33,64 @@ from pyrogram import types
 #  `client`, so passing `None` for it - already how tests/unit/types/input_content/
 #  test_input_rich_message.py exercises `write()` - keeps these tests mock-free.
 _MEDIA_FACTORIES = [
-    types.InputMediaPhoto,
-    types.InputMediaAnimation,
-    types.InputMediaAudio,
-    types.InputMediaDocument,
-    types.InputMediaSticker,
-    types.InputMediaVoiceNote,
-    types.InputMediaVideo,
-    lambda media: types.InputMediaLivePhoto(media, photo="file_id_placeholder"),
+    pytest.param(types.InputMediaPhoto, id="photo"),
+    pytest.param(types.InputMediaAnimation, id="animation"),
+    pytest.param(types.InputMediaAudio, id="audio"),
+    pytest.param(types.InputMediaDocument, id="document"),
+    pytest.param(types.InputMediaSticker, id="sticker"),
+    pytest.param(types.InputMediaVoiceNote, id="voice-note"),
+    pytest.param(types.InputMediaVideo, id="video"),
+    pytest.param(
+        lambda media: types.InputMediaLivePhoto(media, photo="file_id_placeholder"),
+        id="live-photo",
+    ),
 ]
 
 
+class _MediaFactory(Protocol):
+    def __call__(self, media: Path, /) -> types.InputMedia: ...
+
+
+class _UploadReached(Exception):
+    """Stops `write()` as soon as it hands the media over to be uploaded."""
+
+
+class _RecordingClient:
+    """Records what `write()` passes to `save_file`, then stops the upload.
+
+    `guess_mime_type` answers None so every caller falls back to its own default; these
+    tests are about which branch `write()` takes, not about mime detection.
+    """
+
+    def __init__(self) -> None:
+        self.saved: list[str | Path | BinaryIO] = []
+
+    def guess_mime_type(self, filename: str | Path | BinaryIO) -> str | None:
+        return None
+
+    # Python resolves this attribute before it evaluates the query being passed to it,
+    #  so it has to exist even though `save_file` raises while that query is still
+    #  being built.
+    async def invoke(self, query: raw.core.TLObject) -> raw.core.TLObject:
+        raise AssertionError("`save_file` was expected to stop the upload first")
+
+    async def save_file(
+        self,
+        path: str | Path | BinaryIO,
+        *,
+        progress: Callable | None = None,
+        progress_args: tuple = (),
+    ) -> raw.base.InputFile:
+        self.saved.append(path)
+
+        raise _UploadReached
+
+
 @pytest.mark.parametrize("factory", _MEDIA_FACTORIES)
-async def test_write_raises_for_a_media_path_that_does_not_exist(tmp_path: Path, factory) -> None:
+async def test_write_raises_for_a_media_path_that_does_not_exist(
+    tmp_path: Path,
+    factory: _MediaFactory,
+) -> None:
     missing = tmp_path / "missing.jpg"
 
     with pytest.raises(FileNotFoundError, match=re.escape(str(missing))):
@@ -99,3 +146,18 @@ async def test_live_photo_write_rejects_a_local_photo_next_to_a_remote_media(
 
     with pytest.raises(ValueError, match="both be local files or both be file_ids"):
         await media.write(client=None)
+
+
+@pytest.mark.parametrize("factory", _MEDIA_FACTORIES)
+async def test_write_uploads_a_media_path_that_exists(
+    tmp_path: Path,
+    factory: _MediaFactory,
+) -> None:
+    existing = tmp_path / "media.bin"
+    existing.write_bytes(b"payload")
+    client = _RecordingClient()
+
+    with pytest.raises(_UploadReached):
+        await factory(existing).write(client=client)
+
+    assert client.saved == [existing]

--- a/tests/unit/types/input_content/test_input_media_path_dispatch.py
+++ b/tests/unit/types/input_content/test_input_media_path_dispatch.py
@@ -85,3 +85,17 @@ async def test_write_raises_for_a_path_like_that_is_not_a_pathlib_path(tmp_path:
 
     with pytest.raises(FileNotFoundError, match=re.escape(str(missing))):
         await types.InputMediaPhoto(missing).write(client=None)
+
+
+async def test_live_photo_write_rejects_a_local_photo_next_to_a_remote_media(
+    tmp_path: Path,
+) -> None:
+    # The guard used to check only the TYPE of `photo`, so an existing file was reported
+    #  as `No such file or directory`. What is actually wrong is the mix: the call this
+    #  falls through to addresses both `media` and `photo` by file_id.
+    existing = tmp_path / "photo.jpg"
+    existing.write_bytes(b"payload")
+    media = types.InputMediaLivePhoto("not-a-local-path", photo=existing)
+
+    with pytest.raises(ValueError, match="both be local files or both be file_ids"):
+        await media.write(client=None)

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "aiofiles"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/c3/534eac40372d8ee36ef40df62ec129bee4fdb5ad9706e58a29be53b2c970/aiofiles-25.1.0.tar.gz", hash = "sha256:a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2", size = 46354, upload-time = "2025-10-09T20:51:04.358Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl", hash = "sha256:abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695", size = 14668, upload-time = "2025-10-09T20:51:03.174Z" },
+]
+
+[[package]]
 name = "alabaster"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -738,6 +747,7 @@ wheels = [
 name = "kurigram"
 source = { editable = "." }
 dependencies = [
+    { name = "aiofiles" },
     { name = "pyaes" },
     { name = "python-socks", extra = ["asyncio"] },
 ]
@@ -796,6 +806,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiofiles", specifier = ">=25.1.0" },
     { name = "pyaes", specifier = ">=1.2.0" },
     { name = "python-socks", extras = ["asyncio"], specifier = ">=2.4.0" },
     { name = "qrcode", marker = "extra == 'qrcode'", specifier = ">=5.2.2" },


### PR DESCRIPTION
> **Depends on #449** (`chore/pathlib-migration`, still under review — please don't merge this before #449 lands). This branch is built on top of #449's `os.PathLike` dispatch fixes so the aiofiles conversion below has a consistent type check to build on; the diff therefore also carries #449's commits until it merges into `dev`.

## Summary
- Add `aiofiles` as a runtime dependency and route every local-path upload/download guard (the `isinstance(x, (str, os.PathLike))` existence check) through it instead of blocking `os.path`/`pathlib` calls, so no `async def` in the upload/download paths blocks the event loop.
- Enable ruff's `ASYNC` rule set to catch a blocking call inside an `async def` in this codebase going forward.

## Test plan
- [x] `make lint`
- [x] `make typecheck`
- [x] `make test-unit`