### PR TITLE
fix(types): thread the page media mappings into list blocks and guard a missing document

### DIFF
--- a/pyrogram/types/messages_and_media/rich_block.py
+++ b/pyrogram/types/messages_and_media/rich_block.py
@@ -169,13 +169,23 @@ class RichBlock(Object):
         if isinstance(rich_block, raw.types.PageBlockList):
             return RichBlockList(
                 items=types.List(
-                    [await types.RichBlockListItem._parse(client, i) for i in rich_block.items]
+                    [
+                        await types.RichBlockListItem._parse(
+                            client, i, photos, documents, part, users, chats
+                        )
+                        for i in rich_block.items
+                    ]
                 )
             )
         if isinstance(rich_block, raw.types.PageBlockOrderedList):
             return RichBlockList(
                 items=types.List(
-                    [await types.RichBlockListItem._parse(client, i) for i in rich_block.items]
+                    [
+                        await types.RichBlockListItem._parse(
+                            client, i, photos, documents, part, users, chats
+                        )
+                        for i in rich_block.items
+                    ]
                 )
             )
         if isinstance(rich_block, raw.types.PageBlockBlockquoteBlocks):
@@ -546,10 +556,23 @@ class RichBlockListItem(RichBlock):
         self.type = type
 
     @staticmethod
-    async def _parse(client, list_item: raw.base.PageListItem | raw.base.PageListOrderedItem):
+    async def _parse(
+        client: pyrogram.Client,
+        list_item: raw.base.PageListItem | raw.base.PageListOrderedItem,
+        photos: dict[int, raw.base.Photo] | None = None,
+        documents: dict[int, raw.base.Document] | None = None,
+        part: bool | None = None,
+        users: dict[int, raw.base.User] | None = None,
+        chats: dict[int, raw.base.Chat] | None = None,
+    ) -> RichBlockListItem | None:
         if isinstance(list_item, raw.types.PageListItemBlocks):
             blocks = types.List(
-                [await types.RichBlock._parse(client, block) for block in list_item.blocks]
+                [
+                    await types.RichBlock._parse(
+                        client, block, photos, documents, part, users, chats
+                    )
+                    for block in list_item.blocks
+                ]
             )
             label = "•"
             has_checkbox = list_item.checkbox
@@ -569,7 +592,12 @@ class RichBlockListItem(RichBlock):
 
         elif isinstance(list_item, raw.types.PageListOrderedItemBlocks):
             blocks = types.List(
-                [await types.RichBlock._parse(client, block) for block in list_item.blocks]
+                [
+                    await types.RichBlock._parse(
+                        client, block, photos, documents, part, users, chats
+                    )
+                    for block in list_item.blocks
+                ]
             )
             has_checkbox = list_item.checkbox
             is_checked = list_item.checked

--- a/pyrogram/types/messages_and_media/rich_block.py
+++ b/pyrogram/types/messages_and_media/rich_block.py
@@ -287,7 +287,7 @@ class RichBlock(Object):
         if isinstance(rich_block, raw.types.PageBlockVideo):
             doc = documents.get(rich_block.video_id)
 
-            if doc is None:
+            if not isinstance(doc, raw.types.Document):
                 return RichBlockUnsupported()
 
             attributes = {type(i): i for i in doc.attributes}
@@ -328,7 +328,7 @@ class RichBlock(Object):
         if isinstance(rich_block, raw.types.PageBlockDocument):
             doc = documents.get(rich_block.document_id)
 
-            if doc is None:
+            if not isinstance(doc, raw.types.Document):
                 return RichBlockUnsupported()
 
             attributes = {type(i): i for i in doc.attributes}
@@ -344,7 +344,7 @@ class RichBlock(Object):
         if isinstance(rich_block, raw.types.PageBlockAudio):
             doc = documents.get(rich_block.audio_id)
 
-            if doc is None:
+            if not isinstance(doc, raw.types.Document):
                 return RichBlockUnsupported()
 
             attributes = {type(i): i for i in doc.attributes}

--- a/pyrogram/types/messages_and_media/rich_block.py
+++ b/pyrogram/types/messages_and_media/rich_block.py
@@ -276,6 +276,10 @@ class RichBlock(Object):
             )
         if isinstance(rich_block, raw.types.PageBlockVideo):
             doc = documents.get(rich_block.video_id)
+
+            if doc is None:
+                return RichBlockUnsupported()
+
             attributes = {type(i): i for i in doc.attributes}
 
             file_name = getattr(
@@ -313,6 +317,10 @@ class RichBlock(Object):
                     )
         if isinstance(rich_block, raw.types.PageBlockDocument):
             doc = documents.get(rich_block.document_id)
+
+            if doc is None:
+                return RichBlockUnsupported()
+
             attributes = {type(i): i for i in doc.attributes}
 
             file_name = getattr(
@@ -325,6 +333,10 @@ class RichBlock(Object):
             )
         if isinstance(rich_block, raw.types.PageBlockAudio):
             doc = documents.get(rich_block.audio_id)
+
+            if doc is None:
+                return RichBlockUnsupported()
+
             attributes = {type(i): i for i in doc.attributes}
 
             file_name = getattr(

--- a/tests/unit/types/messages_and_media/test_rich_block.py
+++ b/tests/unit/types/messages_and_media/test_rich_block.py
@@ -19,11 +19,18 @@
 from __future__ import annotations as _annotations
 
 import json
+from typing import Final
 
 import pytest
 
 import pyrogram
 from pyrogram import raw, types
+
+
+_EMPTY_CAPTION: Final[raw.types.PageCaption] = raw.types.PageCaption(
+    text=raw.types.TextEmpty(),
+    credit=raw.types.TextEmpty(),
+)
 
 
 async def _parse(block: raw.base.PageBlock) -> types.RichBlock:
@@ -355,3 +362,39 @@ async def test_a_document_block_parses_the_document_it_points_at() -> None:
 
     assert parsed.document.file_name == "a.pdf"
     assert parsed.caption.text == "caption"
+
+
+@pytest.mark.parametrize(
+    "block",
+    [
+        pytest.param(
+            raw.types.PageBlockVideo(
+                video_id=1,
+                caption=_EMPTY_CAPTION,
+            ),
+            id="video",
+        ),
+        pytest.param(
+            raw.types.PageBlockDocument(
+                document_id=1,
+                caption=_EMPTY_CAPTION,
+            ),
+            id="document",
+        ),
+        pytest.param(
+            raw.types.PageBlockAudio(
+                audio_id=1,
+                caption=_EMPTY_CAPTION,
+            ),
+            id="audio",
+        ),
+    ],
+)
+async def test_a_media_block_the_page_carries_no_document_for_is_unsupported(
+    block: raw.base.PageBlock,
+) -> None:
+    parsed = await _parse(block)
+
+    # `type()` rather than `==`: `Object.__eq__` iterates `self.__dict__`, so an attribute-less
+    #  object compares equal to everything, `None` included.
+    assert type(parsed) is types.RichBlockUnsupported

--- a/tests/unit/types/messages_and_media/test_rich_block.py
+++ b/tests/unit/types/messages_and_media/test_rich_block.py
@@ -398,3 +398,39 @@ async def test_a_media_block_the_page_carries_no_document_for_is_unsupported(
     # `type()` rather than `==`: `Object.__eq__` iterates `self.__dict__`, so an attribute-less
     #  object compares equal to everything, `None` included.
     assert type(parsed) is types.RichBlockUnsupported
+
+
+async def test_a_media_block_inside_a_list_item_still_finds_its_document() -> None:
+    document = raw.types.Document(
+        id=555,
+        access_hash=666,
+        file_reference=b"ref",
+        date=0,
+        mime_type="application/pdf",
+        size=10,
+        dc_id=2,
+        attributes=[raw.types.DocumentAttributeFilename(file_name="a.pdf")],
+    )
+
+    parsed = await types.RichBlock._parse(
+        None,
+        raw.types.PageBlockList(
+            items=[
+                raw.types.PageListItemBlocks(
+                    blocks=[
+                        raw.types.PageBlockDocument(
+                            document_id=555,
+                            caption=_EMPTY_CAPTION,
+                        )
+                    ]
+                )
+            ]
+        ),
+        {},
+        {555: document},
+        None,
+        {},
+        {},
+    )
+
+    assert parsed.items[0].blocks[0].document.file_name == "a.pdf"

--- a/tests/unit/types/messages_and_media/test_rich_block.py
+++ b/tests/unit/types/messages_and_media/test_rich_block.py
@@ -390,10 +390,19 @@ async def test_a_document_block_parses_the_document_it_points_at() -> None:
         ),
     ],
 )
-async def test_a_media_block_the_page_carries_no_document_for_is_unsupported(
+@pytest.mark.parametrize(
+    "documents",
+    [
+        pytest.param({}, id="absent"),
+        pytest.param({1: raw.types.DocumentEmpty(id=1)}, id="empty"),
+    ],
+)
+async def test_a_media_block_without_a_usable_document_is_unsupported(
     block: raw.base.PageBlock,
+    *,
+    documents: dict[int, raw.base.Document],
 ) -> None:
-    parsed = await _parse(block)
+    parsed = await types.RichBlock._parse(None, block, {}, documents, None, {}, {})
 
     # `type()` rather than `==`: `Object.__eq__` iterates `self.__dict__`, so an attribute-less
     #  object compares equal to everything, `None` included.


### PR DESCRIPTION
## What

Two defects, both about the `documents` mapping a rich page carries alongside its blocks.

**`RichBlockListItem._parse()` never received the mapping.** Every other nested call in `RichBlock._parse()` forwards `photos, documents, part, users, chats`; the two list branches called `RichBlockListItem._parse(client, i)`, and it in turn called `RichBlock._parse(client, block)`. So any media block inside a list or an ordered list was parsed with an empty mapping and could never find its document, even when the message carried it:

    import asyncio

    from pyrogram import raw, types

    document = raw.types.Document(
        id=555, access_hash=666, file_reference=b"ref", date=0,
        mime_type="application/pdf", size=10, dc_id=2,
        attributes=[raw.types.DocumentAttributeFilename(file_name="a.pdf")],
    )
    caption = raw.types.PageCaption(text=raw.types.TextEmpty(), credit=raw.types.TextEmpty())
    block = raw.types.PageBlockList(
        items=[
            raw.types.PageListItemBlocks(
                blocks=[raw.types.PageBlockDocument(document_id=555, caption=caption)]
            )
        ]
    )

    print(asyncio.run(types.RichBlock._parse(None, block, {}, {555: document})))

before, with the document present in the mapping:

      File "pyrogram/types/messages_and_media/rich_block.py", line 316, in _parse
        attributes = {type(i): i for i in doc.attributes}
    AttributeError: 'NoneType' object has no attribute 'attributes'

after:

    {"_": "RichBlockList", "items": [{"_": "RichBlockListItem", "blocks": [
        {"_": "RichBlockDocument", "document": {"_": "Document", "file_name": "a.pdf", ...

`RichBlockTable._parse()` is left alone on purpose: `pageTableCell` carries `RichText`, not `PageBlock`, so no media can be nested there.

**Three branches used the lookup result without checking it.** `video_id`, `document_id` and `audio_id` all did `documents.get(...)` and went straight to `.attributes`, so a page referencing a document the message genuinely does not carry raised the same `AttributeError`. They now fall into `RichBlockUnsupported`, which is the fallback the function already returns for every block type it does not model.

The photo branch is unaffected: it hands the missing id to `Photo._parse()`, which accepts `None`.

## How to test

`make test-unit`, or the snippet above.

Four unit tests: one per media id for the missing-document case, and one asserting a document nested in a list item is found. Reverting either fix fails exactly the tests that cover it.
