### PR TITLE
fix(keyboards): accept str in copy_text parameter directly

### DIFF
--- a/pyrogram/types/bots_and_keyboards/inline_keyboard_button.py
+++ b/pyrogram/types/bots_and_keyboards/inline_keyboard_button.py
@@ -80,9 +80,9 @@ class InlineKeyboardButton(Object):
             the bot's username and the specified inline query in the input field.
             Not supported for messages sent in channel direct messages chats and on behalf of a business account.
 
-        copy_text (:obj:`~pyrogram.types.CopyTextButton`, *optional*):
+        copy_text (:obj:`~pyrogram.types.CopyTextButton` | ``str``, *optional*):
             A button that copies specified text to clipboard.
-            Limited to 256 character.
+            Limited to 256 characters.
 
         callback_game (:obj:`~pyrogram.types.CallbackGame`, *optional*):
             Description of the game that will be launched when the user presses the button.
@@ -113,7 +113,7 @@ class InlineKeyboardButton(Object):
         switch_inline_query: str | None = None,
         switch_inline_query_current_chat: str | None = None,
         switch_inline_query_chosen_chat: types.SwitchInlineQueryChosenChat | None = None,
-        copy_text: types.CopyTextButton | None = None,
+        copy_text: types.CopyTextButton | str | None = None,
         callback_game: types.CallbackGame | None = None,
         pay: bool | None = None,
         disabled: types.DisabledButton | None = None,
@@ -132,6 +132,9 @@ class InlineKeyboardButton(Object):
         self.switch_inline_query = switch_inline_query
         self.switch_inline_query_current_chat = switch_inline_query_current_chat
         self.switch_inline_query_chosen_chat = switch_inline_query_chosen_chat
+        if isinstance(copy_text, str):
+            copy_text = types.CopyTextButton(text=copy_text)
+
         self.copy_text = copy_text
         self.callback_game = callback_game
         self.pay = pay
@@ -298,7 +301,11 @@ class InlineKeyboardButton(Object):
 
         if self.copy_text is not None:
             button_type = raw.types.InlineButtonTypeCopy(
-                copy_text=self.copy_text.text,
+                copy_text=(
+                    self.copy_text.text
+                    if isinstance(self.copy_text, types.CopyTextButton)
+                    else str(self.copy_text)
+                ),
             )
 
         if self.disabled is not None:

--- a/pyrogram/types/bots_and_keyboards/rich_message_button.py
+++ b/pyrogram/types/bots_and_keyboards/rich_message_button.py
@@ -71,9 +71,9 @@ class RichMessageButton(Object):
             If set, pressing the button will prompt the user to select one of their chats of the specified type, open that chat and insert the bot's username and the specified inline query in the input field.
             Not supported for messages sent in channel direct messages chats and on behalf of a business account.
 
-        copy_text (:obj:`~pyrogram.types.CopyTextButton`, *optional*):
+        copy_text (:obj:`~pyrogram.types.CopyTextButton` | ``str``, *optional*):
             A button that copies specified text to clipboard.
-            Limited to 256 character.
+            Limited to 256 characters.
 
         disabled (:obj:`~pyrogram.types.DisabledButton`, *optional*):
             If set, then the button is disabled and does nothing.
@@ -90,7 +90,7 @@ class RichMessageButton(Object):
         switch_inline_query: str | None = None,
         switch_inline_query_current_chat: str | None = None,
         switch_inline_query_chosen_chat: types.SwitchInlineQueryChosenChat | None = None,
-        copy_text: types.CopyTextButton | None = None,
+        copy_text: types.CopyTextButton | str | None = None,
         disabled: types.DisabledButton | None = None,
     ):
         super().__init__()
@@ -104,6 +104,9 @@ class RichMessageButton(Object):
         self.switch_inline_query = switch_inline_query
         self.switch_inline_query_current_chat = switch_inline_query_current_chat
         self.switch_inline_query_chosen_chat = switch_inline_query_chosen_chat
+        if isinstance(copy_text, str):
+            copy_text = types.CopyTextButton(text=copy_text)
+
         self.copy_text = copy_text
         self.disabled = disabled
 
@@ -254,7 +257,11 @@ class RichMessageButton(Object):
 
         if self.copy_text is not None:
             button_type = raw.types.InlineButtonTypeCopy(
-                copy_text=self.copy_text.text,
+                copy_text=(
+                    self.copy_text.text
+                    if isinstance(self.copy_text, types.CopyTextButton)
+                    else str(self.copy_text)
+                ),
             )
 
         if self.disabled is not None:

--- a/tests/unit/types/bots_and_keyboards/test_inline_keyboard_button.py
+++ b/tests/unit/types/bots_and_keyboards/test_inline_keyboard_button.py
@@ -65,3 +65,28 @@ async def test_a_login_url_button_carries_the_url_of_its_login_url() -> None:
         fwd_text="Sign in",
         bot=raw.types.InputUserSelf(),
     )
+
+
+async def test_a_copy_text_button_carries_its_text_when_passed_as_object() -> None:
+    button = types.InlineKeyboardButton(
+        "Copy",
+        copy_text=types.CopyTextButton(text="abc"),
+    )
+
+    written = await button.write(PeerResolver())
+
+    assert written.type == raw.types.InlineButtonTypeCopy(copy_text="abc")
+
+
+async def test_a_copy_text_button_accepts_str_directly() -> None:
+    button = types.InlineKeyboardButton(
+        "Copy Phone",
+        copy_text="+18005550199",
+    )
+
+    assert isinstance(button.copy_text, types.CopyTextButton)
+    assert button.copy_text.text == "+18005550199"
+
+    written = await button.write(PeerResolver())
+
+    assert written.type == raw.types.InlineButtonTypeCopy(copy_text="+18005550199")

--- a/tests/unit/types/bots_and_keyboards/test_rich_message_button.py
+++ b/tests/unit/types/bots_and_keyboards/test_rich_message_button.py
@@ -128,3 +128,28 @@ async def test_an_inline_keyboard_button_rejects_the_link_style() -> None:
 
     with pytest.raises(ValueError, match=_NO_LINK_FLAG):
         await button.write(PeerResolver())
+
+
+async def test_a_rich_message_copy_text_button_carries_its_text_when_passed_as_object() -> None:
+    button = types.RichMessageButton(
+        text="Copy",
+        copy_text=types.CopyTextButton(text="abc"),
+    )
+
+    written = await button.write(PeerResolver())
+
+    assert written.type == raw.types.InlineButtonTypeCopy(copy_text="abc")
+
+
+async def test_a_rich_message_copy_text_button_accepts_str_directly() -> None:
+    button = types.RichMessageButton(
+        text="Copy Link",
+        copy_text="https://example.com",
+    )
+
+    assert isinstance(button.copy_text, types.CopyTextButton)
+    assert button.copy_text.text == "https://example.com"
+
+    written = await button.write(PeerResolver())
+
+    assert written.type == raw.types.InlineButtonTypeCopy(copy_text="https://example.com")


### PR DESCRIPTION
## What

`InlineKeyboardButton` and `RichMessageButton` previously required passing an explicit `types.CopyTextButton` object into `copy_text`. Passing a raw `str` failed during `.write()`:

```python
btn = InlineKeyboardButton("Copy Phone", copy_text="+18005550199")
# AttributeError: 'str' object has no attribute 'text'
```

### Changes
- **`InlineKeyboardButton` & `RichMessageButton`**:
  - Annotate and accept `copy_text: types.CopyTextButton | str | None = None`.
  - Automatically wrap `str` inputs into `types.CopyTextButton(text=copy_text)` on initialization.
  - Safely fall back to string extraction in `.write()` if `self.copy_text` is passed as `str`.
- **Tests**:
  - Added unit tests covering raw `str` and `CopyTextButton` objects for both `InlineKeyboardButton` and `RichMessageButton`.

## How to test

```bash
pytest tests/unit/types/bots_and_keyboards/
pytest tests/guards/
ruff check pyrogram/ tests/
```
