### PR TITLE
fix(keyboards): annotate `LoginUrl.request_write_access` as the `bool` the schema declares

### DIFF
--- a/pyrogram/types/bots_and_keyboards/login_url.py
+++ b/pyrogram/types/bots_and_keyboards/login_url.py
@@ -51,11 +51,15 @@ class LoginUrl(Object):
             See `Linking your domain to the bot <https://core.telegram.org/widgets/login#linking-your-domain-to-the-bot>`_
             for more details.
 
-        request_write_access (``str``, *optional*):
+        request_write_access (``bool``, *optional*):
             Pass True to request the permission for your bot to send messages to the user.
 
         button_id (``int``):
             Button identifier.
+
+    **NOTE**: A button received from Telegram never carries *bot_username* or
+    *request_write_access*: the incoming ``inlineButtonTypeUrlAuth`` constructor has no field
+    for either, so both are always ``None`` on a parsed button.
     """
 
     def __init__(
@@ -64,7 +68,7 @@ class LoginUrl(Object):
         url: str,
         forward_text: str | None = None,
         bot_username: str | None = None,
-        request_write_access: str | None = None,
+        request_write_access: bool | None = None,
         button_id: int | None = None,
     ):
         super().__init__()

--- a/pyrogram/types/bots_and_keyboards/login_url.py
+++ b/pyrogram/types/bots_and_keyboards/login_url.py
@@ -29,6 +29,12 @@ class LoginUrl(Object):
     Serves as a great replacement for the Telegram Login Widget when the user is coming from Telegram.
     All the user needs to do is tap/click a button and confirm that they want to log in.
 
+    .. note::
+
+        A button received from Telegram carries neither *bot_username* nor
+        *request_write_access*: the incoming ``inlineButtonTypeUrlAuth`` constructor has no
+        field for either, so both are always ``None`` on a parsed button.
+
     Parameters:
         url (``str``):
             An HTTP URL to be opened with user authorization data added to the query string when the button is pressed.
@@ -56,10 +62,6 @@ class LoginUrl(Object):
 
         button_id (``int``):
             Button identifier.
-
-    **NOTE**: A button received from Telegram never carries *bot_username* or
-    *request_write_access*: the incoming ``inlineButtonTypeUrlAuth`` constructor has no field
-    for either, so both are always ``None`` on a parsed button.
     """
 
     def __init__(


### PR DESCRIPTION
## What

`LoginUrl.request_write_access` was declared `str | None`, while the schema declares it a boolean flag: `inputInlineButtonTypeUrlAuth#9961bcb4 flags:# request_write_access:flags.0?true` (`compiler/api/source/main_api.tl:2261`). The docstring said ``str`` on one line and "Pass True" on the next, and the library already documents the same field as ``bool`` elsewhere (`pyrogram/types/messages_and_media/message.py:9409`).

    $ uv run python -c 'import inspect; from pyrogram.types import LoginUrl; print(repr(inspect.signature(LoginUrl.__init__).parameters["request_write_access"]))'

before:

    <Parameter "request_write_access: 'str | None' = None">

after:

    <Parameter "request_write_access: 'bool | None' = None">

Nothing changes on the wire. Both call sites pass the value straight into the raw constructor as a flag (`pyrogram/types/bots_and_keyboards/inline_keyboard_button.py:350`, `pyrogram/types/bots_and_keyboards/rich_message_button.py:305`), where a string was truthy and the permission was requested anyway. What changes is that the annotation now agrees with the schema and with the rest of the library.

The class docstring also gains a note about something the library cannot fix: a button coming back from Telegram arrives as `inlineButtonTypeUrlAuth#bfd02da2` (`compiler/api/source/main_api.tl:2260`), which carries `url`, `fwd_text` and `button_id` and nothing else, so `bot_username` and `request_write_access` are always `None` on a parsed button.

## How to test

`make lint`, `make typecheck`, `make test-unit`.

The write path is already covered: `test_a_login_url_button_carries_the_url_of_its_login_url` and `test_a_login_url_button_carries_the_fields_of_its_login_url` both pass `request_write_access=True` and assert it reaches `InputInlineButtonTypeUrlAuth`, so no new test is added here.
